### PR TITLE
fix: Correct type for latest deploy

### DIFF
--- a/src/brain/pleaseDeployNotifier/actionViewUndeployedCommits.ts
+++ b/src/brain/pleaseDeployNotifier/actionViewUndeployedCommits.ts
@@ -7,6 +7,7 @@ import {
   GOCD_SENTRYIO_BE_PIPELINE_NAME,
   OWNER,
 } from '@/config';
+import { firstMaterialSHA } from '@/utils/gocdHelpers';
 import { getBlocksForCommit } from '@api/getBlocksForCommit';
 import { getClient } from '@api/github/getClient';
 import { getRelevantCommit } from '@api/github/getRelevantCommit';
@@ -68,7 +69,11 @@ export async function actionViewUndeployedCommits({
   }
 
   const octokit = await getClient(ClientType.App, OWNER);
-  const base = lastDeploy.pipeline_build_cause[0].modifications[0].revision;
+  const base = firstMaterialSHA(lastDeploy);
+  if (!base) {
+    // Failed to get base sha
+    return;
+  }
   const head = payload.value;
 
   // Get all getsentry commits between `base` and `head`

--- a/src/brain/saveGoCDStageEvents/index.ts
+++ b/src/brain/saveGoCDStageEvents/index.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/node';
 
-import { GoCDBuildMaterial, GoCDResponse } from '@/types';
+import { DBGoCDBuildMaterial, GoCDResponse } from '@/types';
 import { gocdevents } from '@api/gocdevents';
 import { db } from '@utils/db';
 
@@ -51,7 +51,7 @@ export async function handler(resBody: GoCDResponse) {
 }
 
 async function saveBuildMaterials(pipeline_id, pipeline) {
-  const gocdMaterials: Array<GoCDBuildMaterial> = [];
+  const gocdMaterials: Array<DBGoCDBuildMaterial> = [];
   for (const bc of pipeline['build-cause']) {
     if (!bc.material || bc.material.type != 'git') {
       // The material may be an upstream pipeline

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -250,12 +250,31 @@ interface GoCDGitConfiguration {
   url: string;
 }
 
-export interface GoCDBuildMaterial {
+export interface DBGoCDBuildMaterial {
   stage_material_id: string;
   pipeline_id: string;
   url: string;
   branch: string;
   revision: string;
+}
+
+export interface DBGoCDDeployment {
+  pipeline_id: string;
+
+  pipeline_name: string;
+  pipeline_counter: string;
+  pipeline_group: string;
+  pipeline_build_cause: Array<GoCDBuildCause>;
+
+  stage_name: string;
+  stage_counter: string;
+  stage_approval_type: string;
+  stage_approved_by: string;
+  stage_state: string;
+  stage_result: string;
+  stage_create_time: string;
+  stage_last_transition_time: string;
+  stage_jobs: Array<GoCDJob>;
 }
 
 type GoCDJobResult = 'Unknown' | 'Passed';

--- a/src/utils/db/getLatestDeploy.test.ts
+++ b/src/utils/db/getLatestDeploy.test.ts
@@ -1,0 +1,100 @@
+import { DB_TABLE_STAGES } from '@/brain/saveGoCDStageEvents';
+import { db } from '@utils/db';
+
+import { getLatestGoCDDeploy } from './getLatestDeploy';
+
+describe('getLatestDeploy', function () {
+  beforeAll(async function () {
+    await db.migrate.latest();
+  });
+
+  afterAll(async function () {
+    await db.destroy();
+  });
+
+  afterEach(async function () {
+    await db(DB_TABLE_STAGES).delete();
+  });
+
+  describe('getLatestGoCDDeploy', function () {
+    it('return nothing when no deploys', async function () {
+      const got = await getLatestGoCDDeploy(
+        'example-pipeline-group',
+        'example-pipeline-name'
+      );
+      expect(got).toEqual(undefined);
+    });
+
+    it('return latest GoCD deploy', async function () {
+      const materials = [
+        {
+          material: {
+            'git-configuration': {
+              'shallow-clone': false,
+              branch: 'master',
+              url: 'git@github.com:example/example-1.git',
+            },
+            type: 'git',
+          },
+          changed: false,
+          modifications: [
+            {
+              revision: 'abc123',
+              'modified-time': 'Oct 26, 2022, 5:05:17 PM',
+              data: {},
+            },
+          ],
+        },
+        {
+          material: {
+            'git-configuration': {
+              'shallow-clone': false,
+              branch: 'master',
+              url: 'git@github.com:example/example-2.git',
+            },
+            type: 'git',
+          },
+          changed: false,
+          modifications: [
+            {
+              revision: 'def456',
+              'modified-time': 'Oct 26, 2022, 5:05:17 PM',
+              data: {},
+            },
+          ],
+        },
+      ];
+
+      const pipeline = {
+        pipeline_id: 'pipeline-id-123',
+
+        pipeline_name: 'example-pipeline-name',
+        pipeline_counter: 2,
+        pipeline_group: 'example-pipeline-group',
+        pipeline_build_cause: JSON.stringify(materials),
+
+        stage_name: 'stage-name',
+        stage_counter: 1,
+        stage_approval_type: '',
+        stage_approved_by: '',
+        stage_state: 'unknown',
+        stage_result: 'unknown',
+        stage_create_time: new Date('2022-10-26T17:57:53.000Z'),
+        stage_last_transition_time: new Date('2022-10-26T17:57:53.000Z'),
+        stage_jobs: '{}',
+      };
+      await db(DB_TABLE_STAGES).insert(pipeline);
+
+      const got = await getLatestGoCDDeploy(
+        'example-pipeline-group',
+        'example-pipeline-name'
+      );
+      expect(got).toEqual(
+        Object.assign({}, pipeline, {
+          pipeline_build_cause: materials,
+          stage_jobs: {},
+        })
+      );
+    });
+  });
+});

--- a/src/utils/db/getLatestDeploy.ts
+++ b/src/utils/db/getLatestDeploy.ts
@@ -1,3 +1,6 @@
+import { DB_TABLE_STAGES } from '@/brain/saveGoCDStageEvents';
+import { DBGoCDDeployment } from '@/types';
+
 import { db } from '.';
 
 export async function getLatestDeploy(app_name: string) {
@@ -16,10 +19,10 @@ export async function getLatestDeploy(app_name: string) {
 export async function getLatestGoCDDeploy(
   pipeline_group: string,
   pipeline_name: string
-) {
+): Promise<DBGoCDDeployment | undefined> {
   return await db
     .select('*')
-    .from('gocd-stages')
+    .from(DB_TABLE_STAGES)
     .where({
       pipeline_group,
       pipeline_name,

--- a/src/utils/gocdHelpers.test.ts
+++ b/src/utils/gocdHelpers.test.ts
@@ -1,0 +1,41 @@
+import { firstMaterialSHA } from '@/utils/gocdHelpers';
+
+describe('firstMaterialSHA', () => {
+  it('return nothing for no deploy', async function () {
+    const got = firstMaterialSHA(null);
+    expect(got).toEqual(undefined);
+  });
+
+  it('return nothing no build materials', async function () {
+    const got = firstMaterialSHA({
+      pipeline_build_cause: [],
+    });
+    expect(got).toEqual(undefined);
+  });
+
+  it('return nothing no modifications', async function () {
+    const got = firstMaterialSHA({
+      pipeline_build_cause: [
+        {
+          modifications: [],
+        },
+      ],
+    });
+    expect(got).toEqual(undefined);
+  });
+
+  it('return first material sha', async function () {
+    const got = firstMaterialSHA({
+      pipeline_build_cause: [
+        {
+          modifications: [
+            {
+              revision: 'abc123',
+            },
+          ],
+        },
+      ],
+    });
+    expect(got).toEqual('abc123');
+  });
+});

--- a/src/utils/gocdHelpers.ts
+++ b/src/utils/gocdHelpers.ts
@@ -1,4 +1,4 @@
-import { GoCDPipeline } from '@types';
+import { DBGoCDDeployment, GoCDPipeline } from '@types';
 
 import {
   Color,
@@ -76,4 +76,20 @@ export function getProgressColor(pipeline: GoCDPipeline) {
     default:
       return Color.DANGER;
   }
+}
+
+export function firstMaterialSHA(
+  deploy: DBGoCDDeployment | undefined
+): string | void {
+  if (!deploy) {
+    return;
+  }
+  if (deploy.pipeline_build_cause.length == 0) {
+    return;
+  }
+  const bc = deploy.pipeline_build_cause[0];
+  if (bc.modifications.length == 0) {
+    return;
+  }
+  return bc.modifications[0].revision;
 }


### PR DESCRIPTION
This change should fix the issue of people not being alerted when their commits are being deployed.

The issue was me using a `sha` value that didn't exist anymore which was originally from the freight deploys.

Will follow up with cleanup to remove freight from eng-pipes and sweep for more places where types would find issues.