### PR TITLE
ref: disable flaky build retrying

### DIFF
--- a/src/brain/requiredChecks/index.test.ts
+++ b/src/brain/requiredChecks/index.test.ts
@@ -1157,7 +1157,7 @@ describe('requiredChecks', function () {
     );
   });
 
-  it('does not notify slack channel when restarting due to intermittent CI issue', async function () {
+  it.skip('does not notify slack channel when restarting due to intermittent CI issue', async function () {
     // @ts-expect-error
     rerunFlakeyJobs.mockImplementation(async () => ({ hasReruns: true }));
 


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/DEVINFRA-93

https://sentry.io/organizations/sentry/issues/3584516283/

github changed their url format at some point (I think this has been broken for over a year?) making the parsing for run id incorrect.  I started fixing that and noticed that github now has 3 ids -- a run id, a job url id, and a job id.  the urls are structured like `/actions/runs/<run id>/jobs/<job url id>` -- the job url id is kinda useless as I can't seem to find its use in the api.  the job id appears to be hidden

rather than rewriting the flakey detector, I'm opting to turn it off to get the slack notifications working again and we'll revisit whether we think the reruns are valuable