### PR TITLE
ref: Refactor normalizing GitHub profile field

### DIFF
--- a/src/api/getUser/index.ts
+++ b/src/api/getUser/index.ts
@@ -1,10 +1,10 @@
 import * as Sentry from '@sentry/node';
 
+import { SLACK_PROFILE_ID_GITHUB } from '@/config';
 import { bolt } from '@api/slack';
 import { db } from '@utils/db';
 import { findUser } from '@utils/db/findUser';
-
-import { SLACK_PROFILE_ID_GITHUB } from '@/config';
+import { normalizeGithubUser } from '@utils/normalizeGithubUser';
 
 type GetUserParams = Parameters<typeof findUser>[0];
 
@@ -79,9 +79,8 @@ export async function getUser({ email, slackUser, githubUser }: GetUserParams) {
   const githubLogin =
     profileResult?.ok &&
     !githubUser &&
-    profileResult?.profile.fields?.[SLACK_PROFILE_ID_GITHUB]?.value.replace(
-      'https://github.com/',
-      ''
+    normalizeGithubUser(
+      profileResult?.profile.fields?.[SLACK_PROFILE_ID_GITHUB]?.value
     );
 
   const userObject = {

--- a/src/utils/normalizeGithubUser.test.ts
+++ b/src/utils/normalizeGithubUser.test.ts
@@ -1,0 +1,24 @@
+import { normalizeGithubUser } from './normalizeGithubUser';
+
+describe('normalizeGithubUser', function () {
+  it('does nothing if we have a string w/o protocol/host', function () {
+    expect(normalizeGithubUser('githubUser')).toBe('githubUser');
+  });
+
+  it('strips off the github URL', function () {
+    expect(normalizeGithubUser('https://github.com/githubUser')).toBe(
+      'githubUser'
+    );
+    expect(normalizeGithubUser('http://github.com/githubUser')).toBe(
+      'githubUser'
+    );
+  });
+
+  it('strips off the github hostname (no protocol)', function () {
+    expect(normalizeGithubUser('github.com/githubUser')).toBe('githubUser');
+  });
+
+  it('returns undefined if called with undefined', function () {
+    expect(normalizeGithubUser()).toBeUndefined();
+  });
+});

--- a/src/utils/normalizeGithubUser.ts
+++ b/src/utils/normalizeGithubUser.ts
@@ -1,0 +1,16 @@
+/**
+ * This normalizes a GitHub Username from the Slack profile field.
+ *
+ * Because it's a Slack custom profile field, people can input their profiles
+ * in a number of ways including:
+ *
+ * - just the username
+ * - full URL
+ * - partial URL without the protocol
+ * - probably more?
+ *
+ * This strips the protocol and/or host name (github.com)
+ */
+export function normalizeGithubUser(user?: string) {
+  return user?.replace(/(https?:\/\/|)github.com\//, '');
+}


### PR DESCRIPTION
Extract to a function so that we can re-use. This function cleans the Slack profile field for GitHub usernames. People enter in usernames, full URLs to the profile, and even partial URLs.