### PR TITLE
Downgrade setup gcloud to 0.6.2 since v1.0.0 removes deprecated workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
 
       # Setup gcloud CLI
       - name: Setup gcloud CLI
-        uses: google-github-actions/setup-gcloud@v1.0.0
+        uses: google-github-actions/setup-gcloud@v0.6.2
         with:
           service_account_email: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_EMAIL }}
           service_account_key: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}


### PR DESCRIPTION
title is explanatory here