### PR TITLE
Update messaging and and correct gocd payload

### DIFF
--- a/src/brain/saveGoCDStageEvents/index.test.ts
+++ b/src/brain/saveGoCDStageEvents/index.test.ts
@@ -51,8 +51,8 @@ describe('saveGoCDStageEvents.handler', function () {
           modifications: [
             {
               data: {},
-              'modified-time': 'Oct 20, 2022, 12:02:21 PM',
-              revision: 'ab16771cdb95d63196a6fe2f14875fbb745c0cee',
+              'modified-time': 'Oct 26, 2022, 5:05:17 PM',
+              revision: '2b0034becc4ab26b985f4c1a08ab068f153c274c',
             },
           ],
         },
@@ -69,20 +69,20 @@ describe('saveGoCDStageEvents.handler', function () {
           modifications: [
             {
               data: {},
-              'modified-time': 'Oct 20, 2022, 12:01:37 PM',
-              revision: 'ec3e4e543fda1a38aa57fbed72d68b0c09e62af8',
+              'modified-time': 'Oct 26, 2022, 5:56:18 PM',
+              revision: '77b189ad3b4b48a7eb1ec63cc486cdc991332352',
             },
           ],
         },
       ],
-      pipeline_counter: '115',
+      pipeline_counter: '20',
       pipeline_group: 'sentryio',
-      pipeline_id: 'sentryio_getsentry_frontend_115',
+      pipeline_id: 'sentryio_getsentry_frontend_20',
       pipeline_name: 'getsentry_frontend',
       stage_approval_type: 'success',
       stage_approved_by: 'matt.gaunt@sentry.io',
       stage_counter: '1',
-      stage_create_time: new Date('2022-10-20T14:05:13.000Z'),
+      stage_create_time: new Date('2022-10-26T17:57:53.000Z'),
       stage_jobs: [
         {
           name: 'preliminary-checks',
@@ -120,8 +120,8 @@ describe('saveGoCDStageEvents.handler', function () {
           modifications: [
             {
               data: {},
-              'modified-time': 'Oct 20, 2022, 12:02:21 PM',
-              revision: 'ab16771cdb95d63196a6fe2f14875fbb745c0cee',
+              'modified-time': 'Oct 26, 2022, 5:05:17 PM',
+              revision: '2b0034becc4ab26b985f4c1a08ab068f153c274c',
             },
           ],
         },
@@ -138,29 +138,29 @@ describe('saveGoCDStageEvents.handler', function () {
           modifications: [
             {
               data: {},
-              'modified-time': 'Oct 20, 2022, 12:01:37 PM',
-              revision: 'ec3e4e543fda1a38aa57fbed72d68b0c09e62af8',
+              'modified-time': 'Oct 26, 2022, 5:56:18 PM',
+              revision: '77b189ad3b4b48a7eb1ec63cc486cdc991332352',
             },
           ],
         },
       ],
-      pipeline_counter: '115',
+      pipeline_counter: '20',
       pipeline_group: 'sentryio',
-      pipeline_id: 'sentryio_getsentry_frontend_115',
+      pipeline_id: 'sentryio_getsentry_frontend_20',
       pipeline_name: 'getsentry_frontend',
-      stage_approval_type: 'success',
+      stage_approval_type: 'manual',
       stage_approved_by: 'matt.gaunt@sentry.io',
       stage_counter: '1',
-      stage_create_time: new Date('2022-10-20T14:05:13.000Z'),
+      stage_create_time: new Date('2022-10-26T17:58:42.000Z'),
       stage_jobs: [
         {
-          name: 'preliminary-checks',
+          name: 'deploy_static',
           result: 'Failed',
           state: 'Completed',
         },
       ],
-      stage_last_transition_time: new Date('2022-10-20T14:05:36.000Z'),
-      stage_name: 'preliminary-checks',
+      stage_last_transition_time: new Date('2022-10-26T17:58:47.000Z'),
+      stage_name: 'deploy_frontend',
       stage_result: 'Failed',
       stage_state: 'Failed',
     });

--- a/src/brain/saveGoCDStageEvents/index.ts
+++ b/src/brain/saveGoCDStageEvents/index.ts
@@ -6,7 +6,7 @@ import { db } from '@utils/db';
 export async function handler(resBody: GoCDResponse) {
   const DB_TABLE = 'gocd-stages';
 
-  const pipeline = resBody.data;
+  const { pipeline } = resBody.data;
   const { stage } = pipeline;
 
   const pipeline_id = `${pipeline.group}_${pipeline.name}_${pipeline.counter}`;

--- a/src/brain/updateDeployNotifications/index.test.ts
+++ b/src/brain/updateDeployNotifications/index.test.ts
@@ -792,7 +792,7 @@ describe('updateDeployNotifications', function () {
           },
         ],
         "channel": "U789123",
-        "text": "Your commit getsentry@<https://github.com/getsentry/getsentry/commits/982345|982345> is ready to deploy",
+        "text": "Your commit getsentry@<https://github.com/getsentry/getsentry/commits/982345|982345> is being deployed",
       }
     `);
 

--- a/src/utils/db/getDeployForQueuedCommit.ts
+++ b/src/utils/db/getDeployForQueuedCommit.ts
@@ -3,7 +3,7 @@ import { db } from '.';
 /**
  * Get the deploy for a queued commit.
  */
-export async function getDeployForQueuedCommit(sha: string) {
+export async function getFreightDeployForQueuedCommit(sha: string) {
   return await db
     .select('*')
     .from('queued_commits')

--- a/test/payloads/gocd/gocd-stage-building.json
+++ b/test/payloads/gocd/gocd-stage-building.json
@@ -1,62 +1,64 @@
 {
   "data": {
-    "name": "getsentry_frontend",
-    "counter": "115",
-    "group": "sentryio",
-    "build-cause": [
-      {
-        "material": {
-          "git-configuration": {
-            "shallow-clone": false,
-            "branch": "master",
-            "url": "git@github.com:getsentry/getsentry.git"
+    "pipeline": {
+      "name": "getsentry_frontend",
+      "counter": "20",
+      "group": "sentryio",
+      "build-cause": [
+        {
+          "material": {
+            "git-configuration": {
+              "shallow-clone": false,
+              "branch": "master",
+              "url": "git@github.com:getsentry/getsentry.git"
+            },
+            "type": "git"
           },
-          "type": "git"
+          "changed": false,
+          "modifications": [
+            {
+              "revision": "2b0034becc4ab26b985f4c1a08ab068f153c274c",
+              "modified-time": "Oct 26, 2022, 5:05:17 PM",
+              "data": {}
+            }
+          ]
         },
-        "changed": false,
-        "modifications": [
-          {
-            "revision": "ab16771cdb95d63196a6fe2f14875fbb745c0cee",
-            "modified-time": "Oct 20, 2022, 12:02:21 PM",
-            "data": {}
-          }
-        ]
-      },
-      {
-        "material": {
-          "git-configuration": {
-            "shallow-clone": false,
-            "branch": "master",
-            "url": "git@github.com:getsentry/sentry.git"
+        {
+          "material": {
+            "git-configuration": {
+              "shallow-clone": false,
+              "branch": "master",
+              "url": "git@github.com:getsentry/sentry.git"
+            },
+            "type": "git"
           },
-          "type": "git"
-        },
-        "changed": false,
-        "modifications": [
+          "changed": false,
+          "modifications": [
+            {
+              "revision": "77b189ad3b4b48a7eb1ec63cc486cdc991332352",
+              "modified-time": "Oct 26, 2022, 5:56:18 PM",
+              "data": {}
+            }
+          ]
+        }
+      ],
+      "stage": {
+        "name": "preliminary-checks",
+        "counter": "1",
+        "approval-type": "success",
+        "approved-by": "matt.gaunt@sentry.io",
+        "state": "Building",
+        "result": "Unknown",
+        "create-time": "Oct 26, 2022, 5:57:53 PM",
+        "jobs": [
           {
-            "revision": "ec3e4e543fda1a38aa57fbed72d68b0c09e62af8",
-            "modified-time": "Oct 20, 2022, 12:01:37 PM",
-            "data": {}
+            "name": "preliminary-checks",
+            "schedule-time": "Oct 26, 2022, 5:57:53 PM",
+            "state": "Scheduled",
+            "result": "Unknown"
           }
         ]
       }
-    ],
-    "stage": {
-      "name": "preliminary-checks",
-      "counter": "1",
-      "approval-type": "success",
-      "approved-by": "matt.gaunt@sentry.io",
-      "state": "Building",
-      "result": "Unknown",
-      "create-time": "Oct 20, 2022, 2:05:13 PM",
-      "jobs": [
-        {
-          "name": "preliminary-checks",
-          "schedule-time": "Oct 20, 2022, 2:05:13 PM",
-          "state": "Scheduled",
-          "result": "Unknown"
-        }
-      ]
     }
   },
   "type": "stage"

--- a/test/payloads/gocd/gocd-stage-failed.json
+++ b/test/payloads/gocd/gocd-stage-failed.json
@@ -1,65 +1,66 @@
 {
   "data": {
-    "name": "getsentry_frontend",
-    "counter": "115",
-    "group": "sentryio",
-    "build-cause": [
-      {
-        "material": {
-          "git-configuration": {
-            "shallow-clone": false,
-            "branch": "master",
-            "url": "git@github.com:getsentry/getsentry.git"
+    "pipeline": {
+      "name": "getsentry_frontend",
+      "counter": "20",
+      "group": "sentryio",
+      "build-cause": [
+        {
+          "material": {
+            "git-configuration": {
+              "shallow-clone": false,
+              "branch": "master",
+              "url": "git@github.com:getsentry/getsentry.git"
+            },
+            "type": "git"
           },
-          "type": "git"
+          "changed": false,
+          "modifications": [
+            {
+              "revision": "2b0034becc4ab26b985f4c1a08ab068f153c274c",
+              "modified-time": "Oct 26, 2022, 5:05:17 PM",
+              "data": {}
+            }
+          ]
         },
-        "changed": false,
-        "modifications": [
-          {
-            "revision": "ab16771cdb95d63196a6fe2f14875fbb745c0cee",
-            "modified-time": "Oct 20, 2022, 12:02:21 PM",
-            "data": {}
-          }
-        ]
-      },
-      {
-        "material": {
-          "git-configuration": {
-            "shallow-clone": false,
-            "branch": "master",
-            "url": "git@github.com:getsentry/sentry.git"
+        {
+          "material": {
+            "git-configuration": {
+              "shallow-clone": false,
+              "branch": "master",
+              "url": "git@github.com:getsentry/sentry.git"
+            },
+            "type": "git"
           },
-          "type": "git"
-        },
-        "changed": false,
-        "modifications": [
+          "changed": false,
+          "modifications": [
+            {
+              "revision": "77b189ad3b4b48a7eb1ec63cc486cdc991332352",
+              "modified-time": "Oct 26, 2022, 5:56:18 PM",
+              "data": {}
+            }
+          ]
+        }
+      ],
+      "stage": {
+        "name": "deploy_frontend",
+        "counter": "1",
+        "approval-type": "manual",
+        "approved-by": "matt.gaunt@sentry.io",
+        "state": "Failed",
+        "result": "Failed",
+        "create-time": "Oct 26, 2022, 5:58:42 PM",
+        "last-transition-time": "Oct 26, 2022, 5:58:47 PM",
+        "jobs": [
           {
-            "revision": "ec3e4e543fda1a38aa57fbed72d68b0c09e62af8",
-            "modified-time": "Oct 20, 2022, 12:01:37 PM",
-            "data": {}
+            "name": "deploy_static",
+            "schedule-time": "Oct 26, 2022, 5:58:42 PM",
+            "complete-time": "Oct 26, 2022, 5:58:47 PM",
+            "state": "Completed",
+            "result": "Failed"
           }
         ]
       }
-    ],
-    "stage": {
-      "name": "preliminary-checks",
-      "counter": "1",
-      "approval-type": "success",
-      "approved-by": "matt.gaunt@sentry.io",
-      "state": "Failed",
-      "result": "Failed",
-      "create-time": "Oct 20, 2022, 2:05:13 PM",
-      "last-transition-time": "Oct 20, 2022, 2:05:36 PM",
-      "jobs": [
-        {
-          "name": "preliminary-checks",
-          "schedule-time": "Oct 20, 2022, 2:05:13 PM",
-          "complete-time": "Oct 20, 2022, 2:05:36 PM",
-          "state": "Completed",
-          "result": "Failed",
-          "agent-uuid": "c070e21a-2b9a-4fa9-92f1-6fde2328adad"
-        }
-      ]
     }
   },
   "type": "stage"


### PR DESCRIPTION
After testing the GoCD on gocd-mattgaunt.getsentry.net I ran into a difference between payloads from GoCD and the stored values. I suspect I picked up payloads from the "other" plugin (i.e. not our plugin).

This also renames a few variables/functions ahead of next set of changes and changes the slack message when we know a commit is queued for deployment.