### PR TITLE
fix: Don't fail for ossMetrics when no repo

### DIFF
--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -182,6 +182,10 @@ export async function insertOss(
   eventType: string,
   payload: Record<string, any>
 ) {
+  if (!payload.repository) {
+    // we are not interested in events w/o a repo
+    return;
+  }
   const userType = await getOssUserType(payload);
   const data: Record<string, any> = {
     type: eventType,


### PR DESCRIPTION
There are certain events such as `crated` which doesn't have the `repository` field in the payload. Since we assume this field to be always there in the `ossMetrics` handler, this was causing failures. This patch fixes that.
