### PR TITLE
feat: Add AppHome view

### DIFF
--- a/src/api/slack/index.ts
+++ b/src/api/slack/index.ts
@@ -1,10 +1,10 @@
 import * as Sentry from '@sentry/node';
 import { App, LogLevel } from '@slack/bolt';
-import { WebClient } from '@slack/web-api';
 
 import { SLACK_BOT_USER_ACCESS_TOKEN, SLACK_SIGNING_SECRET } from '@app/config';
 
 const bolt = new App({
+  logLevel: LogLevel.INFO,
   token: SLACK_BOT_USER_ACCESS_TOKEN,
   signingSecret: SLACK_SIGNING_SECRET,
   endpoints: '/',

--- a/src/api/slack/updateAppHome/index.ts
+++ b/src/api/slack/updateAppHome/index.ts
@@ -1,0 +1,97 @@
+import { KnownBlock } from '@slack/bolt';
+
+import { getUser } from '@api/getUser';
+import { bolt } from '@api/slack';
+import { muteDeployNotificationsButton } from '@app/blocks/muteDeployNotificationsButton';
+import { unmuteDeployNotificationsButton } from '@app/blocks/unmuteDeployNotificationsButton';
+
+export async function updateAppHome(slackUser: string) {
+  // Listen for users opening your App Home
+  const user = await getUser({
+    slackUser,
+  });
+
+  const disableSlackNotifications =
+    user?.preferences?.disableSlackNotifications;
+
+  const blocks: KnownBlock[] = [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*Welcome home, <@${slackUser}> :house:* - this is under :construction:`,
+      },
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text:
+          'Here you will find information about what I am capable of, as well as adjusting some of your options',
+      },
+    },
+  ];
+
+  // If user has a known github login, then show deploy notification prefs
+  if (user?.githubUser) {
+    blocks.push({
+      type: 'header',
+      text: {
+        type: 'plain_text',
+        text: `Deploy Notifications (currently: ${
+          disableSlackNotifications ? 'off' : 'on'
+        })`,
+        emoji: true,
+      },
+    });
+    blocks.push({
+      type: 'actions',
+      elements: [
+        disableSlackNotifications
+          ? unmuteDeployNotificationsButton()
+          : muteDeployNotificationsButton(),
+      ],
+    });
+  } else {
+    blocks.push(
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text:
+            'Enter your GitHub username below to get notifications when your changes are ready to deploy.',
+        },
+      },
+      {
+        type: 'input',
+        block_id: 'github-login-input',
+        dispatch_action: true,
+        label: {
+          type: 'plain_text',
+          text: 'GitHub username',
+        },
+        element: {
+          type: 'plain_text_input',
+          action_id: 'set-github-login',
+          placeholder: {
+            type: 'plain_text',
+            text: 'Enter your GitHub username and press Enter to save',
+          },
+          dispatch_action_config: {
+            trigger_actions_on: ['on_enter_pressed'],
+          },
+        },
+      }
+    );
+  }
+
+  await bolt.client.views.publish({
+    // Use the user ID associated with the event
+    user_id: slackUser,
+    view: {
+      // Home tabs must be enabled in your app configuration page under "App Home"
+      type: 'home',
+      blocks,
+    },
+  });
+}

--- a/src/api/slackMessageUser/index.ts
+++ b/src/api/slackMessageUser/index.ts
@@ -1,13 +1,7 @@
 import { ChatPostMessageArguments } from '@slack/web-api';
 
+import { getUser } from '@api/getUser';
 import { bolt } from '@api/slack';
-import { getUserPreferences } from '@utils/db/getUserPreferences';
-
-type GetUserParams = {
-  email?: string;
-  slack?: string;
-  github?: string;
-};
 
 /**
  * Attempts to message a user on Slack. This checks the user's notification preferences first
@@ -17,7 +11,7 @@ export async function slackMessageUser(
   message: Omit<ChatPostMessageArguments, 'channel'>
 ) {
   // Check user preference first
-  const user = await getUserPreferences({ slackUser });
+  const user = await getUser({ slackUser });
 
   if (user?.preferences.disableSlackNotifications) {
     return;

--- a/src/handlers/apps/github/brain/pleaseDeployNotifier/actionSlackDeploy.ts
+++ b/src/handlers/apps/github/brain/pleaseDeployNotifier/actionSlackDeploy.ts
@@ -1,10 +1,8 @@
-import { EventTypesPayload } from '@octokit/webhooks';
 import * as Sentry from '@sentry/node';
 
-import { githubEvents } from '@app/api/github';
+import { updateAppHome } from '@api/slack/updateAppHome';
 import { muteDeployNotificationsButton } from '@app/blocks/muteDeployNotificationsButton';
 import { unmuteDeployNotificationsButton } from '@app/blocks/unmuteDeployNotificationsButton';
-import { isGetsentryRequiredCheck } from '@app/handlers/apps/github/utils/isGetsentryRequiredCheck';
 import { setUserPreference } from '@utils/db/setUserPreference';
 
 /**
@@ -64,6 +62,11 @@ export async function actionSlackDeploy({ ack, body, client, context }) {
       user: payload.user.id,
       text: 'There was an error changing your deploy notification preferences',
     });
+  }
+
+  if (body.view) {
+    updateAppHome(body.user.id);
+    return;
   }
 
   /**

--- a/src/handlers/apps/github/brain/requiredChecks/index.ts
+++ b/src/handlers/apps/github/brain/requiredChecks/index.ts
@@ -4,13 +4,11 @@ import { getBlocksForCommit } from '@api/getBlocksForCommit';
 import { getRelevantCommit } from '@api/github/getRelevantCommit';
 import { bolt } from '@api/slack';
 import { githubEvents } from '@app/api/github';
-import { getClient } from '@app/api/github/getClient';
 import {
   Color,
   GETSENTRY_REPO,
   OWNER,
   REQUIRED_CHECK_CHANNEL,
-  SENTRY_REPO,
 } from '@app/config';
 import { isGetsentryRequiredCheck } from '@app/handlers/apps/github/utils/isGetsentryRequiredCheck';
 

--- a/src/handlers/apps/slack/brain/appHome/index.ts
+++ b/src/handlers/apps/slack/brain/appHome/index.ts
@@ -1,0 +1,31 @@
+import { getUser } from '@api/getUser';
+import { bolt } from '@api/slack';
+import { updateAppHome } from '@api/slack/updateAppHome';
+import { db } from '@utils/db';
+
+export function appHome() {
+  // User used App Home to set GitHub login
+  bolt.action('set-github-login', async ({ ack, body, payload }) => {
+    ack();
+    // @ts-ignore
+    const submittedUsername = payload.value;
+    // If user does not yet exist, this will save a new user with slack + github
+    const user = await getUser({
+      slackUser: body.user.id,
+      githubUser: submittedUsername,
+    });
+
+    // User already existed in db, link their GH username
+    if (user && !user.githubUser) {
+      await db('users')
+        .where({ id: user.id })
+        .update({ githubUser: submittedUsername });
+    }
+    updateAppHome(body.user.id);
+  });
+
+  // Listen for users opening your App Home
+  bolt.event('app_home_opened', async ({ event }) => {
+    updateAppHome(event.user);
+  });
+}

--- a/src/handlers/apps/slack/index.ts
+++ b/src/handlers/apps/slack/index.ts
@@ -4,6 +4,7 @@ import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 
 import { pleaseDeployNotifier } from '../github/brain/pleaseDeployNotifier';
 
+import { appHome } from './brain/appHome';
 import { ghaCancel } from './brain/gha-cancel';
 import { notificationPreferences } from './brain/notificationPreferences';
 import { typescript } from './brain/typescript';
@@ -18,6 +19,7 @@ export function createSlack(
   ghaCancel();
   pleaseDeployNotifier();
   notificationPreferences();
+  appHome();
 
   server.get(
     '/stats',

--- a/src/utils/db/getUserPreferences.ts
+++ b/src/utils/db/getUserPreferences.ts
@@ -1,5 +1,4 @@
 import { findUser } from './findUser';
-import { db } from '.';
 
 type GetUserParams = Parameters<typeof findUser>[0];
 


### PR DESCRIPTION
This adds an "AppHome" view that allows users to specify their GitHub
username. If it has already been set, they can configure notification
preferences.