### PR TITLE
meta: Fix link to Sentry deploy notifications

### DIFF
--- a/src/brain/updateDeployNotifications/index.test.ts
+++ b/src/brain/updateDeployNotifications/index.test.ts
@@ -275,7 +275,7 @@ describe('updateDeployNotifications', function () {
       .toMatchInlineSnapshot(`
       Object {
         "channel": "channel_id",
-        "text": "<@U789123>, your commit has been deployed. **Note** This message is now deprecated as this feature is now native to Sentry. <https://sentry.io/settings/account/notifications/|Configure your Sentry deploy notifications here>",
+        "text": "<@U789123>, your commit has been deployed. *Note* This message from Sentaur is now deprecated as this feature is now native to Sentry. Please <https://sentry.io/settings/account/notifications/deploy/|configure your Sentry deploy notifications here> to turn on Slack deployment notifications",
         "thread_ts": "1234123.123",
       }
     `);

--- a/src/brain/updateDeployNotifications/index.ts
+++ b/src/brain/updateDeployNotifications/index.ts
@@ -161,7 +161,7 @@ export async function handler(payload: FreightPayload) {
                 message.context.target
                   ? `<@${message.context.target}>, your`
                   : 'Your'
-              } commit has been deployed. **Note** This message is now deprecated as this feature is now native to Sentry. <https://sentry.io/settings/account/notifications/|Configure your Sentry deploy notifications here>`,
+              } commit has been deployed. *Note* This message from Sentaur is now deprecated as this feature is now native to Sentry. Please <https://sentry.io/settings/account/notifications/deploy/|configure your Sentry deploy notifications here> to turn on Slack deployment notifications`,
             }),
           ]
         : []),


### PR DESCRIPTION
This should link to the "fine tuning" section of the deploy notifications so that users can make sure deploy notifications get sent via Slack.