### PR TITLE
feat(brain): Hide "View Undeployed Commits"

### DIFF
--- a/src/brain/pleaseDeployNotifier/index.test.ts
+++ b/src/brain/pleaseDeployNotifier/index.test.ts
@@ -133,7 +133,7 @@ describe('pleaseDeployNotifier', function () {
     });
     expect(octokit.repos.getCommit).toHaveBeenCalledTimes(2);
 
-    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(1);
+    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(2);
 
     // First message
     expect(bolt.client.chat.postMessage).toHaveBeenCalledWith(
@@ -335,16 +335,6 @@ describe('pleaseDeployNotifier', function () {
                   "type": "button",
                   "url": "https://freight.getsentry.net/deploy?app=getsentry",
                   "value": "6d225cb77225ac655d817a7551a26fff85090fe6",
-                },
-                Object {
-                  "action_id": "view-undeployed-commits",
-                  "text": Object {
-                    "emoji": true,
-                    "text": "View Undeployed Commits",
-                    "type": "plain_text",
-                  },
-                  "type": "button",
-                  "value": "999999:6d225cb77225ac655d817a7551a26fff85090fe6",
                 },
                 Object {
                   "action_id": "mute-slack-deploy",

--- a/src/brain/pleaseDeployNotifier/index.ts
+++ b/src/brain/pleaseDeployNotifier/index.ts
@@ -84,18 +84,20 @@ async function handler({
 
   const lastDeploy = await getLastSuccessfulDeploy();
 
+  const actions = [
+    freightDeploy(commit),
+    // ...(lastDeploy
+    // ? [viewUndeployedCommits(`${lastDeploy.sha}:${commit}`)]
+    // : []),
+    muteDeployNotificationsButton(),
+  ];
+
   const blocks = [
     ...commitBlocks,
 
     {
       type: 'actions',
-      elements: [
-        freightDeploy(commit),
-        ...(lastDeploy
-          ? [viewUndeployedCommits(`${lastDeploy.sha}:${commit}`)]
-          : []),
-        muteDeployNotificationsButton(),
-      ],
+      elements: actions,
     },
   ];
 
@@ -105,6 +107,28 @@ async function handler({
       {
         color: Color.NEUTRAL,
         blocks,
+      },
+    ],
+  });
+
+  await bolt.client.chat.postMessage({
+    channel: '#z-billy',
+    text,
+    attachments: [
+      {
+        color: Color.NEUTRAL,
+        blocks: [
+          ...commitBlocks,
+          {
+            type: 'actions',
+            elements: [
+              ...actions,
+              ...(lastDeploy
+                ? [viewUndeployedCommits(`${lastDeploy.sha}:${commit}`)]
+                : []),
+            ],
+          },
+        ],
       },
     ],
   });

--- a/src/brain/updateDeployNotifications/index.test.ts
+++ b/src/brain/updateDeployNotifications/index.test.ts
@@ -149,7 +149,7 @@ describe('updateDeployNotifications', function () {
         },
       },
     });
-    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(1);
+    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(2);
     const slackMessages = await db('slack_messages').select('*');
     expect(slackMessages).toHaveLength(1);
     expect(slackMessages[0]).toMatchObject({
@@ -480,7 +480,7 @@ describe('updateDeployNotifications', function () {
     });
 
     // Each commit will cause a message
-    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(2);
+    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(4);
     const slackMessages = await db('slack_messages').select('*');
     expect(slackMessages).toHaveLength(2);
     expect(slackMessages[0]).toMatchObject({
@@ -542,7 +542,7 @@ describe('updateDeployNotifications', function () {
         },
       },
     });
-    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(1);
+    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(2);
     await db('slack_messages').insert({
       refId: '982345',
       channel: 'channel_id',


### PR DESCRIPTION
Soft reverts #151 -- hide the button from users and add a debug message. Add sentry transactions for the button action