### PR TITLE
Add unofficial holidays between Christmas and New Years

### DIFF
--- a/holidays.yml
+++ b/holidays.yml
@@ -27,6 +27,7 @@ sfo:
     "2023-12-27", # Unofficial days between Christmas and New Years
     "2023-12-28",
     "2023-12-29",
+    "2024-01-01", # New Year's Day
   ]
 sea:
   dates: [
@@ -54,6 +55,7 @@ sea:
     "2023-12-27", # Unofficial days between Christmas and New Years
     "2023-12-28",
     "2023-12-29",
+    "2024-01-01", # New Year's Day
   ]
 vie:
   dates: [
@@ -79,6 +81,7 @@ vie:
     "2023-12-27", # Unofficial days between Christmas and New Years
     "2023-12-28",
     "2023-12-29",
+    "2024-01-01", # New Year's Day
   ]
 yyz:
   dates: [
@@ -104,6 +107,7 @@ yyz:
     "2023-12-27", # Unofficial days between Christmas and New Years
     "2023-12-28",
     "2023-12-29",
+    "2024-01-01", # New Year's Day
   ]
 ams:
   dates: [
@@ -119,4 +123,5 @@ ams:
     "2023-12-27", # Unofficial days between Christmas and New Years
     "2023-12-28",
     "2023-12-29",
+    "2024-01-01", # New Year's Day
   ]

--- a/src/utils/businessHours.test.ts
+++ b/src/utils/businessHours.test.ts
@@ -158,7 +158,7 @@ describe('businessHours tests', function () {
         'Team: Test',
         '2022-12-31T00:00:00.000Z'
       );
-      expect(result).toEqual('2023-01-04T00:00:00.000Z');
+      expect(result).toEqual('2023-01-04T01:00:00.000Z');
     });
 
     describe('holiday tests', function () {
@@ -169,7 +169,7 @@ describe('businessHours tests', function () {
           '2023-12-24T00:00:00.000Z'
         );
         // 2023-12-24 is Sunday, 2023-12-25/2022-12-26 are holidays
-        expect(result).toEqual('2023-12-29T01:00:00.000Z');
+        expect(result).toEqual('2024-01-04T01:00:00.000Z');
       });
 
       it('should calculate TTR SLO violation for Christmas', async function () {
@@ -179,7 +179,7 @@ describe('businessHours tests', function () {
           '2023-12-24T00:00:00.000Z'
         );
         // 2023-12-24 is Sunday, 2023-12-25/2022-12-26 are holidays
-        expect(result).toEqual('2023-12-28T01:00:00.000Z');
+        expect(result).toEqual('2024-01-03T01:00:00.000Z');
       });
 
       it('should not include holiday in TTR if at least one office is still open', async function () {
@@ -389,10 +389,10 @@ describe('businessHours tests', function () {
         moment('2023-12-23T12:00:00.000Z').utc()
       );
       expect(start.valueOf()).toEqual(
-        moment('2023-12-27T08:00:00.000Z').valueOf()
+        moment('2024-01-02T08:00:00.000Z').valueOf()
       );
       expect(end.valueOf()).toEqual(
-        moment('2023-12-27T16:00:00.000Z').valueOf()
+        moment('2024-01-02T16:00:00.000Z').valueOf()
       );
     });
 


### PR DESCRIPTION
adds unofficial holidays for 2022 and 2023 