### PR TITLE
feat: Only run `updateDeployNotification` for production deploys

### DIFF
--- a/src/brain/updateDeployNotifications/index.ts
+++ b/src/brain/updateDeployNotifications/index.ts
@@ -17,7 +17,6 @@ function getUpdatedDeployMessage({
   payload: FreightPayload;
 }) {
   const { deploy_number, status, user, duration, link, title } = payload;
-
   // You have, user has
   const verbByStatus = {
     true: {
@@ -60,8 +59,11 @@ function getUpdatedDeployMessage({
 
 // Exported for tests
 export async function handler(payload: FreightPayload) {
-  // Get the range of commits for this payload
+  if (payload.environment !== 'production') {
+    return;
+  }
 
+  // Get the range of commits for this payload
   const getsentry = await getClient('getsentry', 'getsentry');
 
   const { data } = await getsentry.repos.compareCommits({


### PR DESCRIPTION
Staging deploys should be ignored, we only care about prod