### PR TITLE
feat(brain): Limit notifications for failing builds

### DIFF
--- a/src/brain/pleaseDeployNotifier/index.test.ts
+++ b/src/brain/pleaseDeployNotifier/index.test.ts
@@ -227,7 +227,7 @@ describe('pleaseDeployNotifier', function () {
               "type": "actions",
             },
           ],
-          "color": "#C6BECF",
+          "color": "#E7E1EC",
         },
       ]
     `);

--- a/src/brain/pleaseDeployNotifier/index.ts
+++ b/src/brain/pleaseDeployNotifier/index.ts
@@ -92,7 +92,7 @@ async function handler({
     text,
     attachments: [
       {
-        color: Color.NEUTRAL,
+        color: Color.OFF_WHITE_TOO,
         blocks,
       },
     ],

--- a/src/brain/updateDeployNotifications/index.test.ts
+++ b/src/brain/updateDeployNotifications/index.test.ts
@@ -205,7 +205,7 @@ describe('updateDeployNotifications', function () {
                 "type": "section",
               },
             ],
-            "color": "#C6BECF",
+            "color": "#E7E1EC",
           },
         ],
         "channel": "channel_id",

--- a/src/brain/updateDeployNotifications/index.ts
+++ b/src/brain/updateDeployNotifications/index.ts
@@ -98,7 +98,7 @@ export async function handler(payload: FreightPayload) {
       : '';
   const progressColor =
     status === 'queued'
-      ? Color.NEUTRAL
+      ? Color.OFF_WHITE_TOO
       : status === 'started'
       ? Color.SUCCESS_LIGHT
       : status === 'finished'

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -15,10 +15,12 @@ export const REQUIRED_CHECK_CHANNEL = '#team-engineering';
 export const SLACK_PROFILE_ID_GITHUB = 'XfEJ1CLM1C';
 export const SLACK_BOT_APP_ID = process.env.SLACK_BOT_APP_ID || '';
 
+// Note, these are Sentry palette colors
 export enum Color {
   DANGER = '#F55459',
   DANGER_LIGHT = '#FCC6C8',
   NEUTRAL = '#C6BECF',
+  OFF_WHITE_TOO = '#E7E1EC',
   SUCCESS = '#33BF9E',
   SUCCESS_LIGHT = '#B6ECDF',
 }
@@ -44,3 +46,20 @@ export const SLACK_SIGNING_SECRET = process.env.SLACK_SIGNING_SECRET || '';
  * Freight
  */
 export const FREIGHT_HOST = 'https://freight.getsentry.net';
+
+export enum BuildStatus {
+  SUCCESS = 'success',
+  NEUTRAL = 'neutral',
+  SKIPPED = 'skipped',
+
+  FAILURE = 'failure',
+  MISSING = 'missing',
+  CANCELLED = 'cancelled',
+  ACTION_REQUIRED = 'action_required',
+  STALE = 'stale',
+  TIMED_OUT = 'timed_out',
+
+  UNKNOWN = 'unknown',
+  FIXED = 'fixed',
+  FLAKE = 'flake',
+}

--- a/src/types/knex/index.d.ts
+++ b/src/types/knex/index.d.ts
@@ -1,5 +1,6 @@
 import Knex from 'knex';
 
+import { BuildStatus } from '@/config';
 import { SlackMessage } from '@/config/slackMessage';
 
 declare module 'knex/types/tables' {
@@ -17,7 +18,7 @@ declare module 'knex/types/tables' {
     ref: string;
     channel: string;
     ts: string;
-    status: 'success' | 'failure';
+    status: BuildStatus;
     failed_at: Date;
     passed_at: Date | null;
   }

--- a/src/utils/db/getFailureMessages.test.ts
+++ b/src/utils/db/getFailureMessages.test.ts
@@ -1,0 +1,75 @@
+import { SlackMessage } from '@/config/slackMessage';
+import { db } from '@utils/db';
+import { saveSlackMessage } from '@utils/db/saveSlackMessage';
+
+import { getFailureMessages } from './getFailureMessages';
+
+describe('getFailureMessages', function () {
+  beforeAll(async function () {
+    await db.migrate.latest();
+  });
+
+  afterAll(async function () {
+    await db.destroy();
+  });
+
+  afterEach(async function () {
+    await db('slack_messages').delete();
+  });
+
+  it('initially is not failing', async function () {
+    expect(await getFailureMessages()).toEqual([]);
+  });
+
+  it('is failing', async function () {
+    await saveSlackMessage(
+      SlackMessage.REQUIRED_CHECK,
+      {
+        refId: '999999',
+        channel: 'channel',
+        ts: '123.123',
+      },
+      {
+        status: 'failure',
+        failed_at: new Date(),
+      }
+    );
+    expect(await getFailureMessages()).toHaveLength(1);
+  });
+
+  it('ignores failed tests older than 2 hours', async function () {
+    const now = new Date();
+    now.setHours(now.getHours() - 3);
+    await saveSlackMessage(
+      SlackMessage.REQUIRED_CHECK,
+      {
+        refId: '999999',
+        channel: 'channel',
+        ts: '123.123',
+      },
+      {
+        status: 'failure',
+        failed_at: now,
+      }
+    );
+    expect(await getFailureMessages()).toEqual([]);
+  });
+
+  it('can fetch all failed tests', async function () {
+    const now = new Date();
+    now.setHours(now.getHours() - 3);
+    await saveSlackMessage(
+      SlackMessage.REQUIRED_CHECK,
+      {
+        refId: '999999',
+        channel: 'channel',
+        ts: '123.123',
+      },
+      {
+        status: 'failure',
+        failed_at: now,
+      }
+    );
+    expect(await getFailureMessages(null)).toHaveLength(1);
+  });
+});

--- a/src/utils/db/getFailureMessages.ts
+++ b/src/utils/db/getFailureMessages.ts
@@ -1,0 +1,31 @@
+import { BuildStatus } from '@/config';
+import { SlackMessage } from '@/config/slackMessage';
+import { db } from '@utils/db';
+import { getTimestamp } from '@utils/db/getTimestamp';
+
+/**
+ * Getsentry is considered to be "failing" if we have a failed status check (which gets saved to `slack_messages`)
+ * within the last 2 hours (by default)
+ *
+ * Returns slack messages that have failed since `since`
+ */
+export async function getFailureMessages(
+  since: string | null = `now() - interval '2 hours'`
+) {
+  const query = db('slack_messages')
+    .select('*')
+    .select(db.raw(`${getTimestamp(`context::json->>'failed_at'`)} as date`))
+    .where({
+      type: SlackMessage.REQUIRED_CHECK,
+    })
+    .where(db.raw(`context::json->>'status' = '${BuildStatus.FAILURE}'`))
+    .orderBy('date', 'desc');
+
+  if (since !== null) {
+    query.where(
+      db.raw(`${getTimestamp(`context::json->>'failed_at'`)} >= ${since}`)
+    );
+  }
+
+  return await query;
+}

--- a/src/utils/db/getTimestamp.ts
+++ b/src/utils/db/getTimestamp.ts
@@ -1,0 +1,8 @@
+/**
+ * Helper for knex query builder
+ *
+ * Creates a raw query string for a column that holds a ISO8601 string in order to transform it to a pg timestamp
+ */
+export function getTimestamp(column: string) {
+  return `to_timestamp(${column}, 'YYYY-MM-DD"T"HH24:MI:SS:MS"Z"')`;
+}


### PR DESCRIPTION
This limits notifications when there are consecutive failing builds. The
following builds will be posted in a thread of the original failing build.

There may be a race condition if we have a flakey build that is followed by
a real build failure.