### PR TITLE
fix: Sync user profile only needs to look for GH username

### DIFF
--- a/src/brain/syncUserProfileChange/index.ts
+++ b/src/brain/syncUserProfileChange/index.ts
@@ -15,18 +15,13 @@ export function syncUserProfileChange() {
       return;
     }
 
-    let githubUser =
+    const githubUser =
       // @ts-ignore
       event.user.profile.fields?.[SLACK_PROFILE_ID_GITHUB]?.value;
 
+    // Only interested for githubUser
     if (!githubUser) {
-      const { profile } = await bolt.client.users.profile.get({
-        user: event.user.id,
-      });
-
-      githubUser =
-        // @ts-ignore
-        profile?.fields?.[SLACK_PROFILE_ID_GITHUB]?.value;
+      return;
     }
 
     // Let's save email/slack even if githubUser is undefined


### PR DESCRIPTION
Change the sync to remove the extra, un-needed profile lookup. The event provides the profile field that we require. If the event does not have it, do not update db.