### PR TITLE
feat(migration): Add `user` column to `slack_messages` table

### DIFF
--- a/migrations/20210224123015_add_user_col_slack_message.ts
+++ b/migrations/20210224123015_add_user_col_slack_message.ts
@@ -1,0 +1,13 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  knex.schema.table('slack_messages', (table) => {
+    table.string('user');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  knex.schema.table('slack_messages', (table) => {
+    table.dropColumn('user');
+  });
+}


### PR DESCRIPTION
The `channel` argument to `postMessage` is not the same as the result of `postMessage()` `channel`. We need to store the user somewhere.