### PR TITLE
Centralize webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The events sent by the bot are defined under "Subscribe to bot events" in the "E
 
 ### Github Sentry Webhooks
 
-Under Sentry's [webhooks](https://github.com/getsentry/sentry/settings/hooks) there's webhooks to the production backend with the route "metrics/github/webhook".
+Under Sentry's [webhooks](https://github.com/organizations/getsentry/settings/hooks) there's webhooks to the production backend with the route "webhooks/github".
 
 ## Pre-requisites
 
@@ -71,7 +71,7 @@ You need to set up:
   - You should see your localhost app respond with 200 status code
   - Congratulations!
 - Configure the webhook for your Github Sentry fork
-  - Create a webhook to your ngrok tunnel with the GH route (e.g. `https://6a88fe29c5cc.ngrok.io/metrics/github/webhook`)
+  - Create a webhook to your ngrok tunnel with the GH route (e.g. `https://6a88fe29c5cc.ngrok.io/webhooks/github`)
     - Notify on every event
   - Make sure to choose `application/json` instead of `application/x-www-form-urlencoded`
   - Place the `GH_WEBHOOK_SECRET` in your `.env`

--- a/src/buildServer.ts
+++ b/src/buildServer.ts
@@ -56,7 +56,7 @@ export async function buildServer(
   // POSTs. Our event handlers for both are under loadBrain.
   // @ts-ignore
   server.use('/apps/slack/events', bolt.receiver.requestListener);
-  server.use('/metrics/github/webhook', githubEvents.middleware);
+  server.use('/webhooks/github', githubEvents.middleware);
   await loadBrain();
 
   // Other webhooks operate as regular Fastify handlers (albeit routed to

--- a/test/utils/createGitHubEvent.ts
+++ b/test/utils/createGitHubEvent.ts
@@ -35,7 +35,7 @@ export async function createGitHubEvent<E extends EmitterWebhookEvent['name']>(
 
   return await fastify.inject({
     method: 'POST',
-    url: '/metrics/github/webhook',
+    url: '/webhooks/github',
     headers: {
       'x-github-delivery': 1234,
       'x-github-event': event as string,


### PR DESCRIPTION
GitHub provides [three kinds of webhooks](https://docs.github.com/en/developers/webhooks-and-events/webhooks/about-webhooks):

1. repo
1. org
1. App

Right now we have a repo-level webhook on four repos, and in order to support our automation goals we want to install the webhook on more and more repos. In order to scale this we want to centralize webhook configuration via the `sentry-internal-tools` GitHub App. There is little enough event traffic that we can take a naive approach to cutting over by deploying this PR at a low-traffic time and manually resolve any duplicate events.

### Deployment Plan

- [x] Configure webhook [on sentry-internal-tools](https://github.com/organizations/getsentry/settings/apps/sentry-internal-tools) GitHub App
    1. **Active:** unchecked (for now)
    1. **Webhook URL:** https://product-eng-webhooks-vmrqv3f7nq-uw.a.run.app/webhooks/github
    1. **Webhook secret (optional):** [take from product-eng-webhooks config](https://console.cloud.google.com/run/detail/us-west1/product-eng-webhooks/yaml/view?project=super-big-data)
    1. **SSL verification:** Enable SSL verification
    1. **Which events would you like to trigger this webhook?** Let me select individual events.
        1. Check runs - _takes action, but only for the `getsentry` repo_
        2. Check suites - _not used afaict—don't remove here tho in order to avoid risk_
        3. Issues - _log metric_
        4. Issue comments - _log metric_
        5. Pull requests - _log metric_
        6. Pull request reviews - _log metric_
    1. **Active:** [checked]
- [x] Watch 404s pile up in new App-level webhook.
- [x] Deactivate App webhook.
- [x] During off hours (targeting Sunday, 2021-05-30):
    - [x] Activate App webhook.
    - [x] Confirm 200 on repo webhooks and 404 on App webhook.
        - [x] Ideally this requires triggering a test event since at a low-traffic time no events would be occurring naturally.
    - [x] Merge/deploy this PR.
    - [x] Confirm 404 on repo webhook and 200 on App webhook.
- [ ] Deactivate repo webhooks.
    - [ ] `getsentry`
    - [ ] `sentry`
    - [x] `sentry-docs`
    - [x] `onpremise`
 - [x] Check with p10y about `development_metrics` having additional repos logged.