### PR TITLE
fix(sentry): Fix Sentry scopes

### DIFF
--- a/src/brain/pleaseDeployNotifier/index.ts
+++ b/src/brain/pleaseDeployNotifier/index.ts
@@ -67,13 +67,6 @@ async function handler({
 
   const slackTarget = user?.slackUser;
 
-  Sentry.configureScope(async (scope) => {
-    scope.setUser({
-      id: slackTarget,
-      email: relevantCommit.commit.author?.email,
-    });
-  });
-
   // Author of commit found
   const commitBlocks = getBlocksForCommit(relevantCommit);
   const commit = checkRun.head_sha;
@@ -131,7 +124,13 @@ async function handler({
   // TODO(billy): Deploy directly, save user + sha in db state,
   // Follow up messages with commits that are being deployed
   // Tag people whose commits are being deployed
-  tx.finish();
+  Sentry.withScope(async (scope) => {
+    scope.setUser({
+      id: slackTarget,
+      email: relevantCommit.commit.author?.email,
+    });
+    tx.finish();
+  });
 }
 
 export async function pleaseDeployNotifier() {

--- a/src/brain/updateDeployNotifications/index.ts
+++ b/src/brain/updateDeployNotifications/index.ts
@@ -99,13 +99,6 @@ export async function handler(payload: FreightPayload) {
       ? Color.SUCCESS
       : Color.DANGER;
 
-  Sentry.setContext('freight', {
-    ...payload,
-    title: 'freight',
-    description: payload.title,
-    commits: commitShas,
-  });
-
   const tx = Sentry.startTransaction({
     op: 'handler',
     name: 'updateDeployNotifications',
@@ -150,7 +143,16 @@ export async function handler(payload: FreightPayload) {
 
   await Promise.all(promises);
 
-  tx.finish();
+  Sentry.withScope((scope) => {
+    scope.setContext('freight', {
+      ...payload,
+      title: 'freight',
+      description: payload.title,
+      commits: commitShas,
+    });
+
+    tx.finish();
+  });
 }
 
 export async function updateDeployNotifications() {


### PR DESCRIPTION
Use `with-scope` instead of `configure-scope`, as we only want the scope to be limited to each handler call.