### PR TITLE
Patch routing issue when utc date is weekend, but sfo time is not

### DIFF
--- a/src/brain/issueLabelHandler/route.ts
+++ b/src/brain/issueLabelHandler/route.ts
@@ -140,7 +140,7 @@ async function routeIssue(octokit, teamLabelName, teamDescription) {
 }
 
 async function getReadableTimeStamp(timeToTriageBy, teamLabelName) {
-  const dueByMoment = moment(timeToTriageBy);
+  const dueByMoment = moment(timeToTriageBy).utc();
   const officesForTeam = await getSortedOffices(teamLabelName);
   let lastOfficeInBusinessHours;
   (officesForTeam.length > 0 ? officesForTeam : ['sfo']).forEach((office) => {

--- a/src/utils/businessHours.test.ts
+++ b/src/utils/businessHours.test.ts
@@ -302,6 +302,12 @@ describe('businessHours tests', function () {
       expect(result).toEqual(true);
     });
 
+    it('should return true for sfo office if utc day is Saturday, but local sfo time is Friday', async function () {
+      const nowForTest = moment('2023-02-04T01:00:00.000Z').utc();
+      const result = await isChannelInBusinessHours('CHNLIDRND1', nowForTest);
+      expect(result).toEqual(true);
+    });
+
     it('should post message to OSPO channel if offices is undefined', async function () {
       const nowForTest = moment('2023-01-05T18:00:00.000Z').utc();
       const postMessageSpy = jest.spyOn(bolt.client.chat, 'postMessage');

--- a/src/utils/businessHours.ts
+++ b/src/utils/businessHours.ts
@@ -91,9 +91,10 @@ export async function cacheOffices(team) {
 }
 
 export const isTimeInBusinessHours = (time: moment.Moment, office: string) => {
-  const dayOfTheWeek = time.day();
+  const localTime = time.tz(OFFICE_TIME_ZONES[office]);
+  const date = localTime.format('YYYY-MM-DD');
+  const dayOfTheWeek = localTime.day();
   const isWeekend = dayOfTheWeek === 6 || dayOfTheWeek === 0;
-  const date = time.tz(OFFICE_TIME_ZONES[office]).format('YYYY-MM-DD');
   const isHoliday = HOLIDAY_CONFIG[office]?.dates.includes(date);
   if (!isWeekend && !isHoliday) {
     const start = moment
@@ -102,7 +103,7 @@ export const isTimeInBusinessHours = (time: moment.Moment, office: string) => {
     const end = moment
       .tz(`${date} 17:00`, 'YYYY-MM-DD hh:mm', OFFICE_TIME_ZONES[office])
       .utc();
-    return start <= time && time <= end;
+    return start <= localTime && localTime <= end;
   }
   return false;
 };


### PR DESCRIPTION
This should resolve https://sentry.sentry.io/issues/3912368214/events/433575db377d418c827a61b4699800b1/?project=5246761

Apparently this issue only fired before sfo business hours on Thursday

