### PR TITLE
feat(migration): Change `deploys` to have external_id and env be unique

### DIFF
--- a/migrations/20210301130906_add_deploy_unique.ts
+++ b/migrations/20210301130906_add_deploy_unique.ts
@@ -1,0 +1,24 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('deploys', (table) => {
+    table.dropPrimary();
+    table.renameColumn('id', 'external_id');
+    table.unique(['external_id', 'environment']);
+  });
+  await knex.schema.alterTable('deploys', (table) => {
+    table.bigIncrements('id').primary();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('deploys', (table) => {
+    table.dropColumn('id');
+    table.dropUnique(['external_id', 'environment']);
+  });
+
+  await knex.schema.alterTable('deploys', (table) => {
+    table.renameColumn('external_id', 'id');
+    table.primary(['id']);
+  });
+}

--- a/src/brain/deployState/index.ts
+++ b/src/brain/deployState/index.ts
@@ -21,7 +21,7 @@ export async function deployState() {
     }) =>
       await db('deploys')
         .insert({
-          id: deploy_number,
+          external_id: deploy_number,
           user_id,
           app_name,
           user,
@@ -35,7 +35,7 @@ export async function deployState() {
           started_at: date_started,
           finished_at: date_finished,
         })
-        .onConflict('id')
+        .onConflict(['external_id', 'environment'])
         .merge()
   );
 }

--- a/src/types/knex/index.d.ts
+++ b/src/types/knex/index.d.ts
@@ -33,6 +33,7 @@ declare module 'knex/types/tables' {
 
   interface Deploys {
     id: number;
+    external_id: number;
     user_id: number;
     app_name: string;
     user: string;
@@ -41,11 +42,10 @@ declare module 'knex/types/tables' {
     previous_sha: string;
     status: FreightStatus;
     environment: string;
-    duration: number;
+    duration: number | null;
     created_at: string;
-    date_created;
-    started_at: string;
-    finished_at: string;
+    started_at: string | null;
+    finished_at: string | null;
   }
 
   interface Tables {


### PR DESCRIPTION
This changes `deploys` schema so that external_id and env are unique.
external_id is `deploy_number` from Freight.