### PR TITLE
fix(migrations): Give up on `onConflict` for upsert

### DIFF
--- a/src/brain/deployState/index.test.ts
+++ b/src/brain/deployState/index.test.ts
@@ -78,6 +78,7 @@ describe('deployState', function () {
     // I think `onConflict` is causing this
     await tick();
     await tick();
+    await tick();
     // @ts-ignore
     deploys = await dbMock('deploys').select('*');
     expect(deploys).toHaveLength(1);
@@ -106,6 +107,7 @@ describe('deployState', function () {
       status: 'finished',
     });
     expect(dbMock).toHaveBeenCalledTimes(1);
+    await tick();
     await tick();
     await tick();
     // @ts-ignore


### PR DESCRIPTION
I have no idea why it does not work. Local tests are working correctly. Giving up and just using 2 queries here to upsert.