### PR TITLE
Capture an error message when trying to find timezone to display during routing

### DIFF
--- a/src/brain/issueLabelHandler/route.ts
+++ b/src/brain/issueLabelHandler/route.ts
@@ -151,7 +151,7 @@ async function getReadableTimeStamp(timeToTriageBy, teamLabelName) {
       lastOfficeInBusinessHours = office;
     }
   });
-  if (!lastOfficeInBusinessHours) {
+  if (lastOfficeInBusinessHours == null) {
     lastOfficeInBusinessHours = 'sfo';
     Sentry.captureMessage(
       `Unable to find an office in business hours for ${teamLabelName} for time ${timeToTriageBy}`


### PR DESCRIPTION
This helps find the root cause of https://sentry.io/organizations/sentry/issues/3898435867/?query=is%3Aunresolved&referrer=issue-stream

Speculating that this [revert](https://github.com/getsentry/eng-pipes/pull/395) did not entirely resolve this issue 