### PR TITLE
Add comparison URLs to deploy feed

### DIFF
--- a/src/api/github/__mocks__/getClient.ts
+++ b/src/api/github/__mocks__/getClient.ts
@@ -1,6 +1,8 @@
 import MockCompareCommits from '@test/compareCommits.json';
 import { workflow_run_job } from '@test/payloads/github/workflow_run_job';
 
+import { ClientType } from '../clientType';
+
 import { MockOctokitError } from './mockError';
 
 function mockClient() {
@@ -104,6 +106,8 @@ function mockClient() {
 
       listPullRequestsAssociatedWithCommit: jest.fn(),
 
+      getContent: jest.fn(),
+
       compareCommits: jest.fn(({ base, head }) => {
         // If base is older than head, then status will be ahead
         // For tests it might be easier to think of base/head as incrementing
@@ -153,13 +157,25 @@ function mockClient() {
   };
 }
 
-const mocks = {};
+let userMock;
+const appMocks = {};
 
-export async function getClient(org?: string) {
-  if (mocks[org]) {
-    return mocks[org];
+export async function getClient(type: ClientType, org?: string) {
+  if (type == ClientType.User) {
+    if (userMock) {
+      return userMock;
+    }
+    userMock = mockClient();
+    return userMock;
+  } else if (type == ClientType.App) {
+    if (!org) {
+      throw Error('Org required for mock getClient()');
+    }
+    if (appMocks[org]) {
+      return appMocks[org];
+    }
+
+    appMocks[org] = mockClient();
+    return appMocks[org];
   }
-
-  mocks[org] = mockClient();
-  return mocks[org];
 }

--- a/src/brain/projectsHandler/index.test.ts
+++ b/src/brain/projectsHandler/index.test.ts
@@ -36,7 +36,7 @@ describe('projectsHandler', function () {
   beforeEach(async function () {
     fastify = await buildServer(false);
     await projectsHandler();
-    octokit = await getClient(ClientType.App, 'Enterprise');
+    octokit = await getClient(ClientType.App, 'test-org');
   });
 
   afterEach(async function () {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -94,7 +94,7 @@ export interface GoCDBuildCause {
   modifications: Array<GoCDModification>;
 }
 
-interface GoCDModification {
+export interface GoCDModification {
   revision: string;
   'modified-time': string;
 }


### PR DESCRIPTION
This adds a link to compare the commits in a GoCD deploy.

Sentaurs seem to want something in this space and it would have helped identify issues with the update notifications.
