### PR TITLE
Bug fixes for notify-for-triage office logic

### DIFF
--- a/src/brain/issueNotifier/index.test.ts
+++ b/src/brain/issueNotifier/index.test.ts
@@ -156,7 +156,6 @@ describe('issueNotifier Tests', function () {
       const channel_id = channelId(3);
       const command = {
         channel_id,
-        channel_name: 'test',
         text: '',
       };
       await slackHandler({ command, ack, say, respond, client });
@@ -170,7 +169,6 @@ describe('issueNotifier Tests', function () {
       const channel_id = channelId(1);
       const command = {
         channel_id,
-        channel_name: 'test',
         text: '',
       };
       await slackHandler({ command, ack, say, respond, client });
@@ -191,7 +189,6 @@ describe('issueNotifier Tests', function () {
       const channel_id = channelId(1);
       const command = {
         channel_id,
-        channel_name: 'test',
         text: 'Test sfo',
       };
       await slackHandler({ command, ack, say, respond, client });
@@ -212,7 +209,6 @@ describe('issueNotifier Tests', function () {
       const channel_id = channelId(1);
       const command = {
         channel_id,
-        channel_name: 'test',
         text: '',
       };
       await slackHandler({ command, ack, say, respond, client });
@@ -233,7 +229,6 @@ describe('issueNotifier Tests', function () {
       const channel_id = channelId(1);
       const command = {
         channel_id,
-        channel_name: 'test',
         text: 'Test sea',
       };
       await slackHandler({ command, ack, say, respond, client });
@@ -254,7 +249,6 @@ describe('issueNotifier Tests', function () {
       const channel_id = channelId(1);
       const command = {
         channel_id,
-        channel_name: 'test',
         text: 'Test blah',
       };
       await slackHandler({ command, ack, say, respond, client });
@@ -275,7 +269,6 @@ describe('issueNotifier Tests', function () {
       const channel_id = channelId(1);
       const command = {
         channel_id,
-        channel_name: 'test',
         text: 'Test vie',
       };
       await slackHandler({ command, ack, say, respond, client });
@@ -296,7 +289,6 @@ describe('issueNotifier Tests', function () {
       const channel_id = channelId(1);
       const command = {
         channel_id,
-        channel_name: 'test',
         text: 'Test yyz',
       };
       await slackHandler({ command, ack, say, respond, client });
@@ -317,7 +309,6 @@ describe('issueNotifier Tests', function () {
       const channel_id = channelId(1);
       const command = {
         channel_id,
-        channel_name: 'test',
         text: '-Test sea',
       };
       await slackHandler({ command, ack, say, respond, client });
@@ -338,7 +329,6 @@ describe('issueNotifier Tests', function () {
       const channel_id = channelId(1);
       const command = {
         channel_id,
-        channel_name: 'test',
         text: '-Test sea',
       };
       await slackHandler({ command, ack, say, respond, client });
@@ -359,7 +349,6 @@ describe('issueNotifier Tests', function () {
       const channel_id = channelId(1);
       const command = {
         channel_id,
-        channel_name: 'test',
         text: '-Test yyz',
       };
       await slackHandler({ command, ack, say, respond, client });
@@ -380,7 +369,6 @@ describe('issueNotifier Tests', function () {
       const channel_id = channelId(1);
       const command = {
         channel_id,
-        channel_name: 'test',
         text: '-Test sfo',
       };
       await slackHandler({ command, ack, say, respond, client });
@@ -401,7 +389,6 @@ describe('issueNotifier Tests', function () {
       const channel_id = channelId(1);
       const command = {
         channel_id,
-        channel_name: 'test',
         text: '-Test vie',
       };
       await slackHandler({ command, ack, say, respond, client });

--- a/src/brain/issueNotifier/index.ts
+++ b/src/brain/issueNotifier/index.ts
@@ -66,7 +66,7 @@ export const slackHandler = async ({ command, ack, say, respond, client }) => {
   const pending: Promise<unknown>[] = [];
   // Acknowledge command request
   pending.push(ack());
-  const { channel_id, channel_name, text } = command;
+  const { channel_id, text } = command;
   const args = text.match(
     /^\s*(?<op>[+-]?)(?<label>.+)\s(?<office>yyz|vie|sea|sfo?)/
   )?.groups;
@@ -100,27 +100,28 @@ export const slackHandler = async ({ command, ack, say, respond, client }) => {
     let channelInfo;
     let result;
 
+    try {
+      channelInfo = await client.conversations.info({
+        channel: channel_id,
+      });
+    } catch (err) {
+      // @ts-expect-error
+      if (err instanceof Error && err.data.error === 'channel_not_found') {
+        pending.push(
+          respond({
+            response_type: 'ephemeral',
+            text: `You need to invite me to the channel as it is private.`,
+          })
+        );
+        await Promise.all(pending);
+        return;
+      } else {
+        throw err;
+      }
+    }
+
     switch (op) {
       case '+':
-        try {
-          channelInfo = await client.conversations.info({
-            channel: channel_id,
-          });
-        } catch (err) {
-          // @ts-expect-error
-          if (err instanceof Error && err.data.error === 'channel_not_found') {
-            pending.push(
-              respond({
-                response_type: 'ephemeral',
-                text: `You need to invite me to the channel as it is private.`,
-              })
-            );
-            break;
-          } else {
-            throw err;
-          }
-        }
-
         if (!channelInfo.channel.is_member) {
           await client.conversations.join({ channel: channel_id });
         }
@@ -161,7 +162,7 @@ export const slackHandler = async ({ command, ack, say, respond, client }) => {
           pending.push(
             respond({
               response_type: 'ephemeral',
-              text: `This channel (${channel_name}) is already subscribed to '${label_name} during ${newOffice} business hours'.`,
+              text: `This channel (${channelInfo.channel.name}) is already subscribed to '${label_name} during ${newOffice} business hours'.`,
             })
           );
         }
@@ -188,13 +189,13 @@ export const slackHandler = async ({ command, ack, say, respond, client }) => {
           }
           pending.push(
             say(
-              `This channel (${channel_name}) will no longer get notifications for ${label_name} during ${newOffice} business hours.`
+              `This channel (${channelInfo.channel.name}) will no longer get notifications for ${label_name} during ${newOffice} business hours.`
             )
           );
         } else {
           pending.push(
             say(
-              `This channel (${channel_name}) is not subscribed to ${label_name} during ${newOffice} business hours.`
+              `This channel (${channelInfo.channel.name}) is not subscribed to ${label_name} during ${newOffice} business hours.`
             )
           );
         }


### PR DESCRIPTION
This PR includes 2 fixes:
1. default to "no office specified" when offices is null. Sentry issue found [here](https://sentry.io/organizations/sentry/issues/3776454232/?query=is%3Aunresolved&referrer=issue-stream)
2. Private channel names weren't being displayed for some commands, that is now fixed