### PR TITLE
Factor out WebhookRouter

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -24,6 +24,7 @@ module.exports = {
     '^@utils/(.*)$': '<rootDir>/src/utils/$1',
     '^@test/(.*)$': '<rootDir>/test/$1',
     '^@types$': '<rootDir>/src/types',
+    '^@webhooks$': '<rootDir>/src/webhooks',
     '^@webhooks/(.*)$': '<rootDir>/src/webhooks/$1',
   },
 

--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -1,0 +1,42 @@
+import path from 'path';
+
+import * as Sentry from '@sentry/node';
+
+/**
+ * Return a function that routes webhook POSTs to this or that module
+ * based on the service name.
+ */
+
+export function WebhookRouter(server) {
+  return async function (request, reply) {
+    const rootDir = __dirname;
+    let handler;
+
+    try {
+      const handlerPath = path.join(__dirname, request.params.service);
+
+      // Prevent directory traversals
+      if (!handlerPath.startsWith(rootDir)) {
+        throw new Error('Invalid service');
+      }
+
+      ({ handler } = require(handlerPath));
+      if (!handler) {
+        throw new Error('Invalid service');
+      }
+    } catch (err) {
+      console.error(err);
+      Sentry.captureException(err);
+      // @ts-ignore
+      return server.notFound(request, reply);
+    }
+
+    try {
+      return await handler(request, reply);
+    } catch (err) {
+      console.error(err);
+      Sentry.captureException(err);
+      return reply.code(400).send('Bad Request');
+    }
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
     "baseUrl": ".",
     "paths": {
       "@api/*": ["src/api/*"],
+      "@webhooks": ["src/webhooks"],
       "@webhooks/*": ["src/webhooks/*"],
       "@utils/*": ["src/utils/*"],
       "@test/*": ["test/*"],


### PR DESCRIPTION
The purpose of this small refactor is to make it easier to understand what is going on in `buildServer.ts`. I wanted to do this the other day (with #186), but my tired brain failed to see that Fastify spells "response" as "reply" for some reason. 🙄