### PR TITLE
fix(webhooks): Actually prevent directory traversing

### DIFF
--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -13,7 +13,7 @@ export function WebhookRouter(server) {
     let handler;
 
     try {
-      const handlerPath = path.join(__dirname, request.params.service);
+      const handlerPath = path.resolve(__dirname, request.params.service);
 
       // Prevent directory traversals
       if (!handlerPath.startsWith(rootDir)) {


### PR DESCRIPTION
We use `path.join()` to build the module path and then check that the resultant path starts with `__dirname` which is the first argument passed to `path.join()`. Since `path.join()` simply does concatenation, this dosen't prevent one from passing in relative paths like `../../../foo`. It also doesn't prevent people from passing in absolute paths but that gets mitigated both at the URL parsing step and the naive joining of the paths.

This PR replaces `path.join()` with `path.resolve()` to get the original intention: resolve and verify that we are not going beyond the current directory.
