### PR TITLE
ref: Change getsentry freight name to z-getsentry-deprecated

### DIFF
--- a/src/blocks/freightDeploy.ts
+++ b/src/blocks/freightDeploy.ts
@@ -1,6 +1,6 @@
 export function freightDeploy(
   commit: string,
-  app: 'getsentry' | 'getsentry-frontend' = 'getsentry'
+  app: 'z-getsentry-deprecated' | 'getsentry-frontend' = 'z-getsentry-deprecated'
 ) {
   return {
     type: 'button',

--- a/src/brain/pleaseDeployNotifier/index.ts
+++ b/src/brain/pleaseDeployNotifier/index.ts
@@ -177,7 +177,7 @@ async function handler({
     : false;
 
   const actions = [
-    freightDeploy(commit, isFrontendOnly ? 'getsentry-frontend' : 'getsentry'),
+    freightDeploy(commit, isFrontendOnly ? 'getsentry-frontend' : 'z-getsentry-deprecated'),
     viewUndeployedCommits(commit),
     muteDeployNotificationsButton(),
   ];


### PR DESCRIPTION
Changes this to direct to the deprecated `getsentry` deploy for now. Will follow up with a change to either point to `getsentry-frontend` or `getsentry-backend`.