### PR TITLE
feat: Sync slack GitHub user profile changes to db

### DIFF
--- a/src/brain/syncUserProfileChange/index.test.ts
+++ b/src/brain/syncUserProfileChange/index.test.ts
@@ -1,0 +1,129 @@
+import { createSlackEvent } from '@test/utils/createSlackEvent';
+
+import { buildServer } from '@/buildServer';
+import { SLACK_PROFILE_ID_GITHUB } from '@/config';
+import { bolt } from '@api/slack';
+import { db } from '@utils/db';
+import { setUserPreference } from '@utils/db/setUserPreference';
+
+import { syncUserProfileChange } from '.';
+
+// @ts-ignore
+jest.spyOn(db.context, 'raw');
+
+jest.mock('@utils/db/setUserPreference', () => ({
+  setUserPreference: jest.fn(() => true),
+}));
+
+describe('syncUserProfileChange', function () {
+  let fastify;
+
+  beforeAll(async function () {
+    await db.migrate.latest();
+  });
+
+  afterAll(async function () {
+    await db.migrate.rollback();
+    await db.destroy();
+  });
+
+  beforeEach(async function () {
+    fastify = await buildServer(false);
+    syncUserProfileChange();
+    // @ts-ignore
+    bolt.client.users.profile.get.mockClear();
+  });
+
+  afterEach(async function () {
+    fastify.close();
+    await db('users').delete();
+  });
+
+  it('fetches GitHub profile field on `user_change`', async function () {
+    // @ts-ignore
+    bolt.client.users.profile.get.mockImplementation(() => ({
+      profile: {
+        email: 'test@sentry.io',
+        fields: {
+          [SLACK_PROFILE_ID_GITHUB]: { value: 'githubUser' },
+        },
+      },
+    }));
+    const resp = await createSlackEvent(fastify, 'user_change', {
+      user: {
+        id: 'U789123',
+        is_email_confirmed: true,
+        deleted: false,
+        profile: {
+          email: 'test@sentry.io',
+        },
+      },
+    });
+
+    expect(resp.statusCode).toBe(200);
+    expect(bolt.client.users.profile.get).toHaveBeenCalledWith({
+      user: 'U789123',
+    });
+
+    const user = await db('users').first('*');
+    expect(user).toMatchObject({
+      githubUser: 'githubUser',
+      slackUser: 'U789123',
+      email: 'test@sentry.io',
+    });
+  });
+
+  it('does not fetch if email is not from sentry.io', async function () {
+    const resp = await createSlackEvent(fastify, 'user_change', {
+      user: {
+        id: 'U789123',
+        is_email_confirmed: true,
+        deleted: false,
+        profile: {
+          email: 'test@not-sentry.io',
+        },
+      },
+    });
+
+    expect(resp.statusCode).toBe(200);
+    expect(bolt.client.users.profile.get).not.toHaveBeenCalled();
+    const user = await db('users').first('*');
+    expect(user).toBeUndefined();
+  });
+
+  it('does not fetch if email is not confirmed', async function () {
+    const resp = await createSlackEvent(fastify, 'user_change', {
+      user: {
+        id: 'U789123',
+        is_email_confirmed: false,
+        deleted: false,
+        profile: {
+          email: 'test@sentry.io',
+        },
+      },
+    });
+
+    expect(resp.statusCode).toBe(200);
+    expect(bolt.client.users.profile.get).not.toHaveBeenCalled();
+    const user = await db('users').first('*');
+    expect(user).toBeUndefined();
+  });
+
+  it('does not fetch if user account is deleted', async function () {
+    const resp = await createSlackEvent(fastify, 'user_change', {
+      user: {
+        id: 'U789123',
+        is_email_confirmed: true,
+        deleted: true,
+        profile: {
+          email: 'test@sentry.io',
+        },
+      },
+    });
+
+    expect(resp.statusCode).toBe(200);
+    expect(bolt.client.users.profile.get).not.toHaveBeenCalled();
+    const user = await db('users').first('*');
+    expect(user).toBeUndefined();
+  });
+});

--- a/src/brain/syncUserProfileChange/index.ts
+++ b/src/brain/syncUserProfileChange/index.ts
@@ -1,0 +1,46 @@
+import { SLACK_PROFILE_ID_GITHUB } from '@/config';
+import { bolt } from '@api/slack';
+import { db } from '@utils/db';
+import { normalizeGithubUser } from '@utils/normalizeGithubUser';
+
+/**
+ * Syncs a Slack user profile change (specifically the GH profile field) to DB
+ */
+export function syncUserProfileChange() {
+  bolt.event('user_change', async ({ event }) => {
+    console.log(event);
+
+    // Bad Slack types, we get the full User here
+    // @ts-ignore
+    if (!event.user.is_email_confirmed || event.user.deleted) {
+      return;
+    }
+
+    // @ts-ignore
+    if (!event.user.profile.email.endsWith('@sentry.io')) {
+      return;
+    }
+
+    const { profile } = await bolt.client.users.profile.get({
+      user: event.user.id,
+    });
+
+    const githubUser = normalizeGithubUser(
+      // @ts-ignore
+      profile?.fields?.[SLACK_PROFILE_ID_GITHUB]?.value
+    );
+
+    console.log(profile);
+
+    // Let's save email/slack even if githubUser is undefined
+    await db('users')
+      .insert({
+        // @ts-ignore
+        email: profile.email,
+        slackUser: event.user.id,
+        githubUser,
+      })
+      .onConflict(['email'])
+      .merge();
+  });
+}

--- a/test/utils/getSlackEvent.ts
+++ b/test/utils/getSlackEvent.ts
@@ -4,11 +4,13 @@ export function getSlackEvent(
   eventName: string,
   payload?: Record<string, any>
 ) {
-  const eventPayload = require(`@test/payloads/slack/${eventName}.json`);
+  let eventPayload;
 
-  if (!eventPayload) {
-    throw new Error(`Payload not found: @test/payloads/slack/${eventName}`);
+  try {
+    eventPayload = require(`@test/payloads/slack/${eventName}.json`);
+  } catch {
+    // ignore errors as we can have simple events
   }
 
-  return merge(eventPayload, payload);
+  return merge({ type: eventName }, eventPayload, payload);
 }


### PR DESCRIPTION
When a user profile changes, we fetch their profile in hopes that they updated their GH username, but even if it is not
completed, save the users email + slack id to db.

Closes #42