### PR TITLE
feat(brain): Record failed job steps

### DIFF
--- a/src/brain/requiredChecks/rerunFlakeyJobs.test.ts
+++ b/src/brain/requiredChecks/rerunFlakeyJobs.test.ts
@@ -162,6 +162,12 @@ describe('requiredChecks.rerunFlakeyJobs', function () {
         finish: jest.fn(),
       }))
     );
+    const setTagMock = jest.fn();
+    jest.spyOn(Sentry, 'withScope').mockImplementation((fn) => {
+      fn({
+        setTag: setTagMock,
+      });
+    });
 
     octokit.actions.getJobForWorkflowRun.mockImplementation(
       async ({ job_id }) => {
@@ -209,7 +215,9 @@ describe('requiredChecks.rerunFlakeyJobs', function () {
     expect(Sentry.startTransaction).toHaveBeenCalledWith({
       name: 'requiredChecks.failedStep',
     });
+    expect(setTagMock).toHaveBeenCalledWith('stepName', 'Set up job');
 
     Sentry.startTransaction.mockRestore();
+    Sentry.withScope.mockRestore();
   });
 });

--- a/src/brain/requiredChecks/rerunFlakeyJobs.ts
+++ b/src/brain/requiredChecks/rerunFlakeyJobs.ts
@@ -83,7 +83,8 @@ export async function rerunFlakeyJobs(failedJobIds: number[]) {
 
     if (failedSteps.length > 0) {
       Sentry.withScope(async (scope) => {
-        scope.setTag('stepName', failedSteps[0].name);
+        const stepName = failedSteps[0].name;
+        scope.setTag('stepName', stepName);
         Sentry.startTransaction({
           name: 'requiredChecks.failedStep',
         }).finish();


### PR DESCRIPTION
Record failed job steps to Sentry as transaction `requiredChecks.failedStep` and the step name as tag `stepName`
