### PR TITLE
ref(ci): fix set-output / set-state deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
           GIT_BOT_SECRET: ${{ secrets.GIT_BOT_SECRET }}
           GH_USER_TOKEN: ${{ secrets.GH_USER_TOKEN }}
         run: |
-          echo "::set-output name=deploy-start::$(date +%s)"
+          echo "deploy-start=$(date +%s)" >> "$GITHUB_OUTPUT"
           bin/deploy.sh
 
       - name: Sentry Release


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Committed via https://github.com/asottile/all-repos