### PR TITLE
test(utils): Add tests for `saveSlackMessage`

### DIFF
--- a/src/brain/requiredChecks/index.test.ts
+++ b/src/brain/requiredChecks/index.test.ts
@@ -230,7 +230,6 @@ describe('requiredChecks', function () {
       channel: 'channel_id',
       ts: '1234123.123',
       context: {
-        passed_at: null,
         status: 'failure',
       },
     });
@@ -593,7 +592,6 @@ describe('requiredChecks', function () {
       channel: 'channel_id',
       ts: '1234123.123',
       context: {
-        passed_at: null,
         status: 'failure',
       },
     });

--- a/src/brain/requiredChecks/index.ts
+++ b/src/brain/requiredChecks/index.ts
@@ -80,6 +80,7 @@ async function handler({
       },
       {
         status: 'success',
+        passed_at: new Date(),
       }
     );
 
@@ -189,6 +190,7 @@ ${jobsList}`,
     },
     {
       status: 'failure',
+      failed_at: new Date(),
     }
   );
 

--- a/src/utils/db/saveSlackMessage.test.ts
+++ b/src/utils/db/saveSlackMessage.test.ts
@@ -1,0 +1,89 @@
+import { SlackMessage } from '@/config/slackMessage';
+
+import { saveSlackMessage } from './saveSlackMessage';
+import { db } from '.';
+
+describe('saveSlackMessage', function () {
+  beforeAll(async function () {
+    await db.migrate.latest();
+  });
+
+  afterAll(async function () {
+    await db.destroy();
+  });
+
+  beforeEach(async function () {});
+
+  afterEach(async function () {
+    await db('slack_messages').delete();
+  });
+
+  it('saves a new message', async function () {
+    await saveSlackMessage(
+      SlackMessage.REQUIRED_CHECK,
+      {
+        refId: '9999',
+        channel: 'channel',
+        ts: '1234.000',
+      },
+      {
+        test: 'foo',
+      }
+    );
+
+    const slackMessages = await db('slack_messages').select('*');
+
+    expect(slackMessages).toHaveLength(1);
+    expect(slackMessages[0]).toMatchObject({
+      channel: 'channel',
+      context: {
+        test: 'foo',
+      },
+      refId: '9999',
+      ts: '1234.000',
+      type: 'required-check',
+    });
+  });
+
+  it('updates an existing  message', async function () {
+    // @ts-ignore
+    const [res] = await saveSlackMessage(
+      SlackMessage.REQUIRED_CHECK,
+      {
+        refId: '9999',
+        channel: 'channel',
+        ts: '1234.000',
+      },
+      {
+        test: 'foo',
+        another: 'foo',
+      }
+    );
+
+    await saveSlackMessage(
+      SlackMessage.REQUIRED_CHECK,
+      {
+        id: res.id,
+      },
+      {
+        another: 'bar',
+        anew: 'baz',
+      }
+    );
+
+    const slackMessages = await db('slack_messages').select('*');
+
+    expect(slackMessages).toHaveLength(1);
+    expect(slackMessages[0]).toMatchObject({
+      channel: 'channel',
+      context: {
+        anew: 'baz',
+        another: 'bar',
+        test: 'foo',
+      },
+      refId: '9999',
+      ts: '1234.000',
+      type: 'required-check',
+    });
+  });
+});

--- a/src/utils/db/saveSlackMessage.ts
+++ b/src/utils/db/saveSlackMessage.ts
@@ -14,32 +14,21 @@ export async function saveSlackMessage(
   context: Record<string, any>
 ) {
   if (id) {
-    await db('slack_messages')
+    return await db('slack_messages')
       .where({
         id,
       })
       .update({
         // @ts-ignore
-        context: db.raw(`context || ?`, [
-          {
-            status: context.status,
-            passed_at: context.status === 'success' ? new Date() : null,
-          },
-        ]),
+        context: db.raw(`context || ?`, [JSON.stringify(context)]),
       });
-    return;
   }
 
-  return await db('slack_messages').insert({
+  return await db('slack_messages').returning('*').insert({
     refId,
     channel,
     ts,
     type,
-
-    context: {
-      ...context,
-      passed_at: context.status === 'success' ? new Date() : null,
-      failed_at: new Date(),
-    },
+    context,
   });
 }


### PR DESCRIPTION
We had some logic from `requiredChecks` in this db util. Moved into brain and added tests.