### PR TITLE
Send routing and triage timestamps for `Waiting for: *` labeling actions to BigQuery

### DIFF
--- a/src/utils/businessHours.test.ts
+++ b/src/utils/businessHours.test.ts
@@ -23,6 +23,8 @@ import {
   MAX_TRIAGE_DAYS,
   UNROUTED_LABEL,
   UNTRIAGED_LABEL,
+  WAITING_FOR_PRODUCT_OWNER_LABEL,
+  WAITING_FOR_SUPPORT_LABEL,
 } from '@/config';
 import { bolt } from '@api/slack';
 import { db } from '@utils/db';
@@ -269,6 +271,11 @@ describe('businessHours tests', function () {
       expect(result).toEqual(null);
     });
 
+    it('should not calculate SLO violation if label is waiting for product owner', async function () {
+      const result = await calculateSLOViolationRoute(WAITING_FOR_PRODUCT_OWNER_LABEL);
+      expect(result).toEqual(null);
+    });
+
     it('should calculate SLO violation if label is unrouted', async function () {
       const result = await calculateSLOViolationRoute(UNROUTED_LABEL);
       expect(result).not.toEqual(null);
@@ -396,10 +403,25 @@ describe('businessHours tests', function () {
       expect(result).not.toEqual(null);
     });
 
-    it('should calculate SLO violation if label is assigned to another product area', async function () {
+    it('should calculate SLO violation if label is waiting for product owner', async function () {
+      const result = await calculateSLOViolationTriage(WAITING_FOR_PRODUCT_OWNER_LABEL, [
+        { name: 'Product Area: Test' },
+      ]);
+      expect(result).not.toEqual(null);
+    });
+
+    it('should calculate SLO violation if label is assigned to another product area for untriaged label', async function () {
       const result = await calculateSLOViolationTriage(
         'Product Area: Rerouted',
-        [{ name: 'Status: Untriaged' }]
+        [{ name: UNTRIAGED_LABEL }]
+      );
+      expect(result).not.toEqual(null);
+    });
+
+    it('should calculate SLO violation if label is assigned to another product area for waiting for product owner label', async function () {
+      const result = await calculateSLOViolationTriage(
+        'Product Area: Rerouted',
+        [{ name: WAITING_FOR_PRODUCT_OWNER_LABEL }]
       );
       expect(result).not.toEqual(null);
     });


### PR DESCRIPTION
closes https://github.com/getsentry/team-ospo/issues/134