### PR TITLE
Add initial waiting for label logic

### DIFF
--- a/src/brain/issueLabelHandler/followups.ts
+++ b/src/brain/issueLabelHandler/followups.ts
@@ -3,11 +3,7 @@ import * as Sentry from '@sentry/node';
 
 import { isFromABot } from '@utils/isFromABot';
 
-const REPOS_TO_TRACK_FOR_TRIAGE = new Set([
-  'sentry',
-  'sentry-docs',
-  'test-sentry-app',
-]);
+const REPOS_TO_TRACK_FOR_TRIAGE = new Set(['sentry', 'sentry-docs']);
 import { ClientType } from '@/api/github/clientType';
 import {
   isNotFromAnExternalOrGTMUser,

--- a/src/brain/issueLabelHandler/followups.ts
+++ b/src/brain/issueLabelHandler/followups.ts
@@ -1,0 +1,110 @@
+import { EmitterWebhookEvent } from '@octokit/webhooks';
+import * as Sentry from '@sentry/node';
+
+import { isFromABot } from '@utils/isFromABot';
+
+const REPOS_TO_TRACK_FOR_TRIAGE = new Set([
+  'sentry',
+  'sentry-docs',
+  'test-sentry-app',
+]);
+import { ClientType } from '@/api/github/clientType';
+import {
+  isNotFromAnExternalOrGTMUser,
+  shouldSkip,
+} from '@/brain/issueLabelHandler/helpers';
+import {
+  WAITING_FOR_COMMUNITY_LABEL,
+  WAITING_FOR_LABEL_PREFIX,
+  WAITING_FOR_PRODUCT_OWNER_LABEL,
+} from '@/config';
+import { getClient } from '@api/github/getClient';
+
+function isNotInARepoWeCareAboutForTriage(payload) {
+  return !REPOS_TO_TRACK_FOR_TRIAGE.has(payload.repository.name);
+}
+
+function isNotWaitingForCommunity(payload) {
+  const { issue } = payload;
+  return !issue?.labels.some(
+    ({ name }) => name === WAITING_FOR_COMMUNITY_LABEL
+  );
+}
+
+// Markers of State
+
+export async function updateCommunityFollowups({
+  id,
+  payload,
+  ...rest
+}: EmitterWebhookEvent<'issue_comment.created'>) {
+  const tx = Sentry.startTransaction({
+    op: 'brain',
+    name: 'issueLabelHandler.updateCommunityFollowups',
+  });
+
+  const reasonsToDoNothing = [
+    isNotInARepoWeCareAboutForTriage,
+    isNotFromAnExternalOrGTMUser,
+    isNotWaitingForCommunity,
+    isFromABot,
+  ];
+  if (await shouldSkip(payload, reasonsToDoNothing)) {
+    return;
+  }
+
+  const owner = payload.repository.owner.login;
+  const octokit = await getClient(ClientType.App, owner);
+
+  await octokit.issues.removeLabel({
+    owner,
+    repo: payload.repository.name,
+    issue_number: payload.issue.number,
+    name: WAITING_FOR_COMMUNITY_LABEL,
+  });
+
+  await octokit.issues.addLabels({
+    owner,
+    repo: payload.repository.name,
+    issue_number: payload.issue.number,
+    labels: [WAITING_FOR_PRODUCT_OWNER_LABEL],
+  });
+
+  tx.finish();
+}
+
+export async function ensureOneWaitingForLabel({
+  id,
+  payload,
+  ...rest
+}: EmitterWebhookEvent<'issues.labeled'>) {
+  const tx = Sentry.startTransaction({
+    op: 'brain',
+    name: 'issueLabelHandler.ensureOneWaitingForLabel',
+  });
+
+  const reasonsToDoNothing = [isFromABot];
+  if (await shouldSkip(payload, reasonsToDoNothing)) {
+    return;
+  }
+
+  const { issue, label } = payload;
+  const owner = payload.repository.owner.login;
+  const octokit = await getClient(ClientType.App, owner);
+
+  if (label?.name.startsWith(WAITING_FOR_LABEL_PREFIX)) {
+    const labelToRemove =
+      issue.labels?.find(
+        ({ name }) =>
+          name.startsWith(WAITING_FOR_LABEL_PREFIX) && name != label?.name
+      )?.name || '';
+    await octokit.issues.removeLabel({
+      owner: owner,
+      repo: payload.repository.name,
+      issue_number: payload.issue.number,
+      name: labelToRemove,
+    });
+  }
+
+  tx.finish();
+}

--- a/src/brain/issueLabelHandler/helpers.ts
+++ b/src/brain/issueLabelHandler/helpers.ts
@@ -1,0 +1,22 @@
+import { getOssUserType } from '@utils/getOssUserType';
+
+// Validation Helpers
+
+export async function shouldSkip(payload, reasonsToSkip) {
+  // Could do Promise-based async here, but that was getting complicated[1] and
+  // there's not really a performance concern (famous last words).
+  //
+  // [1] https://github.com/getsentry/eng-pipes/pull/212#discussion_r657365585
+
+  for (const skipIf of reasonsToSkip) {
+    if (await skipIf(payload)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export async function isNotFromAnExternalOrGTMUser(payload) {
+  const type = await getOssUserType(payload);
+  return !(type === 'external' || type === 'gtm');
+}

--- a/src/brain/issueLabelHandler/index.test.ts
+++ b/src/brain/issueLabelHandler/index.test.ts
@@ -441,71 +441,71 @@ describe('issueLabelHandler', function () {
       await setupIssue();
       expect(octokit.issues._labels).toEqual(
         new Set([
-          'Status: Untriaged',
-          'Waiting for: Product Owner',
+          UNTRIAGED_LABEL,
+          WAITING_FOR_PRODUCT_OWNER_LABEL,
           'Product Area: Test',
         ])
       );
       await addLabel('Waiting for: Community', 'sentry-docs');
       expect(octokit.issues._labels).toEqual(
         new Set([
-          'Status: Untriaged',
+          UNTRIAGED_LABEL,
           'Product Area: Test',
-          'Waiting for: Community',
+          WAITING_FOR_COMMUNITY_LABEL,
         ])
       );
       await addLabel('Waiting for: Support', 'sentry-docs');
       expect(octokit.issues._labels).toEqual(
         new Set([
-          'Status: Untriaged',
+          UNTRIAGED_LABEL,
           'Product Area: Test',
-          'Waiting for: Support',
+          WAITING_FOR_SUPPORT_LABEL,
         ])
       );
     });
 
     it('should not add `Waiting for: Product Owner` label when product owner/GTM member comments and issue is waiting for community', async function () {
       await setupIssue();
-      await addLabel('Waiting for: Community', 'sentry-docs');
+      await addLabel(WAITING_FOR_COMMUNITY_LABEL, 'sentry-docs');
       jest.spyOn(helpers, 'isNotFromAnExternalOrGTMUser').mockReturnValue(true);
       await addComment('sentry-docs', 'Picard');
       expect(octokit.issues._labels).toEqual(
         new Set([
-          'Status: Untriaged',
+          UNTRIAGED_LABEL,
           'Product Area: Test',
-          'Waiting for: Community',
+          WAITING_FOR_COMMUNITY_LABEL,
         ])
       );
     });
 
     it('should add `Waiting for: Product Owner` label when community member comments and issue is waiting for community', async function () {
       await setupIssue();
-      await addLabel('Waiting for: Community', 'sentry-docs');
+      await addLabel(WAITING_FOR_COMMUNITY_LABEL, 'sentry-docs');
       jest
         .spyOn(helpers, 'isNotFromAnExternalOrGTMUser')
         .mockReturnValue(false);
       await addComment('sentry-docs', 'Picard');
       expect(octokit.issues._labels).toEqual(
         new Set([
-          'Status: Untriaged',
+          UNTRIAGED_LABEL,
           'Product Area: Test',
-          'Waiting for: Product Owner',
+          WAITING_FOR_PRODUCT_OWNER_LABEL,
         ])
       );
     });
 
     it('should not modify labels when community member comments and issue is waiting for product owner', async function () {
       await setupIssue();
-      await addLabel('Waiting for: Product Owner', 'sentry-docs');
+      await addLabel(WAITING_FOR_PRODUCT_OWNER_LABEL, 'sentry-docs');
       jest
         .spyOn(helpers, 'isNotFromAnExternalOrGTMUser')
         .mockReturnValue(false);
       await addComment('sentry-docs', 'Picard');
       expect(octokit.issues._labels).toEqual(
         new Set([
-          'Status: Untriaged',
+          UNTRIAGED_LABEL,
           'Product Area: Test',
-          'Waiting for: Product Owner',
+          WAITING_FOR_PRODUCT_OWNER_LABEL,
         ])
       );
     });

--- a/src/brain/issueLabelHandler/index.ts
+++ b/src/brain/issueLabelHandler/index.ts
@@ -1,5 +1,9 @@
 import { githubEvents } from '@api/github';
 
+import {
+  ensureOneWaitingForLabel,
+  updateCommunityFollowups,
+} from './followups';
 import { markRouted, markUnrouted } from './route';
 import { markTriaged, markUntriaged } from './triage';
 
@@ -14,4 +18,11 @@ export async function issueLabelHandler() {
   githubEvents.on('issues.opened', markUnrouted);
   githubEvents.removeListener('issues.labeled', markRouted);
   githubEvents.on('issues.labeled', markRouted);
+  githubEvents.removeListener(
+    'issue_comment.created',
+    updateCommunityFollowups
+  );
+  githubEvents.on('issue_comment.created', updateCommunityFollowups);
+  githubEvents.removeListener('issues.labeled', ensureOneWaitingForLabel);
+  githubEvents.on('issues.labeled', ensureOneWaitingForLabel);
 }

--- a/src/brain/issueLabelHandler/route.ts
+++ b/src/brain/issueLabelHandler/route.ts
@@ -3,6 +3,10 @@ import * as Sentry from '@sentry/node';
 import moment from 'moment-timezone';
 
 import {
+  isNotFromAnExternalOrGTMUser,
+  shouldSkip,
+} from '@/brain/issueLabelHandler/helpers';
+import {
   BACKLOG_LABEL,
   IN_PROGRESS_LABEL,
   OFFICE_TIME_ZONES,
@@ -13,6 +17,9 @@ import {
   UNKNOWN_LABEL,
   UNROUTED_LABEL,
   UNTRIAGED_LABEL,
+  WAITING_FOR_LABEL_PREFIX,
+  WAITING_FOR_PRODUCT_OWNER_LABEL,
+  WAITING_FOR_SUPPORT_LABEL,
 } from '@/config';
 import {
   calculateSLOViolationRoute,
@@ -20,38 +27,20 @@ import {
   getSortedOffices,
   isTimeInBusinessHours,
 } from '@utils/businessHours';
-import { getOssUserType } from '@utils/getOssUserType';
 import { isFromABot } from '@utils/isFromABot';
 import { slugizeProductArea } from '@utils/slugizeProductArea';
 
-const REPOS_TO_TRACK_FOR_ROUTING = new Set(['sentry', 'sentry-docs']);
+const REPOS_TO_TRACK_FOR_ROUTING = new Set([
+  'sentry',
+  'sentry-docs',
+  'test-sentry-app',
+]);
 
 import { ClientType } from '@/api/github/clientType';
 import { getClient } from '@api/github/getClient';
 
-// Validation Helpers
-
-async function shouldSkip(payload, reasonsToSkip) {
-  // Could do Promise-based async here, but that was getting complicated[1] and
-  // there's not really a performance concern (famous last words).
-  //
-  // [1] https://github.com/getsentry/eng-pipes/pull/212#discussion_r657365585
-
-  for (const skipIf of reasonsToSkip) {
-    if (await skipIf(payload)) {
-      return true;
-    }
-  }
-  return false;
-}
-
 function isAlreadyUnrouted(payload) {
   return payload.issue.labels.some(({ name }) => name === UNROUTED_LABEL);
-}
-
-async function isNotFromAnExternalOrGTMUser(payload) {
-  const type = await getOssUserType(payload);
-  return !(type === 'external' || type === 'gtm');
 }
 
 function isNotInARepoWeCareAboutForRouting(payload) {
@@ -74,7 +63,8 @@ function shouldLabelBeRemoved(label, target_name) {
     (label.name.startsWith(PRODUCT_AREA_LABEL_PREFIX) &&
       label.name !== target_name) ||
     (label.name.startsWith(STATUS_LABEL_PREFIX) &&
-      label.name !== UNTRIAGED_LABEL)
+      label.name !== UNTRIAGED_LABEL) ||
+    label.name.startsWith(WAITING_FOR_LABEL_PREFIX)
   );
 }
 
@@ -106,7 +96,7 @@ export async function markUnrouted({
     owner,
     repo: payload.repository.name,
     issue_number: payload.issue.number,
-    labels: [UNROUTED_LABEL],
+    labels: [UNROUTED_LABEL, WAITING_FOR_SUPPORT_LABEL],
   });
 
   const timeToRouteBy = await calculateSLOViolationRoute(UNROUTED_LABEL);
@@ -229,7 +219,7 @@ export async function markRouted({
     owner: owner,
     repo: payload.repository.name,
     issue_number: payload.issue.number,
-    labels: [UNTRIAGED_LABEL],
+    labels: [UNTRIAGED_LABEL, WAITING_FOR_PRODUCT_OWNER_LABEL],
   });
 
   const routedTeam = await routeIssue(octokit, productAreaLabelName);

--- a/src/brain/issueLabelHandler/route.ts
+++ b/src/brain/issueLabelHandler/route.ts
@@ -30,11 +30,7 @@ import {
 import { isFromABot } from '@utils/isFromABot';
 import { slugizeProductArea } from '@utils/slugizeProductArea';
 
-const REPOS_TO_TRACK_FOR_ROUTING = new Set([
-  'sentry',
-  'sentry-docs',
-  'test-sentry-app',
-]);
+const REPOS_TO_TRACK_FOR_ROUTING = new Set(['sentry', 'sentry-docs']);
 
 import { ClientType } from '@/api/github/clientType';
 import { getClient } from '@api/github/getClient';

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -96,6 +96,10 @@ export const IN_PROGRESS_LABEL = 'Status: In Progress';
 export const UNTRIAGED_LABEL = 'Status: Untriaged';
 export const UNROUTED_LABEL = 'Status: Unrouted';
 export const UNKNOWN_LABEL = 'Status: Unknown';
+export const WAITING_FOR_LABEL_PREFIX = 'Waiting for: ';
+export const WAITING_FOR_SUPPORT_LABEL = 'Waiting for: Support';
+export const WAITING_FOR_COMMUNITY_LABEL = 'Waiting for: Community';
+export const WAITING_FOR_PRODUCT_OWNER_LABEL = 'Waiting for: Product Owner';
 export const MAX_TRIAGE_DAYS = 2;
 export const MAX_ROUTE_DAYS = 1;
 

--- a/test/payloads/github/issue_comment.ts
+++ b/test/payloads/github/issue_comment.ts
@@ -1,0 +1,244 @@
+// Derived from GitHub's docs:
+//
+//   https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#webhook-payload-example-when-someone-edits-an-issue.
+
+export default {
+  action: 'created',
+  issue: {
+    url: 'https://api.github.com/repos/Enterprise/Hello-World/issues/1',
+    repository_url: 'https://api.github.com/repos/Enterprise/Hello-World',
+    labels_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/issues/1/labels{/name}',
+    comments_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/issues/1/comments',
+    events_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/issues/1/events',
+    html_url: 'https://github.com/Enterprise/Hello-World/issues/1',
+    id: 444500041,
+    node_id: 'MDU6SXNzdWU0NDQ1MDAwNDE=',
+    number: 1,
+    title: 'Spelling error in the README file',
+    user: {
+      login: 'Picard',
+      id: 21031067,
+      node_id: 'MDQ6VXNlcjIxMDMxMDY3',
+      avatar_url: 'https://avatars1.githubusercontent.com/u/21031067?v=4',
+      gravatar_id: '',
+      url: 'https://api.github.com/users/Picard',
+      html_url: 'https://github.com/Picard',
+      followers_url: 'https://api.github.com/users/Picard/followers',
+      following_url:
+        'https://api.github.com/users/Picard/following{/other_user}',
+      gists_url: 'https://api.github.com/users/Picard/gists{/gist_id}',
+      starred_url: 'https://api.github.com/users/Picard/starred{/owner}{/repo}',
+      subscriptions_url: 'https://api.github.com/users/Picard/subscriptions',
+      organizations_url: 'https://api.github.com/users/Picard/orgs',
+      repos_url: 'https://api.github.com/users/Picard/repos',
+      events_url: 'https://api.github.com/users/Picard/events{/privacy}',
+      received_events_url:
+        'https://api.github.com/users/Picard/received_events',
+      type: 'User',
+      site_admin: false,
+    },
+    labels: [
+      {
+        id: 1362934389,
+        node_id: 'MDU6TGFiZWwxMzYyOTM0Mzg5',
+        url: 'https://api.github.com/repos/Enterprise/Hello-World/labels/bug',
+        name: 'bug',
+        color: 'd73a4a',
+        default: true,
+      },
+    ],
+    state: 'open',
+    locked: false,
+    assignee: null,
+    assignees: [],
+    milestone: null,
+    comments: 0,
+    created_at: '2019-05-15T15:20:18Z',
+    updated_at: '2019-05-15T15:20:18Z',
+    closed_at: null,
+    author_association: 'OWNER',
+    body: "It looks like you accidently spelled 'commit' with two 't's.",
+  },
+  changes: {},
+  repository: {
+    id: 186853002,
+    node_id: 'MDEwOlJlcG9zaXRvcnkxODY4NTMwMDI=',
+    name: 'Hello-World',
+    full_name: 'Enterprise/Hello-World',
+    private: false,
+    owner: {
+      login: 'Enterprise',
+      id: 21031067,
+      node_id: 'MDQ6VXNlcjIxMDMxMDY3',
+      avatar_url: 'https://avatars1.githubusercontent.com/u/21031067?v=4',
+      gravatar_id: '',
+      url: 'https://api.github.com/users/Enterprise',
+      html_url: 'https://github.com/Enterprise',
+      followers_url: 'https://api.github.com/users/Enterprise/followers',
+      following_url:
+        'https://api.github.com/users/Enterprise/following{/other_user}',
+      gists_url: 'https://api.github.com/users/Enterprise/gists{/gist_id}',
+      starred_url:
+        'https://api.github.com/users/Enterprise/starred{/owner}{/repo}',
+      subscriptions_url:
+        'https://api.github.com/users/Enterprise/subscriptions',
+      organizations_url: 'https://api.github.com/users/Enterprise/orgs',
+      repos_url: 'https://api.github.com/users/Enterprise/repos',
+      events_url: 'https://api.github.com/users/Enterprise/events{/privacy}',
+      received_events_url:
+        'https://api.github.com/users/Enterprise/received_events',
+      type: 'Organization',
+      site_admin: false,
+    },
+    html_url: 'https://github.com/Enterprise/Hello-World',
+    description: null,
+    fork: false,
+    url: 'https://api.github.com/repos/Enterprise/Hello-World',
+    forks_url: 'https://api.github.com/repos/Enterprise/Hello-World/forks',
+    keys_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/keys{/key_id}',
+    collaborators_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/collaborators{/collaborator}',
+    teams_url: 'https://api.github.com/repos/Enterprise/Hello-World/teams',
+    hooks_url: 'https://api.github.com/repos/Enterprise/Hello-World/hooks',
+    issue_events_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/issues/events{/number}',
+    events_url: 'https://api.github.com/repos/Enterprise/Hello-World/events',
+    assignees_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/assignees{/user}',
+    branches_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/branches{/branch}',
+    tags_url: 'https://api.github.com/repos/Enterprise/Hello-World/tags',
+    blobs_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/git/blobs{/sha}',
+    git_tags_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/git/tags{/sha}',
+    git_refs_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/git/refs{/sha}',
+    trees_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/git/trees{/sha}',
+    statuses_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/statuses/{sha}',
+    languages_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/languages',
+    stargazers_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/stargazers',
+    contributors_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/contributors',
+    subscribers_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/subscribers',
+    subscription_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/subscription',
+    commits_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/commits{/sha}',
+    git_commits_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/git/commits{/sha}',
+    comments_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/comments{/number}',
+    issue_comment_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/issues/comments{/number}',
+    contents_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/contents/{+path}',
+    compare_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/compare/{base}...{head}',
+    merges_url: 'https://api.github.com/repos/Enterprise/Hello-World/merges',
+    archive_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/{archive_format}{/ref}',
+    downloads_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/downloads',
+    issues_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/issues{/number}',
+    pulls_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/pulls{/number}',
+    milestones_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/milestones{/number}',
+    notifications_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/notifications{?since,all,participating}',
+    labels_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/labels{/name}',
+    releases_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/releases{/id}',
+    deployments_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/deployments',
+    created_at: '2019-05-15T15:19:25Z',
+    updated_at: '2019-05-15T15:19:27Z',
+    pushed_at: '2019-05-15T15:20:13Z',
+    git_url: 'git://github.com/Enterprise/Hello-World.git',
+    ssh_url: 'git@github.com:Enterprise/Hello-World.git',
+    clone_url: 'https://github.com/Enterprise/Hello-World.git',
+    svn_url: 'https://github.com/Enterprise/Hello-World',
+    homepage: null,
+    size: 0,
+    stargazers_count: 0,
+    watchers_count: 0,
+    language: null,
+    has_issues: true,
+    has_projects: true,
+    has_downloads: true,
+    has_wiki: true,
+    has_pages: true,
+    forks_count: 0,
+    mirror_url: null,
+    archived: false,
+    disabled: false,
+    open_issues_count: 1,
+    license: null,
+    forks: 0,
+    open_issues: 1,
+    watchers: 0,
+    default_branch: 'master',
+  },
+  sender: {
+    login: 'Picard',
+    id: 21031067,
+    node_id: 'MDQ6VXNlcjIxMDMxMDY3',
+    avatar_url: 'https://avatars1.githubusercontent.com/u/21031067?v=4',
+    gravatar_id: '',
+    url: 'https://api.github.com/users/Picard',
+    html_url: 'https://github.com/Picard',
+    followers_url: 'https://api.github.com/users/Picard/followers',
+    following_url: 'https://api.github.com/users/Picard/following{/other_user}',
+    gists_url: 'https://api.github.com/users/Picard/gists{/gist_id}',
+    starred_url: 'https://api.github.com/users/Picard/starred{/owner}{/repo}',
+    subscriptions_url: 'https://api.github.com/users/Picard/subscriptions',
+    organizations_url: 'https://api.github.com/users/Picard/orgs',
+    repos_url: 'https://api.github.com/users/Picard/repos',
+    events_url: 'https://api.github.com/users/Picard/events{/privacy}',
+    received_events_url: 'https://api.github.com/users/Picard/received_events',
+    type: 'User',
+    site_admin: false,
+  },
+  comment: {
+    url: 'https://api.github.com/repos/Enterprise/Hello-World/issues/comments/1532203495',
+    html_url:
+      'https://api.github.com/repos/Enterprise/Hello-World/issues/1#issuecomment-1532203495',
+    issue_url: 'https://api.github.com/repos/Enterprise/Hello-World/issues/1',
+    id: 1532203495,
+    node_id: 'IC_kwDOH8y07c5bU5Hn',
+    user: {
+      login: 'Picard',
+      id: 121517347,
+      node_id: 'U_kgDOBz41Iw',
+      avatar_url: 'https://avatars1.githubusercontent.com/u/21031067?v=4',
+      gravatar_id: '',
+      url: 'https://api.github.com/users/Picard',
+      html_url: 'https://github.com/Picard',
+      followers_url: 'https://api.github.com/users/Picard/followers',
+      following_url:
+        'https://api.github.com/users/Picard/following{/other_user}',
+      gists_url: 'https://api.github.com/users/Picard/gists{/gist_id}',
+      starred_url: 'https://api.github.com/users/Picard/starred{/owner}{/repo}',
+      subscriptions_url: 'https://api.github.com/users/Picard/subscriptions',
+      organizations_url: 'https://api.github.com/users/Picard/orgs',
+      repos_url: 'https://api.github.com/users/Picard/repos',
+      events_url: 'https://api.github.com/users/Picard/events{/privacy}',
+      received_events_url:
+        'https://api.github.com/users/Picard/received_events',
+      type: 'User',
+      site_admin: false,
+    },
+  },
+};


### PR DESCRIPTION
Adds initial `Waiting for: *` labels for `sentry-docs` and `sentry`

1. Ensures that only one `Waiting for: *` label exists on issue
2. `Waiting for: Support` is added to all new issues opened by GTM or community members
3. `Waiting for: Product Owner` is added once issue has been routed
4. If issue has `Waiting for: Community` label and community member comments, `Waiting for: Community` label is removed and`Waiting for: Product Owner` is added