### PR TITLE
Fix `yarn start`

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -18,12 +18,13 @@ module.exports = {
 
   // TODO: Use `ts-jest` and map from tsconfig
   // See https://kulshekhar.github.io/ts-jest/user/config/#jest-config-with-helper
+  // ⚠️  Keep this in sync with package.json and tsconfig.json. ⚠️
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
     '^@api/(.*)$': '<rootDir>/src/api/$1',
-    '^@utils/(.*)$': '<rootDir>/src/utils/$1',
     '^@test/(.*)$': '<rootDir>/test/$1',
     '^@types$': '<rootDir>/src/types',
+    '^@utils/(.*)$': '<rootDir>/src/utils/$1',
     '^@webhooks$': '<rootDir>/src/webhooks',
     '^@webhooks/(.*)$': '<rootDir>/src/webhooks/$1',
   },

--- a/package.json
+++ b/package.json
@@ -30,9 +30,10 @@
     "test:watch": "NODE_ENV=development yarn jest --watch --notify --notifyMode=change --coverage"
   },
   "_moduleAliases": {
+    "_comment": "⚠️  Keep this in sync with jest.config.ts and tsconfig.json. ⚠️ ",
     "@": "lib",
-    "@apps": "lib/apps",
     "@api": "lib/api",
+    "@apps": "lib/apps",
     "@utils": "lib/utils",
     "@webhooks": "lib/webhooks"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,13 +22,14 @@
     "resolveJsonModule": true,
     "baseUrl": ".",
     "paths": {
+      "_comment": ["⚠️  Keep this in sync with jest.config.ts and package.json. ⚠️ "],
+      "@/*": ["src/*"],
       "@api/*": ["src/api/*"],
-      "@webhooks": ["src/webhooks"],
-      "@webhooks/*": ["src/webhooks/*"],
-      "@utils/*": ["src/utils/*"],
       "@test/*": ["test/*"],
       "@types": ["src/types"],
-      "@/*": ["src/*"]
+      "@utils/*": ["src/utils/*"],
+      "@webhooks": ["src/webhooks"],
+      "@webhooks/*": ["src/webhooks/*"]
     }
   },
   "include": ["src/**/*", "test", "migrations/*.ts"],


### PR DESCRIPTION
Regressed in #187.

Red/green confirmed locally:

# Red

```
$ yarn start
/Users/chadwhitacre/workbench/getsentry/sentry-ci-tooling/.pnp.js:16408
    throw firstError;
    ^

Error: Your application tried to access @webhooks, but it isn't declared in your dependencies; this makes the require call ambiguous and unsound.

Required package: @webhooks (via "@webhooks")
Required by: /Users/chadwhitacre/workbench/getsentry/sentry-ci-tooling/lib/

Require stack:
- /Users/chadwhitacre/workbench/getsentry/sentry-ci-tooling/lib/buildServer.js
- /Users/chadwhitacre/workbench/getsentry/sentry-ci-tooling/lib/index.js
    at internalTools_makeError (/Users/chadwhitacre/workbench/getsentry/sentry-ci-tooling/.pnp.js:16152:34)
    at resolveToUnqualified (/Users/chadwhitacre/workbench/getsentry/sentry-ci-tooling/.pnp.js:17111:23)
    at resolveRequest (/Users/chadwhitacre/workbench/getsentry/sentry-ci-tooling/.pnp.js:17209:29)
    at Object.resolveRequest (/Users/chadwhitacre/workbench/getsentry/sentry-ci-tooling/.pnp.js:17287:26)
    at Function.external_module_.Module._resolveFilename (/Users/chadwhitacre/workbench/getsentry/sentry-ci-tooling/.pnp.js:16385:34)
    at Function.Module._resolveFilename (/Users/chadwhitacre/workbench/getsentry/sentry-ci-tooling/.yarn/cache/module-alias-npm-2.2.2-576bd37c03-1b37943df4.zip/node_modules/module-alias/index.js:49:29)
    at Function.external_module_.Module._load (/Users/chadwhitacre/workbench/getsentry/sentry-ci-tooling/.pnp.js:16250:48)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (/Users/chadwhitacre/workbench/getsentry/sentry-ci-tooling/lib/buildServer.js:29:21)
$ git branch -v 
  cwlw/fix-yarn-start b179631 Fix yarn:start
* main                8bedbbf Factor out WebhookRouter (#187)
$
```

# Green

```
$ yarn start
{"level":30,"time":1621275480687,"pid":52446,"hostname":"Chads-MacBook-Pro.local","msg":"Server listening at http://0.0.0.0:3000","v":1}
{"level":30,"time":1621275480688,"pid":52446,"hostname":"Chads-MacBook-Pro.local","msg":"server listening on http://0.0.0.0:3000","v":1}
This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason:
Error: An API error occurred: not_authed
    at Object.platformErrorFromResult (/Users/chadwhitacre/workbench/getsentry/sentry-ci-tooling/.yarn/cache/@slack-web-api-npm-6.0.0-b6d37141cb-7a17d2de07.zip/node_modules/@slack/web-api/dist/errors.js:51:33)
    at WebClient.apiCall (/Users/chadwhitacre/workbench/getsentry/sentry-ci-tooling/.yarn/cache/@slack-web-api-npm-6.0.0-b6d37141cb-7a17d2de07.zip/node_modules/@slack/web-api/dist/WebClient.js:156:28)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
^C%                                                                                                                               $ git branch -v
* cwlw/fix-yarn-start b179631 Fix yarn:start
  main                8bedbbf Factor out WebhookRouter (#187)
$
```