### PR TITLE
feat(ci): Try to fix Sentry releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          # for Sentry releases
+          fetch-depth: 0
 
       - name: Setup node
         uses: actions/setup-node@v2


### PR DESCRIPTION
It is a bit fuzzy, but this might fix our Sentry releases always including the last 20 commits because it cannot find the previous release? https://github.com/getsentry/action-release/issues/41