### PR TITLE
Bugfixes for getsantry issue/project handling

### DIFF
--- a/src/brain/issueLabelHandler/followups.ts
+++ b/src/brain/issueLabelHandler/followups.ts
@@ -30,6 +30,13 @@ function isNotWaitingForLabel(payload) {
   return !payload.label?.name.startsWith(WAITING_FOR_LABEL_PREFIX);
 }
 
+function isNotWaitingForCommunity(payload) {
+  const { issue } = payload;
+  return !issue?.labels.some(
+    ({ name }) => name === WAITING_FOR_COMMUNITY_LABEL
+  );
+}
+
 // Markers of State
 
 export async function updateCommunityFollowups({
@@ -45,6 +52,7 @@ export async function updateCommunityFollowups({
   const reasonsToDoNothing = [
     isNotInARepoWeCareAboutForFollowups,
     isNotFromAnExternalOrGTMUser,
+    isNotWaitingForCommunity,
     isFromABot,
   ];
 

--- a/src/brain/issueLabelHandler/index.test.ts
+++ b/src/brain/issueLabelHandler/index.test.ts
@@ -153,31 +153,6 @@ describe('issueLabelHandler', function () {
     );
   }
 
-  async function editProjectField(
-    projectNodeId?: string,
-    fieldNodeId?: string
-  ) {
-    const projectPayload = {
-      organization: { login: 'test-org' },
-      projects_v2_item: {
-        project_node_id: projectNodeId || 'test-project-node-id',
-        node_id: 'test-node-id',
-        content_node_id: 'test-content-node-id',
-      },
-      changes: {
-        field_value: {
-          field_node_id: fieldNodeId,
-        },
-      },
-    };
-    await createGitHubEvent(
-      fastify,
-      // @ts-expect-error
-      'projects_v2_item.edited',
-      projectPayload
-    );
-  }
-
   // Expectations
 
   function expectUnrouted() {
@@ -579,6 +554,22 @@ describe('issueLabelHandler', function () {
           UNTRIAGED_LABEL,
           'Product Area: Test',
           WAITING_FOR_COMMUNITY_LABEL,
+        ])
+      );
+    });
+
+    it('should not add `Waiting for: Product Owner` label when community member comments and issue is not waiting for community', async function () {
+      await setupIssue();
+      jest
+        .spyOn(helpers, 'isNotFromAnExternalOrGTMUser')
+        .mockReturnValue(false);
+      await addLabel(WAITING_FOR_SUPPORT_LABEL, 'sentry-docs')
+      await addComment('sentry-docs', 'Picard');
+      expect(octokit.issues._labels).toEqual(
+        new Set([
+          UNTRIAGED_LABEL,
+          'Product Area: Test',
+          WAITING_FOR_SUPPORT_LABEL
         ])
       );
     });

--- a/src/brain/projectsHandler/index.test.ts
+++ b/src/brain/projectsHandler/index.test.ts
@@ -130,5 +130,14 @@ describe('projectsHandler', function () {
       expect(octokitIssuesSpy).toHaveBeenCalled();
       expect(octokit.issues._labels).toContain('Waiting for: Community');
     });
+
+    it('should handle project event if field value is unset', async function () {
+      octokitIssuesSpy = jest.spyOn(octokit.issues, 'addLabels');
+      getKeyValueFromProjectFieldSpy.mockReturnValue(undefined);
+      await editProjectField(ISSUES_PROJECT_NODE_ID, STATUS_FIELD_ID);
+      expect(getKeyValueFromProjectFieldSpy).toHaveBeenCalled();
+      expect(getIssueDetailsFromNodeIdSpy).not.toHaveBeenCalled();
+      expect(octokitIssuesSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/brain/projectsHandler/project.ts
+++ b/src/brain/projectsHandler/project.ts
@@ -67,6 +67,12 @@ export async function syncLabelsWithProjectField({
     fieldName,
     octokit
   );
+
+  // Single select field value has been unset, so don't do anything
+  if (fieldValue == null) {
+    return;
+  }
+
   const issueInfo = await getIssueDetailsFromNodeId(
     payload.projects_v2_item.content_node_id,
     octokit


### PR DESCRIPTION
1. Only track followups from community when `Waiting for: Community` label is applied
2. When the project field value of an issue is unset, handle gracefully (should resolve https://sentry.sentry.io/issues/4235971037/activity/?project=5246761&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=3&utc=true)