### PR TITLE
feat(slack): Slack @-mention commit author on failing builds

### DIFF
--- a/src/brain/pleaseDeployNotifier/actionViewUndeployedCommits.ts
+++ b/src/brain/pleaseDeployNotifier/actionViewUndeployedCommits.ts
@@ -78,11 +78,14 @@ export async function actionViewUndeployedCommits({
     data.commits.map(({ sha }) => getRelevantCommit(sha, octokit))
   );
 
-  // Generate the Slack blocks for each commit
-  const commitBlocks = relevantCommits.flatMap((commit) => [
-    ...getBlocksForCommit(commit),
-    { type: 'divider' },
-  ]);
+  const commitBlocks = (
+    await Promise.all(
+      relevantCommits.map(async (commit) => [
+        ...(await getBlocksForCommit(commit)),
+        { type: 'divider' },
+      ])
+    )
+  ).flatMap((i) => i);
 
   // Find the attachments where this action was triggered so that
   // we can find the deploy button that was used

--- a/src/brain/pleaseDeployNotifier/index.ts
+++ b/src/brain/pleaseDeployNotifier/index.ts
@@ -78,7 +78,7 @@ async function handler({
   const slackTarget = user?.slackUser;
 
   // Author of commit found
-  const commitBlocks = getBlocksForCommit(relevantCommit);
+  const commitBlocks = await getBlocksForCommit(relevantCommit);
   const commit = checkRun.head_sha;
   const commitLink = `https://github.com/${OWNER}/${GETSENTRY_REPO}/commits/${commit}`;
   const commitLinkText = `${commit.slice(0, 7)}`;

--- a/src/brain/requiredChecks/index.test.ts
+++ b/src/brain/requiredChecks/index.test.ts
@@ -122,6 +122,11 @@ describe('requiredChecks', function () {
   });
 
   it('notifies slack channel with failure due to a sentry commit (via getsentry bump commit)', async function () {
+    await db('users').insert({
+      email: 'matej.minar@sentry.io',
+      slackUser: 'U123123',
+      githubUser: 'matejminar',
+    });
     await createGitHubEvent(fastify, 'check_run', {
       repository: {
         full_name: 'getsentry/getsentry',
@@ -201,7 +206,7 @@ describe('requiredChecks', function () {
                   "type": "image",
                 },
                 Object {
-                  "text": "<https://github.com/matejminar|Matej Minar (matejminar)>",
+                  "text": "<@U123123>",
                   "type": "mrkdwn",
                 },
               ],

--- a/src/brain/requiredChecks/index.ts
+++ b/src/brain/requiredChecks/index.ts
@@ -282,7 +282,9 @@ async function handler({
   // Retrieve commit information
   const relevantCommit = await getRelevantCommit(checkRun.head_sha);
 
-  const commitBlocks = getBlocksForCommit(relevantCommit);
+  const commitBlocks = await getBlocksForCommit(relevantCommit, {
+    shouldSlackMention: true,
+  });
 
   // Otherwise, there is a failed check
   // Need to notify channel that the build has failed


### PR DESCRIPTION
This change will now @-mention the relevant commit author when their build fails on master.

Closes #106