### PR TITLE
Fix module resolution in VS Code

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "esModuleInterop": true,
     "declaration": true,
     "resolveJsonModule": true,
-    "baseUrl": ".",
+    "baseUrl": "./",
     "paths": {
       "_comment": ["⚠️  Keep this in sync with jest.config.ts and package.json. ⚠️ "],
       "@/*": ["src/*"],


### PR DESCRIPTION
This makes VS Code find the modules imported via `@*`