### PR TITLE
fix: support wider range of inputs/scenarios for gocd events

### DIFF
--- a/src/brain/notifyOnGoCDStageEvent/index.test.ts
+++ b/src/brain/notifyOnGoCDStageEvent/index.test.ts
@@ -262,6 +262,7 @@ describe('notifyOnGoCDStageEvent', function () {
       },
     });
 
+    updateMock.mockClear();
     await handler(gocdPayload);
 
     let commits = await db('queued_commits').select('*');
@@ -448,11 +449,11 @@ describe('notifyOnGoCDStageEvent', function () {
       }
     `);
 
-    updateMock.mockClear();
     // @ts-ignore
     bolt.client.chat.postMessage.mockClear();
 
     // Post message is called when finished
+    updateMock.mockClear();
     await handler(
       merge({}, gocdPayload, {
         data: {
@@ -517,6 +518,7 @@ describe('notifyOnGoCDStageEvent', function () {
       },
     });
 
+    updateMock.mockClear();
     await handler(gocdPayload);
 
     let commits = await db('queued_commits').select('*');
@@ -573,11 +575,11 @@ describe('notifyOnGoCDStageEvent', function () {
       }
     `);
 
-    updateMock.mockClear();
     // @ts-ignore
     bolt.client.chat.postMessage.mockClear();
 
     // Post message is called when finished
+    updateMock.mockClear();
     await handler(
       merge({}, gocdPayload, {
         data: {

--- a/src/brain/notifyOnGoCDStageEvent/index.test.ts
+++ b/src/brain/notifyOnGoCDStageEvent/index.test.ts
@@ -101,7 +101,7 @@ describe('notifyOnGoCDStageEvent', function () {
     octokit = await getClient(ClientType.App, 'getsentry');
     octokit.checks.listForRef.mockImplementation(() => ({
       data: {
-        check_runs: [{ name: 'only backend changes', conclusion: 'success' }],
+        check_runs: [{ name: 'only frontend changes', conclusion: 'success' }],
       },
     }));
     // @ts-ignore

--- a/src/brain/notifyOnGoCDStageEvent/index.ts
+++ b/src/brain/notifyOnGoCDStageEvent/index.ts
@@ -206,10 +206,8 @@ async function filterCommits(octokit, pipeline, commits) {
     // NOTE: We do not handle scenarios where the commit has both
     // frontend and backend changes.
     if (
-      (isFrontendOnly &&
-        pipeline.name == process.env.GOCD_SENTRYIO_FE_PIPELINE_NAME) ||
-      (isBackendOnly &&
-        pipeline.name == process.env.GOCD_SENTRYIO_BE_PIPELINE_NAME)
+      (isFrontendOnly && pipeline.name == GOCD_SENTRYIO_FE_PIPELINE_NAME) ||
+      (isBackendOnly && pipeline.name == GOCD_SENTRYIO_BE_PIPELINE_NAME)
     ) {
       relevantCommitShas.push(sha);
     }

--- a/src/brain/notifyOnGoCDStageEvent/index.ts
+++ b/src/brain/notifyOnGoCDStageEvent/index.ts
@@ -167,6 +167,10 @@ async function updateCommitQueue(
         await clearQueuedCommits(sha);
       }
       break;
+    case 'failed':
+    case 'cancelled':
+      await clearQueuedCommits(sha);
+      break;
     default:
       Sentry.captureException(
         new Error(`Unexpected stage result: ${stage.result}`)
@@ -207,9 +211,6 @@ async function filterCommits(octokit, pipeline, commits) {
       (isBackendOnly &&
         pipeline.name == process.env.GOCD_SENTRYIO_BE_PIPELINE_NAME)
     ) {
-      relevantCommitShas.push(sha);
-    } else {
-      // TODO (mattgaunt): DO NOT COMMIT THIS!
       relevantCommitShas.push(sha);
     }
   }

--- a/src/brain/saveGoCDStageEvents/index.test.ts
+++ b/src/brain/saveGoCDStageEvents/index.test.ts
@@ -1,3 +1,5 @@
+import merge from 'lodash.merge';
+
 import buildingPayload from '@test/payloads/gocd/gocd-stage-building.json';
 import failedPayload from '@test/payloads/gocd/gocd-stage-failed.json';
 
@@ -187,6 +189,216 @@ describe('saveGoCDStageEvents.handler', function () {
       stage_result: 'Failed',
       stage_state: 'Failed',
     });
+  });
+
+  it('saves just the git materials', async function () {
+    let payload = merge({}, buildingPayload);
+    delete payload.data.pipeline['build-cause'];
+    payload = merge(payload, {
+      data: {
+        pipeline: {
+          'build-cause': [
+            {
+              material: {
+                'git-configuration': {
+                  'shallow-clone': false,
+                  branch: 'master',
+                  url: 'git@github.com:getsentry/getsentry.git',
+                },
+                type: 'git',
+              },
+              changed: false,
+              modifications: [
+                {
+                  revision: '2b0034becc4ab26b985f4c1a08ab068f153c274c',
+                  'modified-time': 'Oct 26, 2022, 5:05:17 PM',
+                  data: {},
+                },
+              ],
+            },
+            {
+              material: {
+                'git-configuration': {
+                  'shallow-clone': false,
+                  branch: 'master',
+                  url: 'git@github.com:getsentry/sentry.git',
+                },
+                type: 'git',
+              },
+              changed: false,
+              modifications: [],
+            },
+            {
+              material: {
+                type: 'pipeline',
+              },
+              changed: false,
+            },
+          ],
+        },
+      },
+    });
+
+    await saveGoCDStageEvents.handler(payload);
+
+    // 1x Check if pipeline exists
+    // 1x Insert pipeline
+    // 1x Insert materials and revision
+    expect(dbMock).toHaveBeenCalledTimes(3);
+
+    let stages = await dbMock(saveGoCDStageEvents.DB_TABLE_STAGES).select('*');
+    expect(stages).toHaveLength(1);
+    expect(stages[0]).toMatchObject({
+      pipeline_build_cause: [
+        {
+          changed: false,
+          material: {
+            'git-configuration': {
+              branch: 'master',
+              'shallow-clone': false,
+              url: 'git@github.com:getsentry/getsentry.git',
+            },
+            type: 'git',
+          },
+          modifications: [
+            {
+              data: {},
+              'modified-time': 'Oct 26, 2022, 5:05:17 PM',
+              revision: '2b0034becc4ab26b985f4c1a08ab068f153c274c',
+            },
+          ],
+        },
+        {
+          material: {
+            'git-configuration': {
+              'shallow-clone': false,
+              branch: 'master',
+              url: 'git@github.com:getsentry/sentry.git',
+            },
+            type: 'git',
+          },
+          changed: false,
+          modifications: [],
+        },
+        {
+          material: {
+            type: 'pipeline',
+          },
+          changed: false,
+        },
+      ],
+      pipeline_counter: 20,
+      pipeline_group: 'sentryio',
+      pipeline_id: 'sentryio_getsentry_frontend_20',
+      pipeline_name: 'getsentry_frontend',
+      stage_approval_type: 'success',
+      stage_approved_by: 'matt.gaunt@sentry.io',
+      stage_counter: 1,
+      stage_create_time: new Date('2022-10-26T17:57:53.000Z'),
+      stage_jobs: [
+        {
+          name: 'preliminary-checks',
+          result: 'Unknown',
+          state: 'Scheduled',
+        },
+      ],
+      stage_last_transition_time: null,
+      stage_name: 'preliminary-checks',
+      stage_result: 'Unknown',
+      stage_state: 'Building',
+    });
+
+    const materials = await dbMock(saveGoCDStageEvents.DB_TABLE_MATERIALS)
+      .select('*')
+      .orderBy('url', 'asc');
+    expect(materials).toHaveLength(1);
+    expect(materials[0]).toMatchObject({
+      stage_material_id:
+        'sentryio_getsentry_frontend_20_git@github.com:getsentry/getsentry.git_2b0034becc4ab26b985f4c1a08ab068f153c274c',
+      pipeline_id: 'sentryio_getsentry_frontend_20',
+      url: 'git@github.com:getsentry/getsentry.git',
+      branch: 'master',
+      revision: '2b0034becc4ab26b985f4c1a08ab068f153c274c',
+    });
+
+    dbMock.mockClear();
+
+    await saveGoCDStageEvents.handler(failedPayload);
+
+    expect(dbMock).toHaveBeenCalledTimes(2);
+
+    stages = await dbMock(saveGoCDStageEvents.DB_TABLE_STAGES).select('*');
+    expect(stages).toHaveLength(1);
+
+    expect(stages[0]).toMatchObject({
+      pipeline_build_cause: [
+        {
+          changed: false,
+          material: {
+            'git-configuration': {
+              branch: 'master',
+              'shallow-clone': false,
+              url: 'git@github.com:getsentry/getsentry.git',
+            },
+            type: 'git',
+          },
+          modifications: [
+            {
+              data: {},
+              'modified-time': 'Oct 26, 2022, 5:05:17 PM',
+              revision: '2b0034becc4ab26b985f4c1a08ab068f153c274c',
+            },
+          ],
+        },
+        {
+          changed: false,
+          material: {
+            'git-configuration': {
+              branch: 'master',
+              'shallow-clone': false,
+              url: 'git@github.com:getsentry/sentry.git',
+            },
+            type: 'git',
+          },
+          modifications: [
+            {
+              data: {},
+              'modified-time': 'Oct 26, 2022, 5:56:18 PM',
+              revision: '77b189ad3b4b48a7eb1ec63cc486cdc991332352',
+            },
+          ],
+        },
+      ],
+      pipeline_counter: 20,
+      pipeline_group: 'sentryio',
+      pipeline_id: 'sentryio_getsentry_frontend_20',
+      pipeline_name: 'getsentry_frontend',
+      stage_approval_type: 'manual',
+      stage_approved_by: 'matt.gaunt@sentry.io',
+      stage_counter: 1,
+      stage_create_time: new Date('2022-10-26T17:58:42.000Z'),
+      stage_jobs: [
+        {
+          name: 'deploy_static',
+          result: 'Failed',
+          state: 'Completed',
+        },
+      ],
+      stage_last_transition_time: new Date('2022-10-26T17:58:47.000Z'),
+      stage_name: 'deploy_frontend',
+      stage_result: 'Failed',
+      stage_state: 'Failed',
+    });
+  });
+
+  it('throw if there are no git materials', async function () {
+    const payload = merge({}, buildingPayload);
+    payload.data.pipeline['build-cause'] = [];
+
+    const t = async () => {
+      await saveGoCDStageEvents.handler(payload);
+    };
+    expect(t).rejects.toThrow('Failed to find GoCD modification material');
   });
 });
 

--- a/src/brain/saveGoCDStageEvents/index.ts
+++ b/src/brain/saveGoCDStageEvents/index.ts
@@ -52,10 +52,11 @@ async function saveBuildMaterials(pipeline_id, pipeline) {
   const gocdMaterials: Array<GoCDBuildMaterial> = [];
   for (const bc of pipeline['build-cause']) {
     if (!bc.material || bc.material.type != 'git') {
-      throw new Error('Unexpected GoCD build-case material');
+      // The material may be an upstream pipeline
+      continue;
     }
     if (bc.modifications.length == 0) {
-      throw new Error('No GoCD modification for material');
+      continue;
     }
 
     const gitConfig = bc.material['git-configuration'];
@@ -69,6 +70,10 @@ async function saveBuildMaterials(pipeline_id, pipeline) {
       revision: modification.revision,
     });
   }
+  if (gocdMaterials.length == 0) {
+    throw new Error('Failed to find GoCD modification material');
+  }
+
   await db(DB_TABLE_MATERIALS).insert(gocdMaterials);
 }
 


### PR DESCRIPTION
This change is just supporting cases I didn't handle before around failing pipelines or different materials in pipelines.

This should address some issues flagged in sentryio