### PR TITLE
feat(api): Cache `getClient` and org membership [WIP]

### DIFF
--- a/src/utils/getOssUserType.ts
+++ b/src/utils/getOssUserType.ts
@@ -1,0 +1,68 @@
+import * as Sentry from '@sentry/node';
+
+import { getClient } from '@api/github/getClient';
+
+const _USER_CACHE = new Map();
+
+const KNOWN_BOTS = [
+  // https://www.notion.so/sentry/Bot-Accounts-beea0fc35473453ab50e05e6e4d1d02d
+  'getsentry-bot',
+  'getsentry-release',
+  'sentry-test-fixture-nonmember',
+];
+/**
+ * Given a GitHub username, get user type used for metrics
+ */
+export async function getOssUserType(payload: Record<string, any>) {
+  if (
+    KNOWN_BOTS.includes(payload.sender.login) ||
+    payload.sender.login.endsWith('[bot]')
+  ) {
+    return 'bot';
+  }
+
+  const { owner } = payload.repository;
+  if (owner.type !== 'Organization') {
+    return null;
+  }
+
+  // NB: Try to keep this check in sync with getsentry/.github/.../validate-new-issue.yml.
+  const org = owner.login;
+  const octokit = await getClient(org);
+  const username = payload.sender.login;
+
+  const cachedResult = _USER_CACHE.get(username);
+  if (typeof cachedResult !== 'undefined') {
+    return cachedResult;
+  }
+
+  let responseStatus;
+  const capture = (r) => (responseStatus = r.status);
+  await octokit.orgs
+    .checkMembershipForUser({
+      org,
+      username: payload.sender.login,
+    })
+    .then(capture)
+    .catch(capture);
+
+  // https://docs.github.com/en/rest/reference/orgs#check-organization-membership-for-a-user
+  switch (responseStatus as number) {
+    case 204: {
+      const userType = 'internal';
+      _USER_CACHE.set(username, userType);
+      return userType;
+    }
+    case 404: {
+      const userType = 'external';
+      _USER_CACHE.set(username, userType);
+      return userType;
+    }
+    default: {
+      Sentry.captureException(
+        new Error(`Org membership check failing with ${responseStatus}`)
+      );
+      return null;
+    }
+  }
+}

--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -1,17 +1,11 @@
 import { BigQuery } from '@google-cloud/bigquery';
 import * as Sentry from '@sentry/node';
 
-import { getClient } from '@api/github/getClient';
+import { getOssUserType } from './getOssUserType';
 
 const PROJECT =
   process.env.ENV === 'production' ? 'super-big-data' : 'sentry-dev-tooling';
 const bigqueryClient = new BigQuery({ projectId: PROJECT });
-const KNOWN_BOTS = [
-  // https://www.notion.so/sentry/Bot-Accounts-beea0fc35473453ab50e05e6e4d1d02d
-  'getsentry-bot',
-  'getsentry-release',
-  'sentry-test-fixture-nonmember',
-];
 
 function objectToSchema(obj: Record<string, any>) {
   return Object.entries(obj).map(([name, type]) => ({
@@ -188,50 +182,7 @@ export async function insertOss(
   eventType: string,
   payload: Record<string, any>
 ) {
-  let userType: string | null = null;
-  if (
-    KNOWN_BOTS.includes(payload.sender.login) ||
-    payload.sender.login.endsWith('[bot]')
-  ) {
-    userType = 'bot';
-  } else {
-    const { owner } = payload.repository;
-    if (owner.type === 'Organization') {
-      // NB: Try to keep this check in sync with getsentry/.github/.../validate-new-issue.yml.
-      const org = owner.login;
-      const octokit = await getClient(org);
-
-      let responseStatus;
-      const capture = (r) => (responseStatus = r.status);
-      await octokit.orgs
-        .checkMembershipForUser({
-          org,
-          username: payload.sender.login,
-        })
-        .then(capture)
-        .catch(capture);
-
-      // https://docs.github.com/en/rest/reference/orgs#check-organization-membership-for-a-user
-      switch (responseStatus as number) {
-        case 204: {
-          userType = 'internal';
-          break;
-        }
-        case 404: {
-          userType = 'external';
-          break;
-        }
-        default: {
-          userType = null;
-          Sentry.captureException(
-            new Error(`Org membership check failing with ${responseStatus}`)
-          );
-          break;
-        }
-      }
-    }
-  }
-
+  const userType = await getOssUserType(payload);
   const data: Record<string, any> = {
     type: eventType,
     action: payload.action,
@@ -314,6 +265,7 @@ export async function insertOss(
 
   if (process.env.DRY_RUN) {
     const targetConfig = TARGETS.oss;
+    // eslint-disable-next-line
     console.log(`
 ###### Dry Run: BigQuery Insert ######
   Dataset: ${targetConfig.dataset}


### PR DESCRIPTION
* Cache `getClient` so that we only have 1 client per org. Not sure if
this works/does anything yet, testing locally.
* Cache the `orgs.checkMembershipForUser` call for OSS metrics. This
  list is mostly going to be Sentry employees, and lots of calls are
  repeated quite frequently due to the number of check runs that happen
  simultaneously on `sentry`. I believe this is causing other requests to slow
  down. Here's an example https://sentry.io/organizations/sentry/discover/sentry-ci-tooling:df465e7a0a35472d8010f00079df5d6b/?display=daily&environment=production&field=title&field=timestamp&field=transaction.duration&id=8438&name=Simple+Daily+Aggregate&project=5246761&query=%21transaction%3Ametrics.%2A+%21transaction%3Ainsert.%2A&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1