### PR TITLE
feat: add sha to development_metrics

### DIFF
--- a/src/brain/githubMetrics/index.test.ts
+++ b/src/brain/githubMetrics/index.test.ts
@@ -216,6 +216,7 @@ describe('github webhook', function () {
       source: 'github',
       start_timestamp: '2019-05-15T15:21:12Z',
       end_timestamp: null,
+      sha: 'ec26c3e57ca3a959ca5aad62de7213c562f8c821',
     });
     expect(mockDataset).toHaveBeenCalledWith('product_eng');
     expect(mockTable).toHaveBeenCalledWith('development_metrics');
@@ -229,6 +230,7 @@ describe('github webhook', function () {
         source: 'github',
         source_id: 128620228,
         start_timestamp: '2019-05-15T15:21:12Z',
+        sha: 'ec26c3e57ca3a959ca5aad62de7213c562f8c821',
       },
       {
         schema: [
@@ -262,6 +264,10 @@ describe('github webhook', function () {
           },
           {
             name: 'meta',
+            type: 'string',
+          },
+          {
+            name: 'sha',
             type: 'string',
           },
         ],

--- a/src/brain/githubMetrics/sentryMetrics.ts
+++ b/src/brain/githubMetrics/sentryMetrics.ts
@@ -40,6 +40,7 @@ export async function sentryMetrics({
     start_timestamp: payloadObj.started_at,
     // can be null if it has not completed yet
     end_timestamp: payloadObj.completed_at || null,
+    sha: payloadObj.head_sha,
     meta: {
       type: eventName,
       name: payloadObj.name || payloadObj.app?.name,

--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -109,6 +109,11 @@ export const TARGETS = {
        * Other data in JSON
        */
       meta: 'string',
+
+      /**
+       * the git revision for the event
+       */
+      sha: 'string',
     },
   },
 
@@ -175,7 +180,7 @@ async function _insert(data: Record<string, any>, targetConfig: TargetConfig) {
 
       // This error pops up when our automations close an old issue:
       // Value 1458881574000000 for field created_at of the destination table super-big-data:open_source.github_events is outside the allowed bounds. You can only stream to date range within 1825 days in the past and 366 days in the future relative to the current date.
-      // 
+      //
       // Special error from google sdk I think?
       // @ts-expect-error
       err.errors?.forEach((error) => {

--- a/src/webhooks/bootstrap-dev-env/bootstrap-dev-env.test.ts
+++ b/src/webhooks/bootstrap-dev-env/bootstrap-dev-env.test.ts
@@ -101,6 +101,10 @@ describe('bootstrap-dev-env webhook', function () {
             name: 'meta',
             type: 'string',
           },
+          {
+            name: 'sha',
+            type: 'string',
+          },
         ],
       }
     );


### PR DESCRIPTION
`sha` will allow us to group on this value to get a better idea of end-to-end time for a particular commit

will follow up with handling reruns through `workflow_run`