### PR TITLE
fix(rtl-bot): Update folder path we clone to check the converted tests

### DIFF
--- a/src/brain/reactTestingLibrary/getProgress.ts
+++ b/src/brain/reactTestingLibrary/getProgress.ts
@@ -12,16 +12,16 @@ export async function getProgress() {
   const testContent = await octokit.repos.getContent({
     owner,
     repo,
-    path: 'tests/js',
+    path: 'static',
   });
 
   if (!Array.isArray(testContent.data)) {
     throw new Error('Invalid directory');
   }
 
-  const spec = testContent.data.find(({ name }) => name === 'spec');
+  const app = testContent.data.find(({ name }) => name === 'app');
 
-  if (!spec) {
+  if (!app) {
     throw new Error('Invalid directory');
   }
 
@@ -29,7 +29,7 @@ export async function getProgress() {
   const response = await octokit.rest.repos.downloadTarballArchive({
     owner,
     repo,
-    ref: spec.sha,
+    ref: app.sha,
   });
 
   // @ts-expect-error https://github.com/octokit/types.ts/issues/211


### PR DESCRIPTION
Since the tests were colocated through the [PRs](https://github.com/getsentry/sentry/pulls?q=is%3Apr+chore%3A+colocated+is%3Aclosed+) and the folder spec was removed, the React Testing Library status bot is currently broken and this PR fixes it by updating the folder path we want to clone to look for the converted / non converted RTL files.


Since this is tricky to test, I haven't tested it but I think that with the new changes it shall work