### PR TITLE
fix: Connect GHA secrets to deploy workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,7 @@ jobs:
           DB_NAME: ${{ secrets.DB_NAME }}
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
           DB_INSTANCE_CONNECTION_NAME: ${{ secrets.DB_INSTANCE_CONNECTION_NAME }}
+          GIT_BOT_SECRET: ${{ secrets.GIT_BOT_SECRET }}
         run: |
           echo "::set-output name=deploy-start::$(date +%s)"
           bin/deploy.sh


### PR DESCRIPTION
Forgot to include this in https://github.com/getsentry/eng-pipes/pull/218 where we want to pass the GHA secret to our deploy script.