### PR TITLE
feat: Potentially reduce an API request to `users.profile.get`

### DIFF
--- a/src/api/getUser/index.test.ts
+++ b/src/api/getUser/index.test.ts
@@ -1,9 +1,8 @@
+import { SLACK_PROFILE_ID_GITHUB } from '@/config';
 import { bolt } from '@api/slack';
 import { db } from '@utils/db';
 
 import { getUser } from './';
-
-import { SLACK_PROFILE_ID_GITHUB } from '@/config';
 
 describe('getUser', function () {
   beforeAll(async function () {
@@ -73,7 +72,11 @@ describe('getUser', function () {
     // @ts-ignore
     bolt.client.users.lookupByEmail.mockReturnValueOnce({
       ok: false,
-      user: {},
+      user: {
+        profile: {
+          email: 'test@sentry.io',
+        },
+      },
     });
 
     const user = await getUser({

--- a/src/api/getUser/index.ts
+++ b/src/api/getUser/index.ts
@@ -4,6 +4,7 @@ import { SLACK_PROFILE_ID_GITHUB } from '@/config';
 import { bolt } from '@api/slack';
 import { db } from '@utils/db';
 import { findUser } from '@utils/db/findUser';
+import { isSentrySlackUser } from '@utils/isSentrySlackUser';
 import { normalizeGithubUser } from '@utils/normalizeGithubUser';
 
 type GetUserParams = Parameters<typeof findUser>[0];
@@ -55,10 +56,7 @@ export async function getUser({ email, slackUser, githubUser }: GetUserParams) {
   }
 
   // Do not insert into db if user has not confirmed email, or if they are deleted
-  if (
-    userResult?.user.is_email_confirmed === false ||
-    userResult?.user.deleted === true
-  ) {
+  if (userResult && !isSentrySlackUser(userResult.user)) {
     return null;
   }
 

--- a/src/utils/isSentrySlackUser.test.ts
+++ b/src/utils/isSentrySlackUser.test.ts
@@ -1,0 +1,32 @@
+import { isSentrySlackUser } from './isSentrySlackUser';
+
+describe('isSentrySlackUser', function () {
+  it('must have a `@sentry.io` e-mail addres', function () {
+    expect(
+      isSentrySlackUser({ id: 'U123', profile: { email: 'test@sentry.io' } })
+    ).toBe(true);
+    expect(
+      isSentrySlackUser({
+        id: 'U123',
+        profile: { email: 'test@not-sentry.io' },
+      })
+    ).toBe(false);
+  });
+
+  it('must have a confirmed e-mail addres', function () {
+    expect(
+      isSentrySlackUser({
+        id: 'U123',
+        is_email_confirmed: true,
+        profile: { email: 'test@sentry.io' },
+      })
+    ).toBe(true);
+    expect(
+      isSentrySlackUser({
+        id: 'U123',
+        is_email_confirmed: false,
+        profile: { email: 'test@sentry.io' },
+      })
+    ).toBe(false);
+  });
+});

--- a/src/utils/isSentrySlackUser.ts
+++ b/src/utils/isSentrySlackUser.ts
@@ -1,0 +1,32 @@
+// This is incomplete
+type SlackUser = {
+  id: string;
+  profile: {
+    email?: string;
+  };
+  is_email_confirmed?: boolean;
+  deleted?: boolean;
+  is_restricted?: boolean;
+  is_ultra_restricted?: boolean;
+  is_bot?: boolean;
+  is_app_user?: boolean;
+};
+
+/**
+ * Ensures that a Slack user is a Sentry employee.
+ *
+ * We do explicit boolean checks here because some of these fields seem to be optional from Slack
+ */
+export function isSentrySlackUser(user: SlackUser) {
+  return (
+    user.profile?.email?.endsWith('@sentry.io') &&
+    !(
+      user.is_email_confirmed === false ||
+      user.deleted === true ||
+      user.is_restricted === true ||
+      user.is_ultra_restricted === true ||
+      user.is_bot === true ||
+      user.is_app_user === true
+    )
+  );
+}


### PR DESCRIPTION
It is possible that the `user_change` event include custom profile fields in the user object, which is not the behavior for the `user.info` API. If this happens, skip querying for the user profile and use the value from the event.