### PR TITLE
Fix product owner mentions

### DIFF
--- a/src/api/github/__mocks__/getClient.ts
+++ b/src/api/github/__mocks__/getClient.ts
@@ -56,7 +56,10 @@ function mockClient() {
     },
     teams: {
       getByName: jest.fn(async function (payload) {
-        if (payload.team_slug === 'test' || payload.team_slug === 'rerouted') {
+        if (
+          payload.team_slug === 'product-owners-test' ||
+          payload.team_slug === 'product-owners-rerouted'
+        ) {
           return { status: 200, data: {} };
         }
         throw new MockOctokitError(404);

--- a/src/brain/issueLabelHandler/index.test.ts
+++ b/src/brain/issueLabelHandler/index.test.ts
@@ -315,7 +315,7 @@ describe('issueLabelHandler', function () {
       expectRouted();
       expect(octokit.issues._comments).toEqual([
         'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route), due by **<time datetime=2022-12-20T00:00:00.000Z>Monday, December 19th at 4:00 pm</time> (sfo)**. ⏲️',
-        'Failed to route to @getsentry/product-owners-does-not-exist for Product Area: Does Not Exist. Defaulting to @getsentry/open-source for [triage](https://develop.sentry.dev/processing-tickets/#3-triage), due by **<time datetime=2022-12-21T00:00:00.000Z>Tuesday, December 20th at 4:00 pm</time> (sfo)**. ⏲️',
+        'Failed to route for Product Area: Does Not Exist. Defaulting to @getsentry/open-source for [triage](https://develop.sentry.dev/processing-tickets/#3-triage), due by **<time datetime=2022-12-21T00:00:00.000Z>Tuesday, December 20th at 4:00 pm</time> (sfo)**. ⏲️',
       ]);
     });
 

--- a/src/utils/slugizeProductArea.test.ts
+++ b/src/utils/slugizeProductArea.test.ts
@@ -1,0 +1,21 @@
+import { slugizeProductArea } from './slugizeProductArea';
+
+describe('slugizeProductArea', function () {
+  describe('slugize tests', function () {
+    it('behaves as expected', async function () {
+      const cases = [
+        ['MOST of ALL', 'most-of-all'],
+        ['Cheese & Bread', 'cheese-bread'],
+        ['otherwise - notherwise', 'otherwise-notherwise'],
+        ['over - & - yonder', 'over-yonder'],
+        ["other's druthers", 'others-druthers'],
+      ];
+      cases.forEach((x) => {
+        expect(slugizeProductArea(x[0])).toEqual(x[1]);
+      });
+      expect(() => {
+        slugizeProductArea('other^s druthers');
+      }).toThrow('Bad slug: other^s-druthers');
+    });
+  });
+});

--- a/src/utils/slugizeProductArea.ts
+++ b/src/utils/slugizeProductArea.ts
@@ -1,0 +1,15 @@
+export function slugizeProductArea(s) {
+  // Keep this in sync with slugize in ...
+  // https://github.com/getsentry/security-as-code/blob/main/rbac/lib/make-product-owners
+  // Good luck!
+  const slug = s
+    .replace(/-/g, ' ')
+    .replace(/&/g, ' ')
+    .replace(/ +/g, '-')
+    .replace(/'/g, '')
+    .toLowerCase();
+  if (!/^[a-z][a-z-]+[a-z]$/.test(slug)) {
+    throw 'Bad slug: ' + slug;
+  }
+  return slug;
+}


### PR DESCRIPTION
- removes label description hack (since we have better control of both sides now)
- standardize on `product-owners-` prefix
- match slugification algorithm to [`security-as-code`](https://github.com/getsentry/security-as-code/blob/fb50e07387ad8ab7724a5dfda4eabefcce6a28da/rbac/lib/make-product-owners#L13-L16)