### PR TITLE
fix: Move knexfile into `src`

### DIFF
--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -57,4 +57,4 @@ jobs:
         DB_NAME: ${{ secrets.DB_NAME }}
         DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
       run: |
-        yarn knex migrate:${{ github.event.inputs.name }} --env ${{ github.event.inputs.environment }}
+        yarn migrate migrate:${{ github.event.inputs.name }} --env ${{ github.event.inputs.environment }}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "deploy": "yarn build && (yarn deploy:development-metrics)",
     "deploy:development-metrics": "./bin/deploy.sh",
     "dev": "DEBUG=@slack/events-api:* yarn clean && NODE_ENV=development nodemon --watch src/ -e ts --exec \"yarn start:clean\"",
+    "migrate": "yarn knex --knexfile ./src/knexfile.ts",
     "start:clean": "yarn build && yarn start",
     "start": "node ./lib/index.js",
     "lint": "yarn eslint --ext .ts \"src\" \"test/**/*.ts\" --fix",

--- a/src/knexfile.ts
+++ b/src/knexfile.ts
@@ -6,7 +6,7 @@ import {
   DB_NAME,
   DB_PASSWORD,
   DB_USER,
-} from './src/config';
+} from './config';
 
 const config = {
   local: {
@@ -21,6 +21,7 @@ const config = {
       max: 10,
     },
     migrations: {
+      directory: path.join(__dirname, '..', 'migrations'),
       tableName: 'knex_migrations',
     },
   },
@@ -31,10 +32,10 @@ const config = {
     connection: ':memory:',
     useNullAsDefault: true,
     migrations: {
-      directory: path.join(__dirname, 'migrations'),
+      directory: path.join(__dirname, '..', 'migrations'),
     },
     seeds: {
-      directory: path.join(__dirname, 'seeds'),
+      directory: path.join(__dirname, '..', 'seeds'),
     },
   },
 
@@ -50,6 +51,7 @@ const config = {
       max: 10,
     },
     migrations: {
+      directory: path.join(__dirname, '..', 'migrations'),
       tableName: 'knex_migrations',
     },
   },
@@ -67,6 +69,7 @@ const config = {
       max: 10,
     },
     migrations: {
+      directory: path.join(__dirname, '..', 'migrations'),
       tableName: 'knex_migrations',
     },
   },

--- a/src/utils/db/index.ts
+++ b/src/utils/db/index.ts
@@ -1,6 +1,6 @@
 import Knex from 'knex';
 
-import knexConfig from '../../../knexfile';
+import knexConfig from '@app/knexfile';
 
 const config =
   knexConfig[process.env.NODE_ENV || ''] || knexConfig['production'];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,7 @@
       "@app/*": ["src/*"]
     }
   },
-  "include": ["src/**/*", "test", "migrations/*.ts", "./knexfile.ts"],
+  "include": ["src/**/*", "test", "migrations/*.ts"],
   "exclude": ["*.test.ts", "**/__mocks__/**"],
   "compileOnSave": false
 }


### PR DESCRIPTION
This was causing `tsc` to compile files to the wrong dirs as `knexfile` was outside of `src/`