### PR TITLE
fix: accidental `noEmit` for tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
-    "noEmit": true,
     "pretty": true,
     "strict": true,
     "outDir": "./lib",


### PR DESCRIPTION
This means we dont emit the transpiled code. Accidentally left in while testing