### PR TITLE
fix(brain): Fix backend only deploys being marked as frontend

### DIFF
--- a/src/brain/pleaseDeployNotifier/index.ts
+++ b/src/brain/pleaseDeployNotifier/index.ts
@@ -176,7 +176,9 @@ async function handler({
 
   const isFrontendOnly = !latestDeploy
     ? isHeadCommitFrontendOnly
-    : await canFrontendDeploy(latestDeploy.sha, checkRun.head_sha);
+    : isHeadCommitFrontendOnly
+    ? await canFrontendDeploy(latestDeploy.sha, checkRun.head_sha)
+    : false;
 
   const actions = [
     freightDeploy(commit, isFrontendOnly ? 'getsentry-frontend' : 'getsentry'),


### PR DESCRIPTION
This condition got lost, but if there is a last deploy, but the head commit is not frontend only, we need to short circuit and not call `canFrontendDeploy`