### PR TITLE
feat(brain): Revert `user` col for `slack_messages` table

### DIFF
--- a/migrations/20210224150844_remove_user_col_slack_messages.ts
+++ b/migrations/20210224150844_remove_user_col_slack_messages.ts
@@ -1,0 +1,13 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.table('slack_messages', (table) => {
+    table.dropColumn('user');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.table('slack_messages', (table) => {
+    table.string('user');
+  });
+}

--- a/src/brain/pleaseDeployNotifier/index.ts
+++ b/src/brain/pleaseDeployNotifier/index.ts
@@ -112,8 +112,6 @@ async function handler({
         refId: commit,
         channel: `${message.channel}`,
         ts: `${message.ts}`,
-        // @ts-ignore
-        user: `${message.message.user}`,
       },
       {
         target: slackTarget,

--- a/src/brain/requiredChecks/index.ts
+++ b/src/brain/requiredChecks/index.ts
@@ -187,8 +187,6 @@ ${jobsList}`,
       refId: checkRun.head_sha,
       channel: `${message.channel}`,
       ts: `${message.ts}`,
-      // @ts-ignore
-      user: `${message.message.user}`,
     },
     {
       status: 'failure',

--- a/src/brain/updateDeployNotifications/index.test.ts
+++ b/src/brain/updateDeployNotifications/index.test.ts
@@ -313,7 +313,7 @@ describe('updateDeployNotifications', function () {
           },
         ],
         "channel": "channel_id",
-        "text": "<@U018UAXJVG8>, your commit has been deployed. Please check the Sentry Releases linked below to make sure there are no issues.",
+        "text": "<@U789123>, your commit has been deployed. Please check the Sentry Releases linked below to make sure there are no issues.",
         "thread_ts": "1234123.123",
       }
     `);

--- a/src/brain/updateDeployNotifications/index.ts
+++ b/src/brain/updateDeployNotifications/index.ts
@@ -159,7 +159,9 @@ export async function handler(payload: FreightPayload) {
               thread_ts: message.ts,
               channel: message.channel,
               text: `${
-                message.user ? `<@${message.user}>, your` : 'Your'
+                message.context.target
+                  ? `<@${message.context.target}>, your`
+                  : 'Your'
               } commit has been deployed. Please check the Sentry Releases linked below to make sure there are no issues.`,
               attachments: [
                 {

--- a/src/types/knex/index.d.ts
+++ b/src/types/knex/index.d.ts
@@ -29,7 +29,6 @@ declare module 'knex/types/tables' {
     ts: string;
     type: SlackMessage;
     context: Record<string, any>;
-    user?: string;
   }
 
   interface Tables {

--- a/src/utils/db/saveSlackMessage.ts
+++ b/src/utils/db/saveSlackMessage.ts
@@ -6,7 +6,6 @@ interface SaveSlackMessage {
   channel: string;
   ts: string;
   id?: string;
-  user?: string;
 }
 
 type UpdateSlackMessage = Required<Pick<SaveSlackMessage, 'id'>> &
@@ -14,7 +13,7 @@ type UpdateSlackMessage = Required<Pick<SaveSlackMessage, 'id'>> &
 
 export async function saveSlackMessage(
   type: SlackMessage,
-  { refId, channel, ts, id, user }: SaveSlackMessage | UpdateSlackMessage,
+  { refId, channel, ts, id }: SaveSlackMessage | UpdateSlackMessage,
   context: Record<string, any>
 ) {
   if (id) {
@@ -31,7 +30,6 @@ export async function saveSlackMessage(
   return await db('slack_messages').returning('*').insert({
     refId,
     channel,
-    user,
     ts,
     type,
     context,


### PR DESCRIPTION
This reverts the changes in #126 and #129 - I again, incorrectly assumed that the `postMessage()` response message user referred to the target, but it refers to the author (bot). When saving the slack message, we know the target, so save/use it from context.