### PR TITLE
perf(tracing): Add Sentry tracing to metrics endpoints

### DIFF
--- a/src/brain/githubMetrics/index.test.ts
+++ b/src/brain/githubMetrics/index.test.ts
@@ -31,52 +31,10 @@ jest.spyOn(db, 'insert');
 jest.spyOn(db, 'insertOss');
 jest.mock('@api/github/getClient');
 
-const SCHEMA = [
-  {
-    name: 'type',
-    type: 'STRING',
-  },
-  {
-    name: 'action',
-    type: 'STRING',
-  },
-  {
-    name: 'username',
-    type: 'STRING',
-  },
-  {
-    name: 'user_id',
-    type: 'INT64',
-  },
-  {
-    name: 'repository',
-    type: 'STRING',
-  },
-  {
-    name: 'object_id',
-    type: 'INT64',
-  },
-  {
-    name: 'created_at',
-    type: 'TIMESTAMP',
-  },
-  {
-    name: 'updated_at',
-    type: 'TIMESTAMP',
-  },
-  {
-    name: 'target_id',
-    type: 'INT64',
-  },
-  {
-    name: 'target_name',
-    type: 'STRING',
-  },
-  {
-    name: 'target_type',
-    type: 'STRING',
-  },
-];
+const SCHEMA = Object.entries(db.TARGETS.oss.schema).map(([name, type]) => ({
+  name,
+  type,
+}));
 
 describe('github webhook', function () {
   let fastify: Fastify;

--- a/src/brain/githubMetrics/index.ts
+++ b/src/brain/githubMetrics/index.ts
@@ -1,16 +1,21 @@
 import { githubEvents } from '@api/github';
+import { wrapHandler } from '@utils/wrapHandler';
 
 import { ossMetrics } from './ossMetrics';
 import { sentryMetrics } from './sentryMetrics';
 
-export async function githubMetrics() {
-  githubEvents.removeListener('check_run', sentryMetrics);
-  githubEvents.on('check_run', sentryMetrics);
+// Handlers wrapped with Sentry transaction
+const ossHandler = wrapHandler('metrics.oss', ossMetrics);
+const sentryHandler = wrapHandler('metrics.sentry', sentryMetrics);
 
-  // @ts-ignore
-  githubEvents.removeListener('*', ossMetrics);
+export async function githubMetrics() {
+  githubEvents.removeListener('check_run', sentryHandler);
+  githubEvents.on('check_run', sentryHandler);
+
+  // @ts-ignore Missing in types
+  githubEvents.removeListener('*', ossHandler);
   // This is for open source data so we can consolidate github webhooks
   // It does some data mangling in there, so we may want to extract that out of the
   // "db" utils
-  githubEvents.onAny(ossMetrics);
+  githubEvents.onAny(ossHandler);
 }

--- a/src/brain/githubMetrics/ossMetrics.ts
+++ b/src/brain/githubMetrics/ossMetrics.ts
@@ -5,6 +5,9 @@ import { insertOss } from '@utils/metrics';
 /**
  * GitHub webhooks handler for OSS metrics
  */
-export function ossMetrics({ name: eventType, payload }: EmitterWebhookEvent) {
-  insertOss(eventType, payload);
+export async function ossMetrics({
+  name: eventType,
+  payload,
+}: EmitterWebhookEvent) {
+  return await insertOss(eventType, payload);
 }

--- a/src/brain/githubMetrics/sentryMetrics.ts
+++ b/src/brain/githubMetrics/sentryMetrics.ts
@@ -12,7 +12,7 @@ const CHECK_STATUS_MAP = {
 /**
  * GitHub webhook handler for sentry + getsentry repo metrics
  */
-export function sentryMetrics({
+export async function sentryMetrics({
   name: eventName,
   payload,
 }: EmitterWebhookEvent<'check_run'>) {
@@ -32,7 +32,7 @@ export function sentryMetrics({
         'https://api.github.com/repos/getsentry/getsentry/pulls'
       )
   );
-  insert({
+  return await insert({
     source: 'github',
     event: `build_${status}`,
     object_id: pullRequest?.number,

--- a/src/utils/wrapHandler.ts
+++ b/src/utils/wrapHandler.ts
@@ -11,8 +11,8 @@ export function wrapHandler(name: string, fn: Function) {
     });
 
     const result = await fn.call(null, ...args);
-    tx.finish();
 
+    tx.finish();
     return result;
   };
 }


### PR DESCRIPTION
Tested this locally here: https://sentry.io/organizations/sentry/discover/results/\?display\=daily\&environment\=development\&field\=title\&field\=timestamp\&field\=transaction.duration\&id\=8438\&name\=Simple+Daily+Aggregate\&project\=5246761\&query\=\&sort\=-timestamp\&statsPeriod\=1h\&widths\=-1\&widths\=-1\&widths\=-1 and seems to be working