### PR TITLE
fix: Unauthed bolt client

### DIFF
--- a/src/api/slack/index.ts
+++ b/src/api/slack/index.ts
@@ -17,6 +17,10 @@ const bolt = new App({
   endpoints: '/',
 });
 
+// We have to do this because the original client does not have a token associated with it
+// This is to support multiple workspaces, see https://github.com/slackapi/bolt-js/issues/250
+bolt.client = new WebClient(SLACK_BOT_USER_ACCESS_TOKEN);
+
 export { web2, bolt };
 
 // @ts-ignore


### PR DESCRIPTION
The bolt client that we use outside of slack events is unauthed. This is an intentional design by Slack in order to support apps installed on multiple workspaces.