### PR TITLE
ref(api): Remove repo install, cache org installation id

### DIFF
--- a/src/api/github/__mocks__/getClient.ts
+++ b/src/api/github/__mocks__/getClient.ts
@@ -27,6 +27,7 @@ function mockClient() {
       getCommit: jest.fn(),
       listPullRequestsAssociatedWithCommit: jest.fn(),
       compareCommits: jest.fn(() => ({
+        status: 200,
         data: {
           // Incomplete
           commits: [
@@ -44,11 +45,14 @@ function mockClient() {
 }
 
 const mocks = {
-  sentry: mockClient(),
   getsentry: mockClient(),
-  undefined: mockClient(),
 };
 
-export async function getClient(owner?: string, repo?: string) {
-  return mocks[repo || 'undefined'];
+export async function getClient(org?: string) {
+  if (mocks[org]) {
+    return mocks[org];
+  }
+
+  mocks[org] = mockClient();
+  return mocks[org];
 }

--- a/src/api/github/getRelevantCommit.ts
+++ b/src/api/github/getRelevantCommit.ts
@@ -1,4 +1,3 @@
-import { Octokit } from '@octokit/rest';
 import * as Sentry from '@sentry/node';
 
 import { getClient } from '@/api/github/getClient';
@@ -11,10 +10,9 @@ import { GETSENTRY_REPO, OWNER, SENTRY_REPO } from '@/config';
  * caused a bump commit in getsentry (whose commit message references the sentry commit).
  * In this case, it will return the sentry commit.
  */
-export async function getRelevantCommit(ref: string, client?: Octokit) {
+export async function getRelevantCommit(ref: string) {
   try {
-    // We can save on making extra calls to get GH client
-    const octokit = client || (await getClient(OWNER, GETSENTRY_REPO));
+    const octokit = await getClient(OWNER);
 
     // Attempt to get the getsentry commit first
     const { data: commit } = await octokit.repos.getCommit({

--- a/src/api/github/getSentryPullRequestsForGetsentryRange.ts
+++ b/src/api/github/getSentryPullRequestsForGetsentryRange.ts
@@ -37,12 +37,11 @@ export async function getSentryPullRequestsForGetsentryRange(
   includeGetsentry?: boolean
 ): Promise<PullRequest[number][]> {
   // getsentry client
-  const getsentry = await getClient(OWNER, GETSENTRY_REPO);
-  const sentry = await getClient(OWNER, SENTRY_REPO);
+  const client = await getClient(OWNER);
 
   // Single commit
   if (!previous) {
-    const resp = await getsentry.git.getCommit({
+    const resp = await client.git.getCommit({
       owner: OWNER,
       repo: GETSENTRY_REPO,
       commit_sha: current,
@@ -58,7 +57,6 @@ export async function getSentryPullRequestsForGetsentryRange(
     }
 
     const sentryCommitSha = isBumpCommit && getSentrySha(resp.data.message);
-    const client = isBumpCommit ? sentry : getsentry;
     const pullRequests = await client.repos.listPullRequestsAssociatedWithCommit(
       {
         owner: OWNER,
@@ -70,7 +68,7 @@ export async function getSentryPullRequestsForGetsentryRange(
   }
 
   // Multiple commits
-  const resp = await getsentry.repos.compareCommits({
+  const resp = await client.repos.compareCommits({
     owner: OWNER,
     repo: GETSENTRY_REPO,
     base: previous,
@@ -92,7 +90,7 @@ export async function getSentryPullRequestsForGetsentryRange(
   );
 
   const pullRequestPromises = sentryShas.map((commit_sha) =>
-    sentry.repos.listPullRequestsAssociatedWithCommit({
+    client.repos.listPullRequestsAssociatedWithCommit({
       owner: OWNER,
       repo: SENTRY_REPO,
       commit_sha,
@@ -101,7 +99,7 @@ export async function getSentryPullRequestsForGetsentryRange(
 
   const getSentryPullRequestPromises = nonSyncedCommits.map(
     ({ sha: commit_sha }) =>
-      getsentry.repos.listPullRequestsAssociatedWithCommit({
+      client.repos.listPullRequestsAssociatedWithCommit({
         owner: OWNER,
         repo: GETSENTRY_REPO,
         commit_sha,

--- a/src/brain/ghaCancel/index.test.ts
+++ b/src/brain/ghaCancel/index.test.ts
@@ -21,7 +21,7 @@ describe('gha-test', function () {
   });
   beforeEach(async function () {
     await db('users').delete();
-    octokit = await getClient('getsentry', 'sentry');
+    octokit = await getClient('getsentry');
     fastify = await buildServer(false);
     ghaCancel();
     // @ts-ignore

--- a/src/brain/ghaCancel/index.ts
+++ b/src/brain/ghaCancel/index.ts
@@ -23,7 +23,7 @@ async function handler({ event, say, client }) {
 
   const [, owner, repo, pullRequestNumber] = matches;
 
-  const octokit = await getClient(owner, repo);
+  const octokit = await getClient(owner);
 
   const initialMessagePromise = say({
     thread_ts: event.ts,

--- a/src/brain/pleaseDeployNotifier/actionViewUndeployedCommits.ts
+++ b/src/brain/pleaseDeployNotifier/actionViewUndeployedCommits.ts
@@ -48,7 +48,7 @@ export async function actionViewUndeployedCommits({
 
   // @ts-ignore Slack types suxx
   const [base, head] = payload.value.split(':');
-  const github = await getClient(OWNER, GETSENTRY_REPO);
+  const github = await getClient(OWNER);
 
   // Get all getsentry commits between `base` and `head`
   const { data } = await github.repos.compareCommits({

--- a/src/brain/pleaseDeployNotifier/index.test.ts
+++ b/src/brain/pleaseDeployNotifier/index.test.ts
@@ -25,7 +25,7 @@ describe('pleaseDeployNotifier', function () {
     jest.spyOn(actions, 'actionViewUndeployedCommits');
 
     pleaseDeployNotifier();
-    octokit = await getClient('getsentry', 'getsentry');
+    octokit = await getClient('getsentry');
     octokit.repos.getCommit.mockImplementation(({ repo, ref }) => {
       const defaultPayload = require('@test/payloads/github/commit').default;
       if (repo === 'sentry') {

--- a/src/brain/requiredChecks/index.test.ts
+++ b/src/brain/requiredChecks/index.test.ts
@@ -29,7 +29,7 @@ describe('requiredChecks', function () {
   beforeEach(async function () {
     fastify = await buildServer(false);
     await requiredChecks();
-    octokit = await getClient('getsentry', 'getsentry');
+    octokit = await getClient('getsentry');
 
     octokit.repos.getCommit.mockImplementation(({ repo, ref }) => {
       const defaultPayload = require('@test/payloads/github/commit').default;

--- a/src/brain/typescript/getProgress.ts
+++ b/src/brain/typescript/getProgress.ts
@@ -17,7 +17,7 @@ export default async function getProgress({
   date?: string;
 }) {
   const owner = 'getsentry';
-  const octokit = await getClient('getsentry', repo);
+  const octokit = await getClient('getsentry');
 
   const getContentsParams: {
     owner: string;

--- a/src/brain/updateDeployNotifications/index.test.ts
+++ b/src/brain/updateDeployNotifications/index.test.ts
@@ -48,7 +48,7 @@ describe('updateDeployNotifications', function () {
     await updateDeployNotifications();
     await pleaseDeployNotifier();
 
-    octokit = await getClient('getsentry', 'getsentry');
+    octokit = await getClient('getsentry');
     // @ts-ignore
     octokit.repos.compareCommits.mockImplementation(() => ({
       status: 200,

--- a/src/brain/updateDeployNotifications/index.ts
+++ b/src/brain/updateDeployNotifications/index.ts
@@ -75,7 +75,7 @@ export async function handler(payload: FreightPayload) {
   Sentry.configureScope((scope) => scope.setSpan(tx));
 
   // Get the range of commits for this payload
-  const getsentry = await getClient('getsentry', 'getsentry');
+  const getsentry = await getClient('getsentry');
 
   const { data } = await getsentry.repos.compareCommits({
     owner: OWNER,


### PR DESCRIPTION
We can assume that our GH app is always installed org wide, so there is no need for a repo level installation.
Additionally, cache the installation ID in memory, we could even hard code it as this should never change, but we will just store it in memory for now.

There may be further optimizations to be had here by caching the Octokit client, but we can save that for later.