### PR TITLE
Check label for undefined or null before adding info to metrics

### DIFF
--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -252,15 +252,24 @@ export async function insertOss(
     data.created_at = issue.created_at;
     data.updated_at = issue.updated_at;
     if (data.action === 'labeled' || data.action === 'unlabeled') {
-      data.target_id = label.id;
-      data.target_name = label.name;
-      data.target_type = 'label';
-      if (data.action === 'labeled') {
-        data.timeToRouteBy = await calculateSLOViolationRoute(data.target_name);
-        data.timeToTriageBy = await calculateSLOViolationTriage(
-          data.target_name,
-          issue.labels
+      if (label == null) {
+        Sentry.setContext('payload', payload);
+        Sentry.captureException(
+          new Error('Unable to find label for labeling/unlabeling event')
         );
+      } else {
+        data.target_id = label.id;
+        data.target_name = label.name;
+        data.target_type = 'label';
+        if (data.action === 'labeled') {
+          data.timeToRouteBy = await calculateSLOViolationRoute(
+            data.target_name
+          );
+          data.timeToTriageBy = await calculateSLOViolationTriage(
+            data.target_name,
+            issue.labels
+          );
+        }
       }
     }
   } else if (eventType === 'issue_comment') {


### PR DESCRIPTION
This seems to be weird behavior, this code is 2 years old, yet the error in Sentry only appears from last October. 
https://sentry.sentry.io/issues/3670309284/?query=is%3Aunresolved&referrer=issue-stream

The GitHub actions `labeled` and `unlabeled` should always have the property `label` on them. If there isn't, I don't think it's worth recording metrics or it.