### PR TITLE
ref: mark .yarn files as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.yarn/** binary


### PR DESCRIPTION
this excludes them from `git grep`, etc.