### PR TITLE
ref: Remove `web2` hack

### DIFF
--- a/src/api/getUser/index.ts
+++ b/src/api/getUser/index.ts
@@ -1,4 +1,4 @@
-import { bolt, web2 } from '@api/slack';
+import { bolt } from '@api/slack';
 import { SLACK_PROFILE_ID_GITHUB } from '@app/config';
 import { db } from '@utils/db';
 
@@ -54,7 +54,7 @@ export async function getUser({
   }
 
   // Check for github profile field in slack
-  const profileResult: any = await web2.users.profile.get({
+  const profileResult: any = await bolt.client.users.profile.get({
     user: userResult.user.id,
   });
 

--- a/src/api/slack/index.ts
+++ b/src/api/slack/index.ts
@@ -3,14 +3,6 @@ import { WebClient } from '@slack/web-api';
 
 import { SLACK_BOT_USER_ACCESS_TOKEN, SLACK_SIGNING_SECRET } from '@app/config';
 
-// XXX(billy): Uhhh for some reason our normal bot token
-// (for app Sentry Bot: https://api.slack.com/apps/ASUD2NK2S)
-// does not work for fetching user profiles.
-// Instead we are using DogBot: https://api.slack.com/apps/A0182D08F9T/oauth?
-//
-// I currently have a support ticket with slack about this
-const web2 = new WebClient(process.env.SLACK_BOT_USER_ACCESS_TOKEN_TEMP);
-
 const bolt = new App({
   token: SLACK_BOT_USER_ACCESS_TOKEN,
   signingSecret: SLACK_SIGNING_SECRET,
@@ -21,7 +13,7 @@ const bolt = new App({
 // This is to support multiple workspaces, see https://github.com/slackapi/bolt-js/issues/250
 bolt.client = new WebClient(SLACK_BOT_USER_ACCESS_TOKEN);
 
-export { web2, bolt };
+export { bolt };
 
 // @ts-ignore
 bolt.error((error) => {


### PR DESCRIPTION
I was using another bot token to access user profiles, but I fixed the issue by revoking and reinstalling the App. We were using an outdated token type.