### PR TITLE
fix(slack): Capture original stacktrace for slack exceptions

### DIFF
--- a/src/api/slack/index.ts
+++ b/src/api/slack/index.ts
@@ -20,9 +20,11 @@ export { bolt };
 // @ts-ignore
 bolt.error((error) => {
   // Check the details of the error to handle cases where you should retry sending a message or stop the app
-  Sentry.captureException(error);
+  // @ts-ignore
+  Sentry.captureException(error.original || error);
 
   if (process.env.NODE_ENV !== 'production') {
-    console.error(error);
+    // @ts-ignore
+    console.error(error.original || error);
   }
 });


### PR DESCRIPTION
Previously, we were capturing the stacktrace from the bolt SDK, but we want the original exception that was thrown from application code. See https://github.com/slackapi/bolt-js/issues/903\#issuecomment-833219133 for more infromation