### PR TITLE
feat(brain): Fetch last deploy at runtime for viewing undeployed commits

### DIFF
--- a/src/brain/pleaseDeployNotifier/index.test.ts
+++ b/src/brain/pleaseDeployNotifier/index.test.ts
@@ -12,6 +12,7 @@ import { Fastify } from '@/types';
 import { getClient } from '@api/github/getClient';
 import { bolt } from '@api/slack';
 import { db } from '@utils/db';
+import { getLastSuccessfulDeploy } from '@utils/db/getLastSuccessfulDeploy';
 
 import * as actions from './actionViewUndeployedCommits';
 import { pleaseDeployNotifier } from '.';
@@ -486,8 +487,7 @@ describe('pleaseDeployNotifier', function () {
                       text: 'View Undeployed Commits',
                       emoji: true,
                     },
-                    value:
-                      '1cd4f24731ceed16532c3206393f8628c6a755dd:455e3db9eb4fa6a1789b70e4045b194f02db0b59',
+                    value: '455e3db9eb4fa6a1789b70e4045b194f02db0b59',
                   },
                   {
                     type: 'button',
@@ -542,20 +542,23 @@ describe('pleaseDeployNotifier', function () {
             text: 'View Undeployed Commits',
             emoji: true,
           },
-          value:
-            '1cd4f24731ceed16532c3206393f8628c6a755dd:455e3db9eb4fa6a1789b70e4045b194f02db0b59',
+          value: '455e3db9eb4fa6a1789b70e4045b194f02db0b59',
           type: 'button',
           action_ts: '1614650317.491035',
         },
       ],
     });
     expect(actions.actionViewUndeployedCommits).toHaveBeenCalled();
+    expect(bolt.client.views.open).toHaveBeenCalled();
+    expect(await getLastSuccessfulDeploy()).toMatchObject({
+      sha: '999999',
+    });
 
     // Get list of commits
     expect(octokit.repos.compareCommits).toHaveBeenCalledWith({
       owner: 'getsentry',
       repo: 'getsentry',
-      base: '1cd4f24731ceed16532c3206393f8628c6a755dd',
+      base: '999999',
       head: '455e3db9eb4fa6a1789b70e4045b194f02db0b59',
     });
 

--- a/src/brain/pleaseDeployNotifier/index.ts
+++ b/src/brain/pleaseDeployNotifier/index.ts
@@ -13,7 +13,6 @@ import { getRelevantCommit } from '@api/github/getRelevantCommit';
 import { isGetsentryRequiredCheck } from '@api/github/isGetsentryRequiredCheck';
 import { bolt } from '@api/slack';
 import { slackMessageUser } from '@api/slackMessageUser';
-import { getLastSuccessfulDeploy } from '@utils/db/getLastSuccessfulDeploy';
 import { saveSlackMessage } from '@utils/db/saveSlackMessage';
 import { wrapHandler } from '@utils/wrapHandler';
 
@@ -84,13 +83,9 @@ async function handler({
   const commitLinkText = `${commit.slice(0, 7)}`;
   const text = `Your commit getsentry@<${commitLink}|${commitLinkText}> is ready to deploy`;
 
-  const lastDeploy = await getLastSuccessfulDeploy();
-
   const actions = [
     freightDeploy(commit),
-    // ...(lastDeploy
-    // ? [viewUndeployedCommits(`${lastDeploy.sha}:${commit}`)]
-    // : []),
+    // viewUndeployedCommits(commit),
     muteDeployNotificationsButton(),
   ];
 
@@ -123,12 +118,7 @@ async function handler({
           ...commitBlocks,
           {
             type: 'actions',
-            elements: [
-              ...actions,
-              ...(lastDeploy
-                ? [viewUndeployedCommits(`${lastDeploy.sha}:${commit}`)]
-                : []),
-            ],
+            elements: [...actions, viewUndeployedCommits(commit)],
           },
         ],
       },


### PR DESCRIPTION
Instead of binding the last deployed commit sha when we initially message the user, we should fetch the last deployed SHA at runtime (e.g. when the user requests to view the undeployed commits)