### PR TITLE
CI: Reduce GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,45 +27,6 @@ on:
       - main
 
 jobs:
-  build:
-    name: build
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version: '14'
-
-      - name: yarn install
-        run: yarn install --immutable
-
-      - name: tsc
-        run: yarn build
-
-  lint:
-    name: lint
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version: '14'
-
-      - name: yarn install
-        run: yarn install --immutable
-
-      - name: eslint
-        run: yarn lint
-
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -98,8 +59,12 @@ jobs:
       - name: yarn install
         run: yarn install --immutable
 
+      - name: tsc
+        run: yarn build
       - name: test
         run: yarn test:ci --coverage
+      - name: eslint
+        run: yarn lint
 
   docker:
     runs-on: ubuntu-latest
@@ -117,7 +82,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [lint, test]
+    needs: [test]
     environment: 'production'
     env:
       VERSION: ${{ github.sha }}


### PR DESCRIPTION
With this PR the build and lint are merged into the test step - avoiding checking out and installing deps multiple times in multiple parallel workflows.

NOTE: If this looks good, I'll remove them as required checks and keep the test and docker workflows as the remaining tests.