### PR TITLE
fix(brain): Fix `githubMetrics` not being loaded

### DIFF
--- a/src/brain/githubMetrics/index.test.ts
+++ b/src/brain/githubMetrics/index.test.ts
@@ -25,7 +25,7 @@ import { buildServer } from '@/buildServer';
 import { getClient } from '@api/github/getClient';
 import * as db from '@utils/metrics';
 
-import { metrics } from '.';
+import { githubMetrics as metrics } from '.';
 
 jest.spyOn(db, 'insert');
 jest.spyOn(db, 'insertOss');

--- a/src/brain/githubMetrics/index.ts
+++ b/src/brain/githubMetrics/index.ts
@@ -3,7 +3,7 @@ import { githubEvents } from '@api/github';
 import { ossMetrics } from './ossMetrics';
 import { sentryMetrics } from './sentryMetrics';
 
-export async function metrics() {
+export async function githubMetrics() {
   githubEvents.removeListener('check_run', sentryMetrics);
   githubEvents.on('check_run', sentryMetrics);
 

--- a/src/utils/loadBrain.test.ts
+++ b/src/utils/loadBrain.test.ts
@@ -1,0 +1,12 @@
+import { getBrainModules, getExportedFunctions } from './loadBrain';
+
+jest.unmock('./loadBrain');
+
+describe('loadBrain', function () {
+  it('makes sure that for every file in `brain/`, we load at least one function from it', async function () {
+    const modules = await getBrainModules();
+    const fns = getExportedFunctions(modules);
+
+    expect(new Set(modules)).toEqual(new Set(fns.map((f) => f.name)));
+  });
+});

--- a/src/utils/loadBrain.ts
+++ b/src/utils/loadBrain.ts
@@ -3,32 +3,47 @@ import path from 'path';
 
 import * as Sentry from '@sentry/node';
 
+const ROOT = path.join(__dirname, '../brain');
+
 /**
  * Loads all modules in the root of `@/brain`
+ *
+ * Currently we only want to load the exported fn whose name matches the module name,
+ * this is because we sometimes export functions only for testing.
  */
 export async function loadBrain() {
-  const root = path.join(__dirname, '../brain');
-
-  // @ts-ignore
-  const modules: Function[] = (await fs.readdir(root))
-    .filter((f) => !f.endsWith('.d.ts') && !f.endsWith('.map'))
-    .flatMap((f) => {
-      try {
-        // Only return imported functions that match filename
-        // This is because we sometimes need to export other functions to test
-        return (
-          Object.entries(require(path.join(root, f)))
-            // @ts-ignore
-            .filter(([key]) => key === f)
-            .map(([, value]) => value)
-        );
-      } catch (e) {
-        const err = new Error(`Unable to load brain: ${f}`);
-        Sentry.captureException(err);
-        console.error(err);
-        return [];
-      }
-    });
-
+  const modules = getExportedFunctions(await getBrainModules()) as Function[];
   modules.forEach((m) => m());
+}
+
+/**
+ * This is only exported for test
+ */
+export async function getBrainModules() {
+  return (await fs.readdir(ROOT)).filter(
+    (f) => !f.endsWith('.d.ts') && !f.endsWith('.map') && !f.endsWith('.md')
+  );
+}
+
+/**
+ * This is only exported for test
+ */
+export function getExportedFunctions(fileNames: string[]) {
+  return fileNames.flatMap((f) => {
+    try {
+      // Only return imported functions that match filename
+      // This is because we sometimes need to export other functions to test
+      return (
+        Object.entries(require(path.join(ROOT, f)))
+          // @ts-ignore
+          .filter(([key]) => key === f)
+          .map(([, value]) => value)
+      );
+    } catch (e) {
+      const err = new Error(`Unable to load brain: ${f}`);
+      Sentry.captureException(err);
+      console.error(err);
+      return [];
+    }
+  });
 }

--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -132,10 +132,14 @@ type TargetConfig = {
 };
 
 function _insert(data: Record<string, any>, targetConfig: TargetConfig) {
+  const tx = Sentry.startTransaction({
+    op: 'bigquery',
+    name: `insert.${targetConfig.dataset}`,
+  });
   const dataset = bigqueryClient.dataset(targetConfig.dataset);
   const table = dataset.table(targetConfig.table);
 
-  return table
+  const results = table
     .insert(data, {
       schema: objectToSchema(targetConfig.schema),
     })
@@ -157,6 +161,10 @@ function _insert(data: Record<string, any>, targetConfig: TargetConfig) {
 
       throw err;
     });
+
+  tx.finish();
+
+  return results;
 }
 
 export function insert({ meta = {}, ...row }) {


### PR DESCRIPTION
This regressed in https://github.com/getsentry/sentry-ci-tooling/pull/102 where we filter what modules to autoload based on module name === exported fn name, as there was a function I wanted to import only for testing.

I added a simple test, but this is a bit brittle and we should remove this in the future. e.g. instead of enforcing the names to be the same, we could simply move the exported fn to a different module.