### PR TITLE
perf(tracing): Add Sentry HTTP/pgsql tracing

### DIFF
--- a/src/brain/pleaseDeployNotifier/index.ts
+++ b/src/brain/pleaseDeployNotifier/index.ts
@@ -56,6 +56,8 @@ async function handler({
     name: 'pleaseDeployNotifier',
   });
 
+  Sentry.configureScope((scope) => scope.setSpan(tx));
+
   // Message author on slack that they're commit is ready to deploy
   // and send a link to open freight
   const user = await getUser({

--- a/src/brain/updateDeployNotifications/index.ts
+++ b/src/brain/updateDeployNotifications/index.ts
@@ -68,6 +68,12 @@ export async function handler(payload: FreightPayload) {
     return;
   }
 
+  const tx = Sentry.startTransaction({
+    op: 'brain',
+    name: 'updateDeployNotifications',
+  });
+  Sentry.configureScope((scope) => scope.setSpan(tx));
+
   // Get the range of commits for this payload
   const getsentry = await getClient('getsentry', 'getsentry');
 
@@ -103,11 +109,6 @@ export async function handler(payload: FreightPayload) {
       : status === 'finished'
       ? Color.SUCCESS
       : Color.DANGER;
-
-  const tx = Sentry.startTransaction({
-    op: 'brain',
-    name: 'updateDeployNotifications',
-  });
 
   const promises = messages.map(async (message) => {
     const updatedBlocks = message.context.blocks.slice(0, -1);

--- a/src/buildServer.ts
+++ b/src/buildServer.ts
@@ -1,10 +1,9 @@
-import '@sentry/tracing';
-
 import { ServerResponse } from 'http';
 import path from 'path';
 
 import { RewriteFrames } from '@sentry/integrations';
 import * as Sentry from '@sentry/node';
+import * as Tracing from '@sentry/tracing';
 import fastify, { FastifyReply } from 'fastify';
 
 import { Fastify } from '@types';
@@ -24,20 +23,17 @@ export async function buildServer(
     logger,
   });
 
-  // Only enable in production
-  // if (process.env.ENV === 'production') {
   Sentry.init({
     dsn: SENTRY_DSN,
     release: process.env.VERSION,
-    environment: process.env.ENV,
+    environment: process.env.ENV || 'development',
     integrations: [
       new Sentry.Integrations.Http({ tracing: true }),
-
+      new Tracing.Integrations.Postgres(),
       new RewriteFrames({ root: __dirname || process.cwd() }),
     ],
     tracesSampleRate: 1.0,
   });
-  // }
 
   server.register(require('fastify-formbody'));
 


### PR DESCRIPTION
Removes custom tracing and use Sentry HTTP/pgsql tracing integrations. Also enable Sentry for development.

Note that the Sentry Express integration does not work.