### PR TITLE
feat: Remove @-mentions for deploy notifications

### DIFF
--- a/src/brain/updateDeployNotifications/index.test.ts
+++ b/src/brain/updateDeployNotifications/index.test.ts
@@ -278,7 +278,7 @@ describe('updateDeployNotifications', function () {
       .toMatchInlineSnapshot(`
       Object {
         "channel": "channel_id",
-        "text": "<@U789123>, your commit has been deployed. *Note* This message from Sentaur is now deprecated as this feature is now native to Sentry. Please <https://sentry.io/settings/account/notifications/deploy/|configure your Sentry deploy notifications here> to turn on Slack deployment notifications",
+        "text": "Your commit has been deployed. *Note* This message from Sentaur is now deprecated as this feature is now native to Sentry. Please <https://sentry.io/settings/account/notifications/deploy/|configure your Sentry deploy notifications here> to turn on Slack deployment notifications",
         "thread_ts": "1234123.123",
       }
     `);
@@ -740,7 +740,7 @@ describe('updateDeployNotifications', function () {
       .toMatchInlineSnapshot(`
       Object {
         "channel": "channel_id",
-        "text": "<@U789123>, your commit has been deployed. *Note* This message from Sentaur is now deprecated as this feature is now native to Sentry. Please <https://sentry.io/settings/account/notifications/deploy/|configure your Sentry deploy notifications here> to turn on Slack deployment notifications",
+        "text": "Your commit has been deployed. *Note* This message from Sentaur is now deprecated as this feature is now native to Sentry. Please <https://sentry.io/settings/account/notifications/deploy/|configure your Sentry deploy notifications here> to turn on Slack deployment notifications",
         "thread_ts": "1234123.123",
       }
     `);

--- a/src/brain/updateDeployNotifications/index.ts
+++ b/src/brain/updateDeployNotifications/index.ts
@@ -130,11 +130,7 @@ export async function handler(payload: FreightPayload) {
             bolt.client.chat.postMessage({
               thread_ts: message.ts,
               channel: message.channel,
-              text: `${
-                message.context.target
-                  ? `<@${message.context.target}>, your`
-                  : 'Your'
-              } commit has been deployed. *Note* This message from Sentaur is now deprecated as this feature is now native to Sentry. Please <https://sentry.io/settings/account/notifications/deploy/|configure your Sentry deploy notifications here> to turn on Slack deployment notifications`,
+              text: `Your commit has been deployed. *Note* This message from Sentaur is now deprecated as this feature is now native to Sentry. Please <https://sentry.io/settings/account/notifications/deploy/|configure your Sentry deploy notifications here> to turn on Slack deployment notifications`,
             }),
           ]
         : []),


### PR DESCRIPTION
Keeping the deprecation notice for now as the Sentry feature is not GA, but removed the @ mention
