### PR TITLE
fix: Fix TypeScript on VSCode

### DIFF
--- a/.vim/coc-settings.json
+++ b/.vim/coc-settings.json
@@ -1,5 +1,6 @@
 {
   "eslint.packageManager": "yarn",
   "eslint.nodePath": ".yarn/sdks",
-  "tsserver.tsdk": ".yarn/sdks/typescript/lib"
+  "tsserver.tsdk": ".yarn/sdks/typescript/lib",
+  "workspace.workspaceFolderCheckCwd": false
 }

--- a/.yarn/sdks/prettier/index.js
+++ b/.yarn/sdks/prettier/index.js
@@ -2,7 +2,7 @@
 
 const {existsSync} = require(`fs`);
 const {createRequire, createRequireFromPath} = require(`module`);
-const {resolve, dirname} = require(`path`);
+const {resolve} = require(`path`);
 
 const relPnpApiPath = "../../../.pnp.js";
 
@@ -13,16 +13,6 @@ if (existsSync(absPnpApiPath)) {
   if (!process.versions.pnp) {
     // Setup the environment to be able to require prettier/index.js
     require(absPnpApiPath).setup();
-  }
-
-  const pnpifyResolution = require.resolve(`@yarnpkg/pnpify`, {paths: [dirname(absPnpApiPath)]});
-  if (typeof global[`__yarnpkg_sdk_is_using_pnpify__`] === `undefined`) {
-    Object.defineProperty(global, `__yarnpkg_sdk_is_using_pnpify__`, {configurable: true, value: true});
-
-    process.env.NODE_OPTIONS += ` -r ${pnpifyResolution}`;
-
-    // Apply PnPify to the current process
-    absRequire(pnpifyResolution).patchFs();
   }
 }
 


### PR DESCRIPTION
Just ran `yarn dlx @yarnpkg/pnpify --sdk vscode` as suggested on the interwebs and commiting the result as it seems to be working.
