### PR TITLE
Remove route using label description message to sentry

### DIFF
--- a/src/brain/issueLabelHandler/route.ts
+++ b/src/brain/issueLabelHandler/route.ts
@@ -124,10 +124,6 @@ async function routeIssue(octokit, teamLabelName, teamDescription) {
     });
     return `Routing to @${SENTRY_ORG}/${strippedTeamName} for [triage](https://develop.sentry.dev/processing-tickets/#3-triage)`;
   } catch (error) {
-    // Use capture message here, because many teams rely on the label description for routing and it's not an exception we care about yet.
-    Sentry.captureMessage(
-      'Routing to team label name failed, retrying with label description'
-    );
     // If the label name doesn't work, try description
     try {
       const descriptionSlugName = teamDescription || '';


### PR DESCRIPTION
This message seems unnecessary now since it clutters the issues for the eng-pipes project, originally put it in to make sure it was doing the job correctly. Even then it probably wasn't needed.

https://sentry.io/organizations/sentry/issues/3840887660/?query=is%3Aunresolved&referrer=issue-stream