### PR TITLE
feat(server): Disable request logging

### DIFF
--- a/src/buildServer.ts
+++ b/src/buildServer.ts
@@ -22,6 +22,7 @@ export async function buildServer(
 ) {
   const server: Fastify = fastify({
     logger,
+    disableRequestLogging: true,
   });
 
   Sentry.init({


### PR DESCRIPTION
This disables request logging for fastify. The logs are very verbose and do not provide much value