### PR TITLE
ref(util): Refactor `getSlackMessage` to support multiple refIds

### DIFF
--- a/src/brain/updateDeployNotifications/index.ts
+++ b/src/brain/updateDeployNotifications/index.ts
@@ -9,6 +9,7 @@ import { getUser } from '@api/getUser';
 import { getClient } from '@api/github/getClient';
 import { bolt } from '@api/slack';
 import { db } from '@utils/db';
+import { getSlackMessage } from '@utils/db/getSlackMessage';
 
 function getUpdatedDeployMessage({
   isUserDeploying,
@@ -81,11 +82,10 @@ export async function handler(payload: FreightPayload) {
   const commitShas = data.commits.map(({ sha }) => sha);
 
   // Look for associated slack messages based on getsentry commit sha
-  const messages = await db('slack_messages')
-    .where({
-      type: SlackMessage.PLEASE_DEPLOY,
-    })
-    .whereIn('refId', commitShas);
+  const messages = await getSlackMessage(
+    SlackMessage.PLEASE_DEPLOY,
+    commitShas
+  );
   const { status } = payload;
 
   const progressText =

--- a/src/utils/db/getSlackMessage.ts
+++ b/src/utils/db/getSlackMessage.ts
@@ -1,6 +1,26 @@
+import { SlackMessageRow } from 'knex/types/tables';
+
 import { SlackMessage } from '@/config/slackMessage';
 import { db } from '@utils/db';
 
-export async function getSlackMessage(type: SlackMessage, refId: string) {
-  return await db('slack_messages').where({ refId, type }).first('*');
+export async function getSlackMessage(
+  type: SlackMessage,
+  refIds: string
+): Promise<SlackMessageRow>;
+export async function getSlackMessage(
+  type: SlackMessage,
+  refIds: string[]
+): Promise<SlackMessageRow[]>;
+export async function getSlackMessage(
+  type: SlackMessage,
+  refIds: string | string[]
+): Promise<SlackMessageRow | SlackMessageRow[]> {
+  if (typeof refIds === 'string') {
+    return await db('slack_messages').where({ type, refId: refIds }).first('*');
+  } else {
+    return await db('slack_messages')
+      .where({ type })
+      .whereIn('refId', refIds)
+      .select('*');
+  }
 }


### PR DESCRIPTION
Change `getSlackMessage` to support multiple `refId`s, update `updateDeployNotifications` to use this fn.