### PR TITLE
fix(github): Fix duplicate slack notifications

### DIFF
--- a/src/handlers/apps/github/brain/requiredChecks/index.ts
+++ b/src/handlers/apps/github/brain/requiredChecks/index.ts
@@ -168,6 +168,17 @@ async function handler({ id, payload }: EventTypesPayload['check_run']) {
     return;
   }
 
+  // This will stop double messages because of action == 'created' and 'completed' with the
+  // same status/conclusion
+  // Run only on `completed` action (can be `created`, and not sure what `rerequested` is)
+  // This can still fire multiple times if we have additional failing checks?
+  // I don't think running this once on created will work either as you can have a created w/ non-failure
+  // and later it becomes failing
+  if (payload.action !== 'completed') {
+    console.warn(`Required check with non-completed action: ${payload.action}`);
+    return;
+  }
+
   console.log(
     `Received failed check run ${checkRun.id} (${id}) for commit ${checkRun.head_sha}`
   );

--- a/test/payloads/github/check_run.ts
+++ b/test/payloads/github/check_run.ts
@@ -1,5 +1,5 @@
 const payload = {
-  action: 'created' as const,
+  action: 'completed' as const,
   check_run: {
     id: 128620228,
     node_id: 'MDg6Q2hlY2tSdW4xMjg2MjAyMjg=',


### PR DESCRIPTION
This should fix duplicate slack notifications where we have almost duplicate `check_run` webhook events differing by `action` = `created`|`completed`

We may still get duplicates if another job triggers a check_run with `action = completed`? I am not sure tbh.