### PR TITLE
feat(brain): Change deploy notifier to link to `getsentry-frontend`

### DIFF
--- a/src/api/github/__mocks__/getClient.ts
+++ b/src/api/github/__mocks__/getClient.ts
@@ -6,6 +6,9 @@ function mockClient() {
       listWorkflowRunsForRepo: jest.fn(),
       cancelWorkflowRun: jest.fn(),
     },
+    checks: {
+      listForRef: jest.fn(),
+    },
     git: {
       getCommit: jest.fn(),
     },

--- a/src/api/github/getChangedStack.ts
+++ b/src/api/github/getChangedStack.ts
@@ -1,0 +1,54 @@
+import { Octokit } from '@octokit/rest';
+import * as Sentry from '@sentry/node';
+
+import { getClient } from '@/api/github/getClient';
+import { OWNER } from '@/config';
+
+const FRONTEND_CHANGE_CHECK_NAME = 'only frontend changes';
+const BACKEND_CHANGE_CHECK_NAME = 'only backend changes';
+
+/**
+ * Given a commit and repo, check GitHub Checks to see what type of changes
+ * were made in the commit (frontend, backend, fullstack)
+ */
+export async function getChangedStack(
+  ref: string,
+  repo: string,
+  client?: Octokit
+) {
+  try {
+    // We can save on making extra calls to get GH client
+    const octokit = client || (await getClient(OWNER));
+
+    const { data } = await octokit.checks.listForRef({
+      owner: OWNER,
+      repo,
+      ref,
+    });
+
+    const checkRuns = data.check_runs.filter(
+      ({ name, conclusion }) =>
+        conclusion === 'success' &&
+        [
+          FRONTEND_CHANGE_CHECK_NAME,
+          BACKEND_CHANGE_CHECK_NAME,
+          'fullstack changes',
+        ].includes(name)
+    );
+    const isFrontendOnly = !!checkRuns.find(
+      ({ name }) => name === FRONTEND_CHANGE_CHECK_NAME
+    );
+    const isBackendOnly = !!checkRuns.find(
+      ({ name }) => name === BACKEND_CHANGE_CHECK_NAME
+    );
+
+    return {
+      isFrontendOnly,
+      isBackendOnly,
+      isFullstack: !isFrontendOnly && !isBackendOnly,
+    };
+  } catch (err) {
+    Sentry.captureException(err);
+    return {};
+  }
+}

--- a/src/blocks/freightDeploy.ts
+++ b/src/blocks/freightDeploy.ts
@@ -1,4 +1,7 @@
-export function freightDeploy(commit: string) {
+export function freightDeploy(
+  commit: string,
+  app: 'getsentry' | 'getsentry-frontend' = 'getsentry'
+) {
   return {
     type: 'button',
     style: 'primary',
@@ -8,7 +11,7 @@ export function freightDeploy(commit: string) {
       emoji: true,
     },
     value: commit,
-    url: 'https://freight.getsentry.net/deploy?app=getsentry',
-    action_id: 'freight-deploy',
+    url: `https://freight.getsentry.net/deploy?app=${app}`,
+    action_id: `freight-deploy: ${app}`,
   };
 }

--- a/src/brain/pleaseDeployNotifier/index.test.ts
+++ b/src/brain/pleaseDeployNotifier/index.test.ts
@@ -29,6 +29,7 @@ describe('pleaseDeployNotifier', function () {
       if (repo === 'sentry') {
         return {
           data: merge({}, defaultPayload, {
+            sha: '88c22a29176df64cfc027637a5ccfd9da1544e9f',
             commit: {
               author: {
                 name: 'mars',
@@ -179,7 +180,7 @@ describe('pleaseDeployNotifier', function () {
             Object {
               "elements": Array [
                 Object {
-                  "action_id": "freight-deploy",
+                  "action_id": "freight-deploy: getsentry",
                   "style": "primary",
                   "text": Object {
                     "emoji": true,
@@ -333,7 +334,7 @@ describe('pleaseDeployNotifier', function () {
             Object {
               "elements": Array [
                 Object {
-                  "action_id": "freight-deploy",
+                  "action_id": "freight-deploy: getsentry",
                   "style": "primary",
                   "text": Object {
                     "emoji": true,
@@ -681,5 +682,375 @@ describe('pleaseDeployNotifier', function () {
         "view_id": "viewId",
       }
     `);
+  });
+
+  it('links user to frontend-only deploy from a sentry commit', async function () {
+    octokit.checks.listForRef.mockImplementation(({ ref, repo }) => {
+      if (
+        repo === 'sentry' &&
+        ref === '88c22a29176df64cfc027637a5ccfd9da1544e9f'
+      ) {
+        return {
+          data: {
+            check_runs: [
+              {
+                name: 'only frontend changes',
+                conclusion: 'success',
+              },
+            ],
+          },
+        };
+      }
+    });
+
+    await createGitHubEvent(fastify, 'check_run', {
+      repository: {
+        full_name: 'getsentry/getsentry',
+      },
+      check_run: {
+        status: 'completed',
+        conclusion: 'success',
+        name: REQUIRED_CHECK_NAME,
+        head_sha: '6d225cb77225ac655d817a7551a26fff85090fe6',
+        output: {
+          title: 'All checks passed',
+          summary: 'All checks passed',
+          text:
+            '\n' +
+            '# Required Checks\n' +
+            '\n' +
+            'These are the jobs that must pass before this commit can be deployed. Try re-running a failed job in case it is flakey.\n' +
+            '\n' +
+            '## Status of required checks\n' +
+            '\n' +
+            '| Job | Conclusion |\n' +
+            '| --- | ---------- |\n' +
+            '| [webpack](https://github.com/getsentry/getsentry/runs/1821955151) | ✅  success |\n',
+          annotations_count: 0,
+          annotations_url:
+            'https://api.github.com/repos/getsentry/getsentry/check-runs/1821995033/annotations',
+        },
+      },
+    });
+    expect(octokit.repos.getCommit).toHaveBeenCalledTimes(2);
+
+    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(1);
+
+    // First message
+    expect(bolt.client.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: 'U789123',
+        text:
+          'Your commit getsentry@<https://github.com/getsentry/getsentry/commits/6d225cb77225ac655d817a7551a26fff85090fe6|6d225cb> is ready to deploy',
+      })
+    );
+
+    // @ts-ignore
+    expect(bolt.client.chat.postMessage.mock.calls[0][0].attachments)
+      .toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "blocks": Array [
+            Object {
+              "text": Object {
+                "text": "<https://github.com/getsentry/getsentry/commit/6d225cb77225ac655d817a7551a26fff85090fe6|*feat(ui): Change default period for fresh releases (#23572)*>",
+                "type": "mrkdwn",
+              },
+              "type": "section",
+            },
+            Object {
+              "text": Object {
+                "text": "The fresh releases (not older than one day) will have default statsPeriod on the release detail page set to 24 hours.",
+                "type": "mrkdwn",
+              },
+              "type": "section",
+            },
+            Object {
+              "elements": Array [
+                Object {
+                  "alt_text": "mars",
+                  "image_url": "https://avatars.githubusercontent.com/u/9060071?v=4",
+                  "type": "image",
+                },
+                Object {
+                  "text": "<https://github.com/matejminar|mars (matejminar)>",
+                  "type": "mrkdwn",
+                },
+              ],
+              "type": "context",
+            },
+            Object {
+              "elements": Array [
+                Object {
+                  "action_id": "freight-deploy: getsentry-frontend",
+                  "style": "primary",
+                  "text": Object {
+                    "emoji": true,
+                    "text": "Deploy",
+                    "type": "plain_text",
+                  },
+                  "type": "button",
+                  "url": "https://freight.getsentry.net/deploy?app=getsentry-frontend",
+                  "value": "6d225cb77225ac655d817a7551a26fff85090fe6",
+                },
+                Object {
+                  "action_id": "view-undeployed-commits-",
+                  "text": Object {
+                    "emoji": true,
+                    "text": "View Undeployed Commits",
+                    "type": "plain_text",
+                  },
+                  "type": "button",
+                  "value": "6d225cb77225ac655d817a7551a26fff85090fe6",
+                },
+                Object {
+                  "action_id": "mute-slack-deploy",
+                  "confirm": Object {
+                    "confirm": Object {
+                      "text": "Mute",
+                      "type": "plain_text",
+                    },
+                    "deny": Object {
+                      "text": "Cancel",
+                      "type": "plain_text",
+                    },
+                    "text": Object {
+                      "text": "Are you sure you want to mute these deploy notifications? You can re-enable them by DM-ing me
+
+      \`\`\`
+      deploy notifications on
+      \`\`\`
+
+      Or you can visit the App's \\"Home\\" tab in Slack.
+      ",
+                      "type": "mrkdwn",
+                    },
+                    "title": Object {
+                      "text": "Mute deploy notifications?",
+                      "type": "plain_text",
+                    },
+                  },
+                  "style": "danger",
+                  "text": Object {
+                    "emoji": true,
+                    "text": "Mute",
+                    "type": "plain_text",
+                  },
+                  "type": "button",
+                  "value": "mute",
+                },
+              ],
+              "type": "actions",
+            },
+          ],
+          "color": "#E7E1EC",
+        },
+      ]
+    `);
+
+    expect(await db('slack_messages').first('*')).toMatchObject({
+      refId: '6d225cb77225ac655d817a7551a26fff85090fe6',
+      channel: 'channel_id',
+      ts: '1234123.123',
+      context: {
+        status: 'undeployed',
+      },
+    });
+  });
+
+  it('links user to frontend-only deploy from a getsentry commit', async function () {
+    octokit.repos.getCommit.mockImplementation(({ repo, ref }) => {
+      const defaultPayload = require('@test/payloads/github/commit').default;
+      return {
+        data: merge({}, defaultPayload, {
+          commit: {
+            author: {
+              name: 'mars',
+              email: 'mars@sentry.io',
+              date: '2021-02-03T11:06:46Z',
+            },
+            committer: {
+              name: 'GitHub',
+              email: 'noreply@github.com',
+              date: '2021-02-03T11:06:46Z',
+            },
+            message: `build(ci): Remove if: always() conditions from workflows (#29414)
+
+Remove "always()" from GHA workflows`,
+          },
+        }),
+      };
+    });
+
+    octokit.checks.listForRef.mockImplementation(({ ref, repo }) => {
+      if (repo === 'getsentry') {
+        return {
+          data: {
+            check_runs: [
+              {
+                name: 'only frontend changes',
+                conclusion: 'success',
+              },
+            ],
+          },
+        };
+      } else return null;
+    });
+
+    await createGitHubEvent(fastify, 'check_run', {
+      repository: {
+        full_name: 'getsentry/getsentry',
+      },
+      check_run: {
+        status: 'completed',
+        conclusion: 'success',
+        name: REQUIRED_CHECK_NAME,
+        head_sha: '6d225cb77225ac655d817a7551a26fff85090fe6',
+        output: {
+          title: 'All checks passed',
+          summary: 'All checks passed',
+          text:
+            '\n' +
+            '# Required Checks\n' +
+            '\n' +
+            'These are the jobs that must pass before this commit can be deployed. Try re-running a failed job in case it is flakey.\n' +
+            '\n' +
+            '## Status of required checks\n' +
+            '\n' +
+            '| Job | Conclusion |\n' +
+            '| --- | ---------- |\n' +
+            '| [webpack](https://github.com/getsentry/getsentry/runs/1821955151) | ✅  success |\n',
+          annotations_count: 0,
+          annotations_url:
+            'https://api.github.com/repos/getsentry/getsentry/check-runs/1821995033/annotations',
+        },
+      },
+    });
+
+    // Only once because this is a commit on getsentry
+    expect(octokit.repos.getCommit).toHaveBeenCalledTimes(1);
+
+    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(1);
+
+    // First message
+    expect(bolt.client.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: 'U789123',
+        text:
+          'Your commit getsentry@<https://github.com/getsentry/getsentry/commits/6d225cb77225ac655d817a7551a26fff85090fe6|6d225cb> is ready to deploy',
+      })
+    );
+
+    // @ts-ignore
+    expect(bolt.client.chat.postMessage.mock.calls[0][0].attachments)
+      .toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "blocks": Array [
+            Object {
+              "text": Object {
+                "text": "<https://github.com/getsentry/getsentry/commit/6d225cb77225ac655d817a7551a26fff85090fe6|*build(ci): Remove if: always() conditions from workflows (#29414)*>",
+                "type": "mrkdwn",
+              },
+              "type": "section",
+            },
+            Object {
+              "text": Object {
+                "text": "Remove \\"always()\\" from GHA workflows",
+                "type": "mrkdwn",
+              },
+              "type": "section",
+            },
+            Object {
+              "elements": Array [
+                Object {
+                  "alt_text": "mars",
+                  "image_url": "https://avatars.githubusercontent.com/u/9060071?v=4",
+                  "type": "image",
+                },
+                Object {
+                  "text": "<https://github.com/matejminar|mars (matejminar)>",
+                  "type": "mrkdwn",
+                },
+              ],
+              "type": "context",
+            },
+            Object {
+              "elements": Array [
+                Object {
+                  "action_id": "freight-deploy: getsentry-frontend",
+                  "style": "primary",
+                  "text": Object {
+                    "emoji": true,
+                    "text": "Deploy",
+                    "type": "plain_text",
+                  },
+                  "type": "button",
+                  "url": "https://freight.getsentry.net/deploy?app=getsentry-frontend",
+                  "value": "6d225cb77225ac655d817a7551a26fff85090fe6",
+                },
+                Object {
+                  "action_id": "view-undeployed-commits-",
+                  "text": Object {
+                    "emoji": true,
+                    "text": "View Undeployed Commits",
+                    "type": "plain_text",
+                  },
+                  "type": "button",
+                  "value": "6d225cb77225ac655d817a7551a26fff85090fe6",
+                },
+                Object {
+                  "action_id": "mute-slack-deploy",
+                  "confirm": Object {
+                    "confirm": Object {
+                      "text": "Mute",
+                      "type": "plain_text",
+                    },
+                    "deny": Object {
+                      "text": "Cancel",
+                      "type": "plain_text",
+                    },
+                    "text": Object {
+                      "text": "Are you sure you want to mute these deploy notifications? You can re-enable them by DM-ing me
+
+      \`\`\`
+      deploy notifications on
+      \`\`\`
+
+      Or you can visit the App's \\"Home\\" tab in Slack.
+      ",
+                      "type": "mrkdwn",
+                    },
+                    "title": Object {
+                      "text": "Mute deploy notifications?",
+                      "type": "plain_text",
+                    },
+                  },
+                  "style": "danger",
+                  "text": Object {
+                    "emoji": true,
+                    "text": "Mute",
+                    "type": "plain_text",
+                  },
+                  "type": "button",
+                  "value": "mute",
+                },
+              ],
+              "type": "actions",
+            },
+          ],
+          "color": "#E7E1EC",
+        },
+      ]
+    `);
+
+    expect(await db('slack_messages').first('*')).toMatchObject({
+      refId: '6d225cb77225ac655d817a7551a26fff85090fe6',
+      channel: 'channel_id',
+      ts: '1234123.123',
+      context: {
+        status: 'undeployed',
+      },
+    });
   });
 });

--- a/src/brain/updateDeployNotifications/index.test.ts
+++ b/src/brain/updateDeployNotifications/index.test.ts
@@ -318,7 +318,7 @@ describe('updateDeployNotifications', function () {
               Object {
                 "elements": Array [
                   Object {
-                    "action_id": "freight-deploy",
+                    "action_id": "freight-deploy: getsentry",
                     "style": "primary",
                     "text": Object {
                       "emoji": true,


### PR DESCRIPTION
Check the relevant commits GitHub Checks to see if the commit contains only frontend changes. If so, link to the Freight app "getsentry-frontend" instead of "getsentry" for a faster frontend-only deploy.