### PR TITLE
feat(brain): Refactor and include `actions/cache` step as restartable

### DIFF
--- a/src/brain/requiredChecks/constants.ts
+++ b/src/brain/requiredChecks/constants.ts
@@ -5,13 +5,3 @@ export const OK_CONCLUSIONS = [
   BuildStatus.NEUTRAL,
   BuildStatus.SKIPPED,
 ] as string[];
-
-/**
- * Steps in a workflow job that, when failed, can assume is intermittent and
- * should be restarted
- */
-export const RESTARTABLE_JOB_STEPS = [
-  'Set up job',
-  'Setup Getsentry',
-  'Setup Sentry',
-];

--- a/src/brain/requiredChecks/isRestartableStep.ts
+++ b/src/brain/requiredChecks/isRestartableStep.ts
@@ -1,0 +1,26 @@
+import { Step } from '@/types';
+
+/**
+ * Steps in a workflow job that, when failed, can assume is intermittent and
+ * should be restarted
+ */
+export function isRestartableStep(step: Step) {
+  const RESTARTABLE_JOB_STEPS = [
+    'set up job',
+    'setup getsentry',
+    'setup sentry',
+  ];
+
+  const stepName = step.name.toLowerCase();
+
+  // This action seems to stall often, see https://github.com/actions/cache/issues/810
+  if (stepName.startsWith('runs actions/cache@')) {
+    return true;
+  }
+
+  if (RESTARTABLE_JOB_STEPS.includes(stepName)) {
+    return true;
+  }
+
+  return false;
+}

--- a/src/brain/requiredChecks/rerunFlakeyJobs.ts
+++ b/src/brain/requiredChecks/rerunFlakeyJobs.ts
@@ -3,7 +3,8 @@ import * as Sentry from '@sentry/node';
 import { getClient } from '@/api/github/getClient';
 import { GETSENTRY_REPO, OWNER } from '@/config';
 
-import { OK_CONCLUSIONS, RESTARTABLE_JOB_STEPS } from './constants';
+import { OK_CONCLUSIONS } from './constants';
+import { isRestartableStep } from './isRestartableStep';
 
 /**
  * Examine failed jobs and try to determine if it was an intermittent issue
@@ -51,9 +52,8 @@ export async function rerunFlakeyJobs(failedJobIds: number[]) {
           // in which case, we do not want to cancel and restart
           status === 'completed' && !OK_CONCLUSIONS.includes(conclusion ?? '')
       ) || [];
-    const restartableFailedStep = failedSteps.find(({ name }) =>
-      RESTARTABLE_JOB_STEPS.includes(name)
-    );
+
+    const restartableFailedStep = failedSteps.find(isRestartableStep);
 
     // Restart the workflow
     // https://docs.github.com/en/rest/reference/actions#re-run-a-workflow

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,6 +28,11 @@ export type Annotation = GetResponseDataTypeFromEndpointMethod<
   typeof octokit.checks.listAnnotations
 >[number];
 
+export type Job = GetResponseDataTypeFromEndpointMethod<
+  typeof octokit.actions.getJobForWorkflowRun
+>;
+export type Step = Exclude<Job['steps'], undefined>[number];
+
 export type CheckRun = EmitterWebhookEvent<'check_run'>['payload']['check_run'];
 
 // Note we intentionally only pick the pieces of checkRun that is needed to


### PR DESCRIPTION
We have been seeing intermittent issues where `actions/cache` action stalls and eventually times out the job. Others seem to see it as well (ref: https://github.community/t/cache-timeout-fails-to-restore/18027/4)
