### PR TITLE
fix: Missing slack user throwing slack API errors

### DIFF
--- a/src/brain/pleaseDeployNotifier/index.ts
+++ b/src/brain/pleaseDeployNotifier/index.ts
@@ -58,7 +58,7 @@ async function handler({
     email: relevantCommit.commit.author?.email,
   });
 
-  if (!user) {
+  if (!user?.slackUser) {
     tx.finish();
     return;
   }


### PR DESCRIPTION
We were only checking if a user existed, and not the slack username.

Fixes SENTRY-CI-TOOLING-2Z