### PR TITLE
Remove blocks from update

### DIFF
--- a/src/blocks/getUpdatedDeployMessage.ts
+++ b/src/blocks/getUpdatedDeployMessage.ts
@@ -73,9 +73,9 @@ export function getUpdatedGoCDDeployMessage({
   slackUser: string | undefined;
   pipeline: {
     pipeline_name: string;
-    pipeline_counter: Number;
+    pipeline_counter: number;
     stage_name: string;
-    stage_counter: Number;
+    stage_counter: number;
     stage_state: string;
   };
 }) {

--- a/src/brain/pleaseDeployNotifier/actionSlackDeploy.ts
+++ b/src/brain/pleaseDeployNotifier/actionSlackDeploy.ts
@@ -59,7 +59,7 @@ export async function actionSlackDeploy({ ack, body, client, context }) {
     await client.chat.postEphemeral({
       channel: body.channel?.id || '',
       // @ts-ignore
-      user: payload.user.id,
+      user: body.user.id,
       text: 'There was an error changing your deploy notification preferences',
     });
   }
@@ -70,18 +70,20 @@ export async function actionSlackDeploy({ ack, body, client, context }) {
   }
 
   /**
-   * Update the message to hide Mute button and show Un-mute button
+   * Update the message to hide Mute button and show Un-mute button.
+   * This is needed if the user tries to mute/unmute from a message
+   * with the (un)muteDeployNotificationsButtons shown as an action.
    */
+
   // @ts-ignore
   const { container, message } = body;
-  const { ts, text, attachments, blocks } = message;
+  const { ts, text, attachments } = message;
 
   // Update original message to change mute button to unmute
   await client.chat.update({
     channel: body.channel?.id || '',
     ts,
     text,
-    blocks,
     attachments: updateAttachment(
       attachments,
       container.attachment_id,


### PR DESCRIPTION
This fixes: https://sentry.sentry.io/issues/4144408159/?project=5246761&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=0

The issue is that passing in the blocks from the original message causes slack to throw an error. I tried to find a way of fixing the warning, but the only block is a `rich_text` block that slack makes and is also defined in the plain text of the message.

There are a few other changes in this PR but that were all found while debugging this issue.