### PR TITLE
fix: Fix sentry-cli in deploys and `pleaseDeployNotification` being too noisy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
       id: get-version
       if: github.ref == 'refs/heads/main'
       # Calling `sentry-cli` with `yarn dlx` doesn't work....
-      run: echo "::set-output name=version::$(npx sentry-cli releases propose-version)"
+      run: echo "::set-output name=version::$(yarn dlx -p @sentry/cli sentry-cli releases propose-version)"
 
     # Build ts only when deploying since `test` workflow runs this
     - name: Build


### PR DESCRIPTION
We were wrapping the `check_run` handler instead of after all of the checks for specific check_run events.