### PR TITLE
debug: Remove debug when no slack user found

### DIFF
--- a/src/brain/pleaseDeployNotifier/index.ts
+++ b/src/brain/pleaseDeployNotifier/index.ts
@@ -58,8 +58,12 @@ async function handler({
     email: relevantCommit.commit.author?.email,
   });
 
-  // XXX(billy): Using this to debug and maybe manually alert people for now
-  const slackTarget = !user?.slackUser ? '#z-billy' : user.slackUser;
+  if (!user) {
+    tx.finish();
+    return;
+  }
+
+  const slackTarget = user?.slackUser;
   console.log({ slackTarget });
 
   // Author of commit found


### PR DESCRIPTION
This removes attempt to message a slack channel for debugging purposes.

Fixes SENTRY-CI-TOOLING-2Y