### PR TITLE
ci: Re-organize CI jobs + build when deploying

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          cache: 'yarn'
           node-version: '14'
 
       - name: yarn install
@@ -59,7 +58,6 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          cache: 'yarn'
           node-version: '14'
 
       - name: yarn install
@@ -95,7 +93,6 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          cache: 'yarn'
           node-version: '14'
 
       - name: yarn install
@@ -135,7 +132,6 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          cache: 'yarn'
           node-version: '14'
 
       - name: yarn install


### PR DESCRIPTION
`action-release` is erroring because we are not building and it expects sourcemaps. This might fix our dupe commits issue? Also upgrade action to latest version