### PR TITLE
feat: Change deploy link to be a button

### DIFF
--- a/src/api/getUser/index.ts
+++ b/src/api/getUser/index.ts
@@ -44,12 +44,19 @@ export async function getUser({
     return null;
   }
 
-  // First fetch slack user
-  const userResult: any = await bolt.client.users.lookupByEmail({
-    email,
-  });
+  let userResult: any;
 
-  if (!userResult.ok) {
+  try {
+    // First fetch slack user
+    userResult = await bolt.client.users.lookupByEmail({
+      email,
+    });
+  } catch (err) {
+    // TODO(billy); should probably only explicitly ignore when a user is not found
+    return null;
+  }
+
+  if (!userResult?.ok) {
     return null;
   }
 


### PR DESCRIPTION
The button stands out a bit more. I previously did not add it because we needed to handle the button action. bolt handles this easier than `web-api`.