### PR TITLE
Move tracking issue due dates to `Issues Someone Else Cares About` project

### DIFF
--- a/src/brain/issueLabelHandler/followups.ts
+++ b/src/brain/issueLabelHandler/followups.ts
@@ -4,27 +4,30 @@ import moment from 'moment-timezone';
 
 import { ClientType } from '@/api/github/clientType';
 import {
+  RESPONSE_DUE_DATE_FIELD_ID,
   SENTRY_MONOREPOS,
   SENTRY_REPOS,
   STATUS_FIELD_ID,
+  UNROUTED_LABEL,
+  UNTRIAGED_LABEL,
   WAITING_FOR_COMMUNITY_LABEL,
   WAITING_FOR_LABEL_PREFIX,
   WAITING_FOR_PRODUCT_OWNER_LABEL,
-  RESPONSE_DUE_DATE_FIELD_ID,
-  UNTRIAGED_LABEL,
   WAITING_FOR_SUPPORT_LABEL,
-  UNROUTED_LABEL,
 } from '@/config';
 import {
   addIssueToGlobalIssuesProject,
   isNotFromAnExternalOrGTMUser,
+  modifyDueByDate,
   modifyProjectIssueField,
   shouldSkip,
-  modifyDueByDate,
 } from '@/utils/githubEventHelpers';
 import { getClient } from '@api/github/getClient';
+import {
+  calculateSLOViolationRoute,
+  calculateSLOViolationTriage,
+} from '@utils/businessHours';
 import { isFromABot } from '@utils/isFromABot';
-import { calculateSLOViolationTriage, calculateSLOViolationRoute } from '@utils/businessHours';
 
 const REPOS_TO_TRACK_FOR_FOLLOWUPS = new Set([
   ...SENTRY_REPOS,
@@ -166,20 +169,22 @@ export async function ensureOneWaitingForLabel({
 
   await modifyProjectIssueField(itemId, labelName, STATUS_FIELD_ID, octokit);
 
-  let timeToTriageBy
+  let timeToRespondBy;
   if (labelName === WAITING_FOR_PRODUCT_OWNER_LABEL) {
-    timeToTriageBy = await calculateSLOViolationTriage(UNTRIAGED_LABEL, issue.labels) || moment().toISOString();
-  }
-  else if (labelName === WAITING_FOR_SUPPORT_LABEL) {
-    timeToTriageBy = await calculateSLOViolationRoute(UNROUTED_LABEL) || moment().toISOString()
-  }
-  else{
-    timeToTriageBy = "";
+    timeToRespondBy =
+      (await calculateSLOViolationTriage(UNTRIAGED_LABEL, issue.labels)) ||
+      moment().toISOString();
+  } else if (labelName === WAITING_FOR_SUPPORT_LABEL) {
+    timeToRespondBy =
+      (await calculateSLOViolationRoute(UNROUTED_LABEL)) ||
+      moment().toISOString();
+  } else {
+    timeToRespondBy = '';
   }
 
   await modifyDueByDate(
     itemId,
-    timeToTriageBy,
+    timeToRespondBy,
     RESPONSE_DUE_DATE_FIELD_ID,
     octokit
   );

--- a/src/brain/issueLabelHandler/index.test.ts
+++ b/src/brain/issueLabelHandler/index.test.ts
@@ -3,13 +3,13 @@ import { createGitHubEvent } from '@test/utils/github';
 import { getLabelsTable, slackHandler } from '@/brain/issueNotifier';
 import { buildServer } from '@/buildServer';
 import {
+  RESPONSE_DUE_DATE_FIELD_ID,
+  STATUS_FIELD_ID,
   UNROUTED_LABEL,
   UNTRIAGED_LABEL,
   WAITING_FOR_COMMUNITY_LABEL,
   WAITING_FOR_PRODUCT_OWNER_LABEL,
   WAITING_FOR_SUPPORT_LABEL,
-  STATUS_FIELD_ID,
-  RESPONSE_DUE_DATE_FIELD_ID,
 } from '@/config';
 import { Fastify } from '@/types';
 import { defaultErrorHandler, githubEvents } from '@api/github';
@@ -458,7 +458,9 @@ describe('issueLabelHandler', function () {
       await addLabel('Product Area: Rerouted', 'sentry-docs');
       expect(octokit.issues._labels).toContain('Product Area: Rerouted');
       expect(octokit.issues._labels).toContain('Waiting for: Community');
-      expect(octokit.issues._labels).not.toContain('Waiting for: Product Owner');
+      expect(octokit.issues._labels).not.toContain(
+        'Waiting for: Product Owner'
+      );
       expect(octokit.issues._comments).toEqual([
         'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️',
         'Routing to @getsentry/product-owners-test for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️',
@@ -516,19 +518,23 @@ describe('issueLabelHandler', function () {
   });
 
   describe('followups test cases', function () {
-    let modifyProjectIssueFieldSpy, modifyDueByDateSpy, addIssueToGlobalIssuesProjectSpy;
+    let modifyProjectIssueFieldSpy,
+      modifyDueByDateSpy,
+      addIssueToGlobalIssuesProjectSpy;
     beforeAll(function () {
       modifyProjectIssueFieldSpy = jest
         .spyOn(helpers, 'modifyProjectIssueField')
         .mockImplementation(jest.fn());
-      modifyDueByDateSpy = jest.spyOn(helpers, 'modifyDueByDate').mockImplementation(jest.fn());
+      modifyDueByDateSpy = jest
+        .spyOn(helpers, 'modifyDueByDate')
+        .mockImplementation(jest.fn());
       addIssueToGlobalIssuesProjectSpy = jest
         .spyOn(helpers, 'addIssueToGlobalIssuesProject')
         .mockReturnValue('itemId');
-    })
+    });
     afterEach(function () {
       jest.clearAllMocks();
-    })
+    });
     const setupIssue = async () => {
       await createIssue('sentry-docs');
       await addLabel('Product Area: Test', 'sentry-docs');
@@ -559,8 +565,18 @@ describe('issueLabelHandler', function () {
           WAITING_FOR_SUPPORT_LABEL,
         ])
       );
-      expect(modifyProjectIssueFieldSpy).toHaveBeenLastCalledWith('itemId', WAITING_FOR_SUPPORT_LABEL, STATUS_FIELD_ID, octokit);
-      expect(modifyDueByDateSpy).toHaveBeenLastCalledWith('itemId', '2022-12-20T00:00:00.000Z', RESPONSE_DUE_DATE_FIELD_ID, octokit);
+      expect(modifyProjectIssueFieldSpy).toHaveBeenLastCalledWith(
+        'itemId',
+        WAITING_FOR_SUPPORT_LABEL,
+        STATUS_FIELD_ID,
+        octokit
+      );
+      expect(modifyDueByDateSpy).toHaveBeenLastCalledWith(
+        'itemId',
+        '2022-12-20T00:00:00.000Z',
+        RESPONSE_DUE_DATE_FIELD_ID,
+        octokit
+      );
     });
 
     it('should not add `Waiting for: Product Owner` label when product owner/GTM member comments and issue is waiting for community', async function () {
@@ -575,8 +591,18 @@ describe('issueLabelHandler', function () {
           WAITING_FOR_COMMUNITY_LABEL,
         ])
       );
-      expect(modifyProjectIssueFieldSpy).toHaveBeenLastCalledWith('itemId', WAITING_FOR_COMMUNITY_LABEL, STATUS_FIELD_ID, octokit);
-      expect(modifyDueByDateSpy).toHaveBeenLastCalledWith('itemId', '', RESPONSE_DUE_DATE_FIELD_ID, octokit);
+      expect(modifyProjectIssueFieldSpy).toHaveBeenLastCalledWith(
+        'itemId',
+        WAITING_FOR_COMMUNITY_LABEL,
+        STATUS_FIELD_ID,
+        octokit
+      );
+      expect(modifyDueByDateSpy).toHaveBeenLastCalledWith(
+        'itemId',
+        '',
+        RESPONSE_DUE_DATE_FIELD_ID,
+        octokit
+      );
     });
 
     it('should not add `Waiting for: Product Owner` label when contractor comments and issue is waiting for community', async function () {
@@ -591,8 +617,18 @@ describe('issueLabelHandler', function () {
           WAITING_FOR_COMMUNITY_LABEL,
         ])
       );
-      expect(modifyProjectIssueFieldSpy).toHaveBeenLastCalledWith('itemId', WAITING_FOR_COMMUNITY_LABEL, STATUS_FIELD_ID, octokit);
-      expect(modifyDueByDateSpy).toHaveBeenLastCalledWith('itemId', '', RESPONSE_DUE_DATE_FIELD_ID, octokit);
+      expect(modifyProjectIssueFieldSpy).toHaveBeenLastCalledWith(
+        'itemId',
+        WAITING_FOR_COMMUNITY_LABEL,
+        STATUS_FIELD_ID,
+        octokit
+      );
+      expect(modifyDueByDateSpy).toHaveBeenLastCalledWith(
+        'itemId',
+        '',
+        RESPONSE_DUE_DATE_FIELD_ID,
+        octokit
+      );
     });
 
     it('should not add `Waiting for: Product Owner` label when community member comments and issue is not waiting for community', async function () {
@@ -600,17 +636,27 @@ describe('issueLabelHandler', function () {
       jest
         .spyOn(helpers, 'isNotFromAnExternalOrGTMUser')
         .mockReturnValue(false);
-      await addLabel(WAITING_FOR_SUPPORT_LABEL, 'sentry-docs')
+      await addLabel(WAITING_FOR_SUPPORT_LABEL, 'sentry-docs');
       await addComment('sentry-docs', 'Picard');
       expect(octokit.issues._labels).toEqual(
         new Set([
           UNTRIAGED_LABEL,
           'Product Area: Test',
-          WAITING_FOR_SUPPORT_LABEL
+          WAITING_FOR_SUPPORT_LABEL,
         ])
       );
-      expect(modifyProjectIssueFieldSpy).toHaveBeenLastCalledWith('itemId', WAITING_FOR_SUPPORT_LABEL, STATUS_FIELD_ID, octokit);
-      expect(modifyDueByDateSpy).toHaveBeenLastCalledWith('itemId', '2022-12-20T00:00:00.000Z', RESPONSE_DUE_DATE_FIELD_ID, octokit);
+      expect(modifyProjectIssueFieldSpy).toHaveBeenLastCalledWith(
+        'itemId',
+        WAITING_FOR_SUPPORT_LABEL,
+        STATUS_FIELD_ID,
+        octokit
+      );
+      expect(modifyDueByDateSpy).toHaveBeenLastCalledWith(
+        'itemId',
+        '2022-12-20T00:00:00.000Z',
+        RESPONSE_DUE_DATE_FIELD_ID,
+        octokit
+      );
     });
 
     it('should add `Waiting for: Product Owner` label when community member comments and issue is waiting for community', async function () {
@@ -629,8 +675,18 @@ describe('issueLabelHandler', function () {
       );
       // Simulate GH webhook being thrown when Waiting for: Product Owner label is added
       await addLabel(WAITING_FOR_PRODUCT_OWNER_LABEL);
-      expect(modifyProjectIssueFieldSpy).toHaveBeenLastCalledWith('itemId', WAITING_FOR_PRODUCT_OWNER_LABEL, STATUS_FIELD_ID, octokit);
-      expect(modifyDueByDateSpy).toHaveBeenLastCalledWith('itemId', '2022-12-21T00:00:00.000Z', RESPONSE_DUE_DATE_FIELD_ID, octokit);
+      expect(modifyProjectIssueFieldSpy).toHaveBeenLastCalledWith(
+        'itemId',
+        WAITING_FOR_PRODUCT_OWNER_LABEL,
+        STATUS_FIELD_ID,
+        octokit
+      );
+      expect(modifyDueByDateSpy).toHaveBeenLastCalledWith(
+        'itemId',
+        '2022-12-21T00:00:00.000Z',
+        RESPONSE_DUE_DATE_FIELD_ID,
+        octokit
+      );
     });
 
     it('should not modify labels when community member comments and issue is waiting for product owner', async function () {
@@ -647,8 +703,18 @@ describe('issueLabelHandler', function () {
           WAITING_FOR_PRODUCT_OWNER_LABEL,
         ])
       );
-      expect(modifyProjectIssueFieldSpy).toHaveBeenLastCalledWith('itemId', WAITING_FOR_PRODUCT_OWNER_LABEL, STATUS_FIELD_ID, octokit);
-      expect(modifyDueByDateSpy).toHaveBeenLastCalledWith('itemId', '2022-12-21T00:00:00.000Z', RESPONSE_DUE_DATE_FIELD_ID, octokit);
+      expect(modifyProjectIssueFieldSpy).toHaveBeenLastCalledWith(
+        'itemId',
+        WAITING_FOR_PRODUCT_OWNER_LABEL,
+        STATUS_FIELD_ID,
+        octokit
+      );
+      expect(modifyDueByDateSpy).toHaveBeenLastCalledWith(
+        'itemId',
+        '2022-12-21T00:00:00.000Z',
+        RESPONSE_DUE_DATE_FIELD_ID,
+        octokit
+      );
     });
   });
 });

--- a/src/brain/issueLabelHandler/index.test.ts
+++ b/src/brain/issueLabelHandler/index.test.ts
@@ -8,6 +8,8 @@ import {
   WAITING_FOR_COMMUNITY_LABEL,
   WAITING_FOR_PRODUCT_OWNER_LABEL,
   WAITING_FOR_SUPPORT_LABEL,
+  STATUS_FIELD_ID,
+  RESPONSE_DUE_DATE_FIELD_ID,
 } from '@/config';
 import { Fastify } from '@/types';
 import { defaultErrorHandler, githubEvents } from '@api/github';
@@ -209,9 +211,7 @@ describe('issueLabelHandler', function () {
     beforeAll(function () {
       addIssueToGlobalIssuesProjectSpy = jest
         .spyOn(helpers, 'addIssueToGlobalIssuesProject')
-        .mockReturnValue({
-          addProjectV2ItemById: { item: { id: 'PROJECT_ID' } },
-        });
+        .mockReturnValue('itemId');
     });
     afterEach(function () {
       jest.clearAllMocks();
@@ -359,7 +359,7 @@ describe('issueLabelHandler', function () {
       // Simulate GitHub adding Waiting for Support Label to send webhook
       await addLabel(WAITING_FOR_SUPPORT_LABEL);
       expect(octokit.issues._comments).toEqual([
-        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route), due by **<time datetime=2022-12-20T00:00:00.000Z>Monday, December 19th at 4:00 pm</time> (sfo)**. ⏲️',
+        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️',
       ]);
       expect(addIssueToGlobalIssuesProjectSpy).toHaveBeenCalled();
     });
@@ -371,7 +371,7 @@ describe('issueLabelHandler', function () {
       // Simulate GitHub adding Waiting for Support Label to send webhook
       await addLabel(WAITING_FOR_SUPPORT_LABEL);
       expect(octokit.issues._comments).toEqual([
-        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route), due by **<time datetime=2022-12-20T00:00:00.000Z>Monday, December 19th at 4:00 pm</time> (sfo)**. ⏲️',
+        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️',
       ]);
       expect(addIssueToGlobalIssuesProjectSpy).toHaveBeenCalled();
     });
@@ -400,8 +400,8 @@ describe('issueLabelHandler', function () {
       expect(octokit.issues._labels).not.toContain(WAITING_FOR_SUPPORT_LABEL);
       expect(octokit.issues._labels).toContain(WAITING_FOR_PRODUCT_OWNER_LABEL);
       expect(octokit.issues._comments).toEqual([
-        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route), due by **<time datetime=2022-12-20T00:00:00.000Z>Monday, December 19th at 4:00 pm</time> (sfo)**. ⏲️',
-        'Routing to @getsentry/product-owners-test for [triage](https://develop.sentry.dev/processing-tickets/#3-triage), due by **<time datetime=2022-12-21T00:00:00.000Z>Tuesday, December 20th at 4:00 pm</time> (sfo)**. ⏲️',
+        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️',
+        'Routing to @getsentry/product-owners-test for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️',
       ]);
       expect(modifyProjectIssueFieldSpy).toHaveBeenCalled();
     });
@@ -414,7 +414,7 @@ describe('issueLabelHandler', function () {
       // Simulate GitHub adding Waiting for Support Label to send webhook
       await addLabel(WAITING_FOR_SUPPORT_LABEL);
       expect(octokit.issues._comments).toEqual([
-        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route), due by **<time datetime=2022-12-20T00:00:00.000Z>Monday, December 19th at 4:00 pm</time> (sfo)**. ⏲️',
+        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️',
       ]);
       expect(modifyProjectIssueFieldSpy).toHaveBeenCalled();
     });
@@ -427,8 +427,8 @@ describe('issueLabelHandler', function () {
       expect(octokit.issues._labels).not.toContain(WAITING_FOR_SUPPORT_LABEL);
       expect(octokit.issues._labels).toContain(WAITING_FOR_PRODUCT_OWNER_LABEL);
       expect(octokit.issues._comments).toEqual([
-        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route), due by **<time datetime=2022-12-20T00:00:00.000Z>Monday, December 19th at 4:00 pm</time> (sfo)**. ⏲️',
-        'Failed to route for Product Area: Does Not Exist. Defaulting to @getsentry/open-source for [triage](https://develop.sentry.dev/processing-tickets/#3-triage), due by **<time datetime=2022-12-21T00:00:00.000Z>Tuesday, December 20th at 4:00 pm</time> (sfo)**. ⏲️',
+        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️',
+        'Failed to route for Product Area: Does Not Exist. Defaulting to @getsentry/open-source for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️',
       ]);
       expect(modifyProjectIssueFieldSpy).toHaveBeenCalled();
     });
@@ -442,9 +442,9 @@ describe('issueLabelHandler', function () {
       expect(octokit.issues._labels).toContain('Product Area: Rerouted');
       expect(octokit.issues._labels).not.toContain('Product Area: Test');
       expect(octokit.issues._comments).toEqual([
-        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route), due by **<time datetime=2022-12-20T00:00:00.000Z>Monday, December 19th at 4:00 pm</time> (sfo)**. ⏲️',
-        'Routing to @getsentry/product-owners-test for [triage](https://develop.sentry.dev/processing-tickets/#3-triage), due by **<time datetime=2022-12-21T00:00:00.000Z>Tuesday, December 20th at 4:00 pm</time> (sfo)**. ⏲️',
-        'Routing to @getsentry/product-owners-rerouted for [triage](https://develop.sentry.dev/processing-tickets/#3-triage), due by **<time datetime=2022-12-21T00:00:00.000Z>Tuesday, December 20th at 4:00 pm</time> (sfo)**. ⏲️',
+        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️',
+        'Routing to @getsentry/product-owners-test for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️',
+        'Routing to @getsentry/product-owners-rerouted for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️',
       ]);
       expect(modifyProjectIssueFieldSpy).toHaveBeenCalled();
     });
@@ -460,9 +460,9 @@ describe('issueLabelHandler', function () {
       expect(octokit.issues._labels).toContain('Waiting for: Community');
       expect(octokit.issues._labels).not.toContain('Waiting for: Product Owner');
       expect(octokit.issues._comments).toEqual([
-        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route), due by **<time datetime=2022-12-20T00:00:00.000Z>Monday, December 19th at 4:00 pm</time> (sfo)**. ⏲️',
-        'Routing to @getsentry/product-owners-test for [triage](https://develop.sentry.dev/processing-tickets/#3-triage), due by **<time datetime=2022-12-21T00:00:00.000Z>Tuesday, December 20th at 4:00 pm</time> (sfo)**. ⏲️',
-        'Routing to @getsentry/product-owners-rerouted for [triage](https://develop.sentry.dev/processing-tickets/#3-triage), due by **<time datetime=2022-12-21T00:00:00.000Z>Tuesday, December 20th at 4:00 pm</time> (sfo)**. ⏲️',
+        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️',
+        'Routing to @getsentry/product-owners-test for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️',
+        'Routing to @getsentry/product-owners-rerouted for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️',
       ]);
       expect(modifyProjectIssueFieldSpy).toHaveBeenCalled();
     });
@@ -477,8 +477,8 @@ describe('issueLabelHandler', function () {
       expect(octokit.issues._labels).toContain('Product Area: Rerouted');
       expect(octokit.issues._labels).toContain('Product Area: Test');
       expect(octokit.issues._comments).toEqual([
-        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route), due by **<time datetime=2022-12-20T00:00:00.000Z>Monday, December 19th at 4:00 pm</time> (sfo)**. ⏲️',
-        'Routing to @getsentry/product-owners-test for [triage](https://develop.sentry.dev/processing-tickets/#3-triage), due by **<time datetime=2022-12-21T00:00:00.000Z>Tuesday, December 20th at 4:00 pm</time> (sfo)**. ⏲️',
+        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️',
+        'Routing to @getsentry/product-owners-test for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️',
       ]);
       expect(modifyProjectIssueFieldSpy).toHaveBeenCalled();
     });
@@ -493,8 +493,8 @@ describe('issueLabelHandler', function () {
       expect(octokit.issues._labels).toContain('Product Area: Rerouted');
       expect(octokit.issues._labels).toContain('Product Area: Test');
       expect(octokit.issues._comments).toEqual([
-        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route), due by **<time datetime=2022-12-20T00:00:00.000Z>Monday, December 19th at 4:00 pm</time> (sfo)**. ⏲️',
-        'Routing to @getsentry/product-owners-test for [triage](https://develop.sentry.dev/processing-tickets/#3-triage), due by **<time datetime=2022-12-21T00:00:00.000Z>Tuesday, December 20th at 4:00 pm</time> (sfo)**. ⏲️',
+        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️',
+        'Routing to @getsentry/product-owners-test for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️',
       ]);
       expect(modifyProjectIssueFieldSpy).toHaveBeenCalled();
     });
@@ -508,41 +508,27 @@ describe('issueLabelHandler', function () {
       expect(octokit.issues._labels).toContain('Product Area: Rerouted');
       expect(octokit.issues._labels).toContain('Product Area: Test');
       expect(octokit.issues._comments).toEqual([
-        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route), due by **<time datetime=2022-12-20T00:00:00.000Z>Monday, December 19th at 4:00 pm</time> (sfo)**. ⏲️',
-        'Routing to @getsentry/product-owners-test for [triage](https://develop.sentry.dev/processing-tickets/#3-triage), due by **<time datetime=2022-12-21T00:00:00.000Z>Tuesday, December 20th at 4:00 pm</time> (sfo)**. ⏲️',
+        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️',
+        'Routing to @getsentry/product-owners-test for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️',
       ]);
       expect(modifyProjectIssueFieldSpy).toHaveBeenCalled();
-    });
-
-    it('uses different timestamp for eu office', async function () {
-      await createIssue('sentry-docs');
-      const command = {
-        channel_id: 'CHNLIDRND1',
-        text: 'Test vie',
-      };
-      const client = {
-        conversations: {
-          info: jest
-            .fn()
-            .mockReturnValue({ channel: { name: 'test', is_member: true } }),
-          join: jest.fn(),
-        },
-      };
-      await slackHandler({ command, ack, say, respond, client });
-      jest
-        .spyOn(businessHourFunctions, 'calculateSLOViolationTriage')
-        .mockReturnValue('2022-12-21T13:00:00.000Z');
-      await addLabel('Product Area: Test', 'sentry-docs');
-      expectUntriaged();
-      expectRouted();
-      expect(octokit.issues._comments).toEqual([
-        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route), due by **<time datetime=2022-12-20T00:00:00.000Z>Monday, December 19th at 4:00 pm</time> (sfo)**. ⏲️',
-        'Routing to @getsentry/product-owners-test for [triage](https://develop.sentry.dev/processing-tickets/#3-triage), due by **<time datetime=2022-12-21T13:00:00.000Z>Wednesday, December 21st at 14:00</time> (vie)**. ⏲️',
-      ]);
     });
   });
 
   describe('followups test cases', function () {
+    let modifyProjectIssueFieldSpy, modifyDueByDateSpy, addIssueToGlobalIssuesProjectSpy;
+    beforeAll(function () {
+      modifyProjectIssueFieldSpy = jest
+        .spyOn(helpers, 'modifyProjectIssueField')
+        .mockImplementation(jest.fn());
+      modifyDueByDateSpy = jest.spyOn(helpers, 'modifyDueByDate').mockImplementation(jest.fn());
+      addIssueToGlobalIssuesProjectSpy = jest
+        .spyOn(helpers, 'addIssueToGlobalIssuesProject')
+        .mockReturnValue('itemId');
+    })
+    afterEach(function () {
+      jest.clearAllMocks();
+    })
     const setupIssue = async () => {
       await createIssue('sentry-docs');
       await addLabel('Product Area: Test', 'sentry-docs');
@@ -573,6 +559,8 @@ describe('issueLabelHandler', function () {
           WAITING_FOR_SUPPORT_LABEL,
         ])
       );
+      expect(modifyProjectIssueFieldSpy).toHaveBeenLastCalledWith('itemId', WAITING_FOR_SUPPORT_LABEL, STATUS_FIELD_ID, octokit);
+      expect(modifyDueByDateSpy).toHaveBeenLastCalledWith('itemId', '2022-12-20T00:00:00.000Z', RESPONSE_DUE_DATE_FIELD_ID, octokit);
     });
 
     it('should not add `Waiting for: Product Owner` label when product owner/GTM member comments and issue is waiting for community', async function () {
@@ -587,6 +575,8 @@ describe('issueLabelHandler', function () {
           WAITING_FOR_COMMUNITY_LABEL,
         ])
       );
+      expect(modifyProjectIssueFieldSpy).toHaveBeenLastCalledWith('itemId', WAITING_FOR_COMMUNITY_LABEL, STATUS_FIELD_ID, octokit);
+      expect(modifyDueByDateSpy).toHaveBeenLastCalledWith('itemId', '', RESPONSE_DUE_DATE_FIELD_ID, octokit);
     });
 
     it('should not add `Waiting for: Product Owner` label when contractor comments and issue is waiting for community', async function () {
@@ -594,6 +584,15 @@ describe('issueLabelHandler', function () {
       await addLabel(WAITING_FOR_COMMUNITY_LABEL, 'sentry-docs');
       jest.spyOn(helpers, 'isNotFromAnExternalOrGTMUser').mockReturnValue(true);
       await addComment('sentry-docs', 'Picard', 'COLLABORATOR');
+      expect(octokit.issues._labels).toEqual(
+        new Set([
+          UNTRIAGED_LABEL,
+          'Product Area: Test',
+          WAITING_FOR_COMMUNITY_LABEL,
+        ])
+      );
+      expect(modifyProjectIssueFieldSpy).toHaveBeenLastCalledWith('itemId', WAITING_FOR_COMMUNITY_LABEL, STATUS_FIELD_ID, octokit);
+      expect(modifyDueByDateSpy).toHaveBeenLastCalledWith('itemId', '', RESPONSE_DUE_DATE_FIELD_ID, octokit);
     });
 
     it('should not add `Waiting for: Product Owner` label when community member comments and issue is not waiting for community', async function () {
@@ -610,6 +609,8 @@ describe('issueLabelHandler', function () {
           WAITING_FOR_SUPPORT_LABEL
         ])
       );
+      expect(modifyProjectIssueFieldSpy).toHaveBeenLastCalledWith('itemId', WAITING_FOR_SUPPORT_LABEL, STATUS_FIELD_ID, octokit);
+      expect(modifyDueByDateSpy).toHaveBeenLastCalledWith('itemId', '2022-12-20T00:00:00.000Z', RESPONSE_DUE_DATE_FIELD_ID, octokit);
     });
 
     it('should add `Waiting for: Product Owner` label when community member comments and issue is waiting for community', async function () {
@@ -626,6 +627,10 @@ describe('issueLabelHandler', function () {
           WAITING_FOR_PRODUCT_OWNER_LABEL,
         ])
       );
+      // Simulate GH webhook being thrown when Waiting for: Product Owner label is added
+      await addLabel(WAITING_FOR_PRODUCT_OWNER_LABEL);
+      expect(modifyProjectIssueFieldSpy).toHaveBeenLastCalledWith('itemId', WAITING_FOR_PRODUCT_OWNER_LABEL, STATUS_FIELD_ID, octokit);
+      expect(modifyDueByDateSpy).toHaveBeenLastCalledWith('itemId', '2022-12-21T00:00:00.000Z', RESPONSE_DUE_DATE_FIELD_ID, octokit);
     });
 
     it('should not modify labels when community member comments and issue is waiting for product owner', async function () {
@@ -642,6 +647,8 @@ describe('issueLabelHandler', function () {
           WAITING_FOR_PRODUCT_OWNER_LABEL,
         ])
       );
+      expect(modifyProjectIssueFieldSpy).toHaveBeenLastCalledWith('itemId', WAITING_FOR_PRODUCT_OWNER_LABEL, STATUS_FIELD_ID, octokit);
+      expect(modifyDueByDateSpy).toHaveBeenLastCalledWith('itemId', '2022-12-21T00:00:00.000Z', RESPONSE_DUE_DATE_FIELD_ID, octokit);
     });
   });
 });

--- a/src/brain/issueLabelHandler/route.ts
+++ b/src/brain/issueLabelHandler/route.ts
@@ -1,19 +1,15 @@
 import { EmitterWebhookEvent } from '@octokit/webhooks';
 import * as Sentry from '@sentry/node';
-import moment from 'moment-timezone';
 
 import {
   BACKLOG_LABEL,
   IN_PROGRESS_LABEL,
   SENTRY_MONOREPOS,
-  OFFICE_TIME_ZONES,
-  OFFICES_24_HOUR,
   PRODUCT_AREA_FIELD_ID,
   PRODUCT_AREA_LABEL_PREFIX,
   PRODUCT_AREA_UNKNOWN,
   SENTRY_ORG,
   STATUS_LABEL_PREFIX,
-  UNKNOWN_LABEL,
   UNROUTED_LABEL,
   UNTRIAGED_LABEL,
   WAITING_FOR_PRODUCT_OWNER_LABEL,
@@ -25,12 +21,6 @@ import {
   modifyProjectIssueField,
   shouldSkip,
 } from '@/utils/githubEventHelpers';
-import {
-  calculateSLOViolationRoute,
-  calculateSLOViolationTriage,
-  getSortedOffices,
-  isTimeInBusinessHours,
-} from '@utils/businessHours';
 import { slugizeProductArea } from '@utils/slugizeProductArea';
 
 const REPOS_TO_TRACK_FOR_ROUTING = new Set(SENTRY_MONOREPOS);
@@ -101,14 +91,11 @@ export async function markUnrouted({
     labels: [UNROUTED_LABEL, WAITING_FOR_SUPPORT_LABEL],
   });
 
-  const timeToRouteBy = await calculateSLOViolationRoute(UNROUTED_LABEL);
-  const { readableDueByDate, lastOfficeInBusinessHours } =
-    await getReadableTimeStamp(timeToRouteBy, UNKNOWN_LABEL);
   await octokit.issues.createComment({
     owner,
     repo: repo,
     issue_number: issueNumber,
-    body: `Assigning to @${SENTRY_ORG}/support for [routing](https://open.sentry.io/triage/#2-route), due by **<time datetime=${timeToRouteBy}>${readableDueByDate}</time> (${lastOfficeInBusinessHours})**. ⏲️`,
+    body: `Assigning to @${SENTRY_ORG}/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️`,
   });
 
   tx.finish();
@@ -122,41 +109,11 @@ async function routeIssue(octokit, productAreaLabelName) {
       org: SENTRY_ORG,
       team_slug: ghTeamSlug,
     }); // expected to throw if team doesn't exist
-    return `Routing to @${SENTRY_ORG}/${ghTeamSlug} for [triage](https://develop.sentry.dev/processing-tickets/#3-triage)`;
+    return `Routing to @${SENTRY_ORG}/${ghTeamSlug} for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️`;
   } catch (error) {
     Sentry.captureException(error);
-    return `Failed to route for ${productAreaLabelName}. Defaulting to @${SENTRY_ORG}/open-source for [triage](https://develop.sentry.dev/processing-tickets/#3-triage)`;
+    return `Failed to route for ${productAreaLabelName}. Defaulting to @${SENTRY_ORG}/open-source for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️`;
   }
-}
-
-async function getReadableTimeStamp(timeToTriageBy, productAreaLabelName) {
-  const dueByMoment = moment(timeToTriageBy).utc();
-  const officesForProductArea = await getSortedOffices(productAreaLabelName);
-  let lastOfficeInBusinessHours;
-  (officesForProductArea.length > 0 ? officesForProductArea : ['sfo']).forEach(
-    (office) => {
-      if (isTimeInBusinessHours(dueByMoment, office)) {
-        lastOfficeInBusinessHours = office;
-      }
-    }
-  );
-  if (lastOfficeInBusinessHours == null) {
-    lastOfficeInBusinessHours = 'sfo';
-    Sentry.captureMessage(
-      `Unable to find an office in business hours for ${productAreaLabelName} for time ${timeToTriageBy}`
-    );
-  }
-  const officeDateFormat =
-    lastOfficeInBusinessHours &&
-    OFFICES_24_HOUR.includes(lastOfficeInBusinessHours)
-      ? 'dddd, MMMM Do [at] HH:mm'
-      : 'dddd, MMMM Do [at] h:mm a';
-  return {
-    readableDueByDate: dueByMoment
-      .tz(OFFICE_TIME_ZONES[lastOfficeInBusinessHours])
-      .format(officeDateFormat),
-    lastOfficeInBusinessHours,
-  };
 }
 
 export async function markRouted({
@@ -230,16 +187,8 @@ export async function markRouted({
     });
   }
 
-  const routedTeam = await routeIssue(octokit, productAreaLabelName);
+  const comment = await routeIssue(octokit, productAreaLabelName);
 
-  const timeToTriageBy = await calculateSLOViolationTriage(UNTRIAGED_LABEL, [
-    productAreaLabel,
-  ]);
-
-  const { readableDueByDate, lastOfficeInBusinessHours } =
-    await getReadableTimeStamp(timeToTriageBy, productAreaLabelName);
-  const dueBy = `due by **<time datetime=${timeToTriageBy}>${readableDueByDate}</time> (${lastOfficeInBusinessHours})**. ⏲️`;
-  const comment = `${routedTeam}, ${dueBy}`;
   await octokit.issues.createComment({
     owner,
     repo: payload.repository.name,

--- a/src/brain/issueLabelHandler/route.ts
+++ b/src/brain/issueLabelHandler/route.ts
@@ -4,10 +4,10 @@ import * as Sentry from '@sentry/node';
 import {
   BACKLOG_LABEL,
   IN_PROGRESS_LABEL,
-  SENTRY_MONOREPOS,
   PRODUCT_AREA_FIELD_ID,
   PRODUCT_AREA_LABEL_PREFIX,
   PRODUCT_AREA_UNKNOWN,
+  SENTRY_MONOREPOS,
   SENTRY_ORG,
   STATUS_LABEL_PREFIX,
   UNROUTED_LABEL,
@@ -103,7 +103,9 @@ export async function markUnrouted({
 
 async function routeIssue(octokit, productAreaLabelName) {
   try {
-    const productArea = productAreaLabelName?.substr(PRODUCT_AREA_LABEL_PREFIX.length);
+    const productArea = productAreaLabelName?.substr(
+      PRODUCT_AREA_LABEL_PREFIX.length
+    );
     const ghTeamSlug = 'product-owners-' + slugizeProductArea(productArea);
     await octokit.teams.getByName({
       org: SENTRY_ORG,
@@ -138,7 +140,7 @@ export async function markRouted({
   const owner = payload.repository.owner.login;
   const octokit = await getClient(ClientType.App, owner);
   const labelsToRemove: string[] = [];
-  const labelNames = issue?.labels?.map(label => label.name) || [];
+  const labelNames = issue?.labels?.map((label) => label.name) || [];
   const isBeingRoutedBySupport = labelNames.includes(WAITING_FOR_SUPPORT_LABEL);
 
   // When routing, remove all Status and Product Area labels that currently exist on issue
@@ -206,7 +208,9 @@ export async function markRouted({
     payload.issue.number,
     octokit
   );
-  const productArea = productAreaLabelName?.substr(PRODUCT_AREA_LABEL_PREFIX.length);
+  const productArea = productAreaLabelName?.substr(
+    PRODUCT_AREA_LABEL_PREFIX.length
+  );
   await modifyProjectIssueField(
     itemId,
     productArea,

--- a/src/brain/issueLabelHandler/triage.ts
+++ b/src/brain/issueLabelHandler/triage.ts
@@ -1,22 +1,21 @@
 import { EmitterWebhookEvent } from '@octokit/webhooks';
 import * as Sentry from '@sentry/node';
 
-import {
-  isNotFromAnExternalOrGTMUser,
-  shouldSkip,
-  modifyProjectIssueField,
-} from '@/utils/githubEventHelpers';
-import { isFromABot } from '@utils/isFromABot';
-import { SENTRY_REPOS } from '@/config';
-
 import { ClientType } from '@/api/github/clientType';
+import { SENTRY_REPOS } from '@/config';
 import {
+  STATUS_FIELD_ID,
   UNTRIAGED_LABEL,
   WAITING_FOR_PRODUCT_OWNER_LABEL,
-  STATUS_FIELD_ID,
 } from '@/config';
-import { getClient } from '@api/github/getClient';
+import {
+  isNotFromAnExternalOrGTMUser,
+  modifyProjectIssueField,
+  shouldSkip,
+} from '@/utils/githubEventHelpers';
 import { addIssueToGlobalIssuesProject } from '@/utils/githubEventHelpers';
+import { getClient } from '@api/github/getClient';
+import { isFromABot } from '@utils/isFromABot';
 
 const REPOS_TO_TRACK_FOR_TRIAGE = new Set(SENTRY_REPOS);
 
@@ -70,7 +69,12 @@ export async function markUntriaged({
     labels: [UNTRIAGED_LABEL, WAITING_FOR_PRODUCT_OWNER_LABEL],
   });
 
-  const itemId: string = await addIssueToGlobalIssuesProject(payload.issue.node_id, repo, issueNumber, octokit);
+  const itemId: string = await addIssueToGlobalIssuesProject(
+    payload.issue.node_id,
+    repo,
+    issueNumber,
+    octokit
+  );
 
   await modifyProjectIssueField(
     itemId,

--- a/src/brain/projectsHandler/index.test.ts
+++ b/src/brain/projectsHandler/index.test.ts
@@ -1,7 +1,11 @@
 import { createGitHubEvent } from '@test/utils/github';
 
 import { buildServer } from '@/buildServer';
-import { ISSUES_PROJECT_NODE_ID, PRODUCT_AREA_FIELD_ID, STATUS_FIELD_ID } from '@/config';
+import {
+  ISSUES_PROJECT_NODE_ID,
+  PRODUCT_AREA_FIELD_ID,
+  STATUS_FIELD_ID,
+} from '@/config';
 import { Fastify } from '@/types';
 import { defaultErrorHandler, githubEvents } from '@api/github';
 import { ClientType } from '@api/github/clientType';

--- a/src/brain/projectsHandler/project.ts
+++ b/src/brain/projectsHandler/project.ts
@@ -3,10 +3,10 @@ import * as Sentry from '@sentry/node';
 
 import { ClientType } from '@/api/github/clientType';
 import {
-  PRODUCT_AREA_LABEL_PREFIX,
-  STATUS_FIELD_ID,
   ISSUES_PROJECT_NODE_ID,
   PRODUCT_AREA_FIELD_ID,
+  PRODUCT_AREA_LABEL_PREFIX,
+  STATUS_FIELD_ID,
 } from '@/config';
 import { shouldSkip } from '@/utils/githubEventHelpers';
 import { getClient } from '@api/github/getClient';
@@ -20,17 +20,19 @@ function isNotInAProjectWeCareAbout(payload) {
 }
 
 function isNotAProjectFieldWeCareAbout(payload) {
-  return payload?.changes?.field_value?.field_node_id !== PRODUCT_AREA_FIELD_ID && payload?.changes?.field_value?.field_node_id !== STATUS_FIELD_ID;
+  return (
+    payload?.changes?.field_value?.field_node_id !== PRODUCT_AREA_FIELD_ID &&
+    payload?.changes?.field_value?.field_node_id !== STATUS_FIELD_ID
+  );
 }
 
 function getFieldName(payload) {
   if (payload?.changes?.field_value?.field_node_id === PRODUCT_AREA_FIELD_ID) {
-    return "Product Area";
+    return 'Product Area';
+  } else if (payload?.changes?.field_value?.field_node_id === STATUS_FIELD_ID) {
+    return 'Status';
   }
-  else if (payload?.changes?.field_value?.field_node_id === STATUS_FIELD_ID) {
-    return "Status";
-  }
-  return "";
+  return '';
 }
 
 function isMissingNodeId(payload) {
@@ -82,7 +84,11 @@ export async function syncLabelsWithProjectField({
     owner,
     repo: issueInfo.repo,
     issue_number: issueInfo.number,
-    labels: [`${fieldName === "Product Area" ? PRODUCT_AREA_LABEL_PREFIX : ""}${fieldValue}`],
+    labels: [
+      `${
+        fieldName === 'Product Area' ? PRODUCT_AREA_LABEL_PREFIX : ''
+      }${fieldValue}`,
+    ],
   });
 
   tx.finish();

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -102,7 +102,7 @@ export const WAITING_FOR_PRODUCT_OWNER_LABEL = 'Waiting for: Product Owner';
 export const MAX_TRIAGE_DAYS = 2;
 export const MAX_ROUTE_DAYS = 1;
 
-export const SENTRY_MONOREPOS = [ 'sentry', 'sentry-docs' ];
+export const SENTRY_MONOREPOS = ['sentry', 'sentry-docs'];
 export const SENTRY_REPOS = [
   'arroyo',
   'cdc',
@@ -142,10 +142,14 @@ export const SENTRY_REPOS = [
  * Issues Someone Else Cares About Project
  */
 
-export const ISSUES_PROJECT_NODE_ID = process.env.ISSUES_PROJECT_NODE_ID || "PVT_kwDOABVQ184AOGW8";
-export const PRODUCT_AREA_FIELD_ID = process.env.PRODUCT_AREA_FIELD_ID || "PVTSSF_lADOABVQ184AOGW8zgJEBno";
-export const STATUS_FIELD_ID = process.env.STATUS_FIELD_ID || "PVTSSF_lADOABVQ184AOGW8zgI_7g0";
-export const RESPONSE_DUE_DATE_FIELD_ID = process.env.RESPONSE_DUE_DATE_FIELD_ID || "PVTF_lADOABVQ184AOGW8zgLLxGg";
+export const ISSUES_PROJECT_NODE_ID =
+  process.env.ISSUES_PROJECT_NODE_ID || 'PVT_kwDOABVQ184AOGW8';
+export const PRODUCT_AREA_FIELD_ID =
+  process.env.PRODUCT_AREA_FIELD_ID || 'PVTSSF_lADOABVQ184AOGW8zgJEBno';
+export const STATUS_FIELD_ID =
+  process.env.STATUS_FIELD_ID || 'PVTSSF_lADOABVQ184AOGW8zgI_7g0';
+export const RESPONSE_DUE_DATE_FIELD_ID =
+  process.env.RESPONSE_DUE_DATE_FIELD_ID || 'PVTF_lADOABVQ184AOGW8zgLLxGg';
 
 /**
  * Personal Access Token for the Sentry bot used to do things that aren't possible with the App account, e.g. querying org membership

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -145,6 +145,7 @@ export const SENTRY_REPOS = [
 export const ISSUES_PROJECT_NODE_ID = process.env.ISSUES_PROJECT_NODE_ID || "PVT_kwDOABVQ184AOGW8";
 export const PRODUCT_AREA_FIELD_ID = process.env.PRODUCT_AREA_FIELD_ID || "PVTSSF_lADOABVQ184AOGW8zgJEBno";
 export const STATUS_FIELD_ID = process.env.STATUS_FIELD_ID || "PVTSSF_lADOABVQ184AOGW8zgI_7g0";
+export const RESPONSE_DUE_DATE_FIELD_ID = process.env.RESPONSE_DUE_DATE_FIELD_ID || "PVTF_lADOABVQ184AOGW8zgLLxGg";
 
 /**
  * Personal Access Token for the Sentry bot used to do things that aren't possible with the App account, e.g. querying org membership

--- a/src/utils/businessHours.test.ts
+++ b/src/utils/businessHours.test.ts
@@ -272,7 +272,9 @@ describe('businessHours tests', function () {
     });
 
     it('should not calculate SLO violation if label is waiting for product owner', async function () {
-      const result = await calculateSLOViolationRoute(WAITING_FOR_PRODUCT_OWNER_LABEL);
+      const result = await calculateSLOViolationRoute(
+        WAITING_FOR_PRODUCT_OWNER_LABEL
+      );
       expect(result).toEqual(null);
     });
 
@@ -404,9 +406,10 @@ describe('businessHours tests', function () {
     });
 
     it('should calculate SLO violation if label is waiting for product owner', async function () {
-      const result = await calculateSLOViolationTriage(WAITING_FOR_PRODUCT_OWNER_LABEL, [
-        { name: 'Product Area: Test' },
-      ]);
+      const result = await calculateSLOViolationTriage(
+        WAITING_FOR_PRODUCT_OWNER_LABEL,
+        [{ name: 'Product Area: Test' }]
+      );
       expect(result).not.toEqual(null);
     });
 

--- a/src/utils/businessHours.ts
+++ b/src/utils/businessHours.ts
@@ -54,7 +54,10 @@ export async function calculateTimeToRespondBy(
 
 export async function calculateSLOViolationTriage(target_name, labels) {
   // calculate time to triage for issues that come in with untriaged label
-  if (target_name === UNTRIAGED_LABEL || target_name === WAITING_FOR_PRODUCT_OWNER_LABEL) {
+  if (
+    target_name === UNTRIAGED_LABEL ||
+    target_name === WAITING_FOR_PRODUCT_OWNER_LABEL
+  ) {
     const productArea = labels?.find((label) =>
       label.name.startsWith(PRODUCT_AREA_LABEL_PREFIX)
     )?.name;
@@ -63,7 +66,11 @@ export async function calculateSLOViolationTriage(target_name, labels) {
   // calculate time to triage for issues that are rerouted
   else if (
     target_name.startsWith(PRODUCT_AREA_LABEL_PREFIX) &&
-    labels?.some((label) => label.name === UNTRIAGED_LABEL || label.name === WAITING_FOR_PRODUCT_OWNER_LABEL)
+    labels?.some(
+      (label) =>
+        label.name === UNTRIAGED_LABEL ||
+        label.name === WAITING_FOR_PRODUCT_OWNER_LABEL
+    )
   ) {
     return calculateTimeToRespondBy(MAX_TRIAGE_DAYS, target_name);
   }
@@ -71,7 +78,10 @@ export async function calculateSLOViolationTriage(target_name, labels) {
 }
 
 export async function calculateSLOViolationRoute(target_name) {
-  if (target_name === UNROUTED_LABEL || target_name === WAITING_FOR_SUPPORT_LABEL) {
+  if (
+    target_name === UNROUTED_LABEL ||
+    target_name === WAITING_FOR_SUPPORT_LABEL
+  ) {
     return calculateTimeToRespondBy(MAX_ROUTE_DAYS, 'Product Area: Unknown');
   }
   return null;

--- a/src/utils/githubEventHelpers.ts
+++ b/src/utils/githubEventHelpers.ts
@@ -97,7 +97,7 @@ export async function modifyProjectIssueField(
 ) {
   const projectFieldNodeIDMapping = await getAllProjectFieldNodeIds(fieldId, octokit);
   const singleSelectOptionId = projectFieldNodeIDMapping[projectFieldOption];
-  const addIssueToGlobalIssuesProjectMutation = `mutation {
+  const modifyProjectIssueFieldMutation = `mutation {
     updateProjectV2ItemFieldValue(
       input: {
         projectId: "${ISSUES_PROJECT_NODE_ID}"
@@ -118,7 +118,39 @@ export async function modifyProjectIssueField(
     projectFieldOption,
     fieldId,
   }
-  await sendQuery(addIssueToGlobalIssuesProjectMutation, data, octokit);
+  await sendQuery(modifyProjectIssueFieldMutation, data, octokit);
+}
+
+export async function modifyDueByDate(
+  itemId: string,
+  projectFieldOption: string,
+  fieldId: string,
+  octokit: Octokit
+) {
+
+  const modifyDueByDateMutation = `mutation {
+    updateProjectV2ItemFieldValue(
+      input: {
+        projectId: "${ISSUES_PROJECT_NODE_ID}"
+        itemId: "${itemId}"
+        fieldId: "${fieldId}"
+        value: {
+          text: "${projectFieldOption}"
+        }
+      }
+    ) {
+      projectV2Item {
+        id
+      }
+    }
+  }`;
+
+  const data = {
+    itemId,
+    projectFieldOption,
+    fieldId,
+  }
+  await sendQuery(modifyDueByDateMutation, data, octokit);
 }
 
 export async function getKeyValueFromProjectField(

--- a/src/utils/githubEventHelpers.ts
+++ b/src/utils/githubEventHelpers.ts
@@ -1,9 +1,7 @@
 import { Octokit } from '@octokit/rest';
 import * as Sentry from '@sentry/node';
 
-import {
-  ISSUES_PROJECT_NODE_ID,
-} from '@/config';
+import { ISSUES_PROJECT_NODE_ID } from '@/config';
 import { getOssUserType } from '@utils/getOssUserType';
 
 // Validation Helpers
@@ -60,13 +58,20 @@ export async function addIssueToGlobalIssuesProject(
   const data = {
     repo,
     issueNumber,
-  }
-  const response = await sendQuery(addIssueToGlobalIssuesProjectMutation, data, octokit);
+  };
+  const response = await sendQuery(
+    addIssueToGlobalIssuesProjectMutation,
+    data,
+    octokit
+  );
 
   return response?.addProjectV2ItemById.item.id;
 }
 
-export async function getAllProjectFieldNodeIds(projectFieldId: string, octokit: Octokit) {
+export async function getAllProjectFieldNodeIds(
+  projectFieldId: string,
+  octokit: Octokit
+) {
   const queryForProjectFieldNodeIDs = `query{
     node(id: "${projectFieldId}") {
       ... on ProjectV2SingleSelectField {
@@ -80,7 +85,7 @@ export async function getAllProjectFieldNodeIds(projectFieldId: string, octokit:
 
   const data = {
     projectFieldId,
-  }
+  };
   const response = await sendQuery(queryForProjectFieldNodeIDs, data, octokit);
 
   return response?.node.options.reduce((acc, { name, id }) => {
@@ -95,7 +100,10 @@ export async function modifyProjectIssueField(
   fieldId: string,
   octokit: Octokit
 ) {
-  const projectFieldNodeIDMapping = await getAllProjectFieldNodeIds(fieldId, octokit);
+  const projectFieldNodeIDMapping = await getAllProjectFieldNodeIds(
+    fieldId,
+    octokit
+  );
   const singleSelectOptionId = projectFieldNodeIDMapping[projectFieldOption];
   const modifyProjectIssueFieldMutation = `mutation {
     updateProjectV2ItemFieldValue(
@@ -117,7 +125,7 @@ export async function modifyProjectIssueField(
     itemId,
     projectFieldOption,
     fieldId,
-  }
+  };
   await sendQuery(modifyProjectIssueFieldMutation, data, octokit);
 }
 
@@ -127,7 +135,6 @@ export async function modifyDueByDate(
   fieldId: string,
   octokit: Octokit
 ) {
-
   const modifyDueByDateMutation = `mutation {
     updateProjectV2ItemFieldValue(
       input: {
@@ -149,7 +156,7 @@ export async function modifyDueByDate(
     itemId,
     projectFieldOption,
     fieldId,
-  }
+  };
   await sendQuery(modifyDueByDateMutation, data, octokit);
 }
 
@@ -179,7 +186,7 @@ export async function getKeyValueFromProjectField(
   const data = {
     issueNodeId,
     fieldName,
-  }
+  };
   const response = await sendQuery(query, data, octokit);
 
   return response?.node.fieldValueByName?.name;
@@ -202,7 +209,7 @@ export async function getIssueDetailsFromNodeId(
 
   const data = {
     issueNodeId,
-  }
+  };
   const response = await sendQuery(query, data, octokit);
 
   return {

--- a/src/utils/metrics.test.ts
+++ b/src/utils/metrics.test.ts
@@ -19,9 +19,9 @@ import { getLabelsTable } from '@/brain/issueNotifier';
 import {
   UNROUTED_LABEL,
   UNTRIAGED_LABEL,
+  WAITING_FOR_COMMUNITY_LABEL,
   WAITING_FOR_PRODUCT_OWNER_LABEL,
   WAITING_FOR_SUPPORT_LABEL,
-  WAITING_FOR_COMMUNITY_LABEL
 } from '@/config';
 import { db } from '@utils/db';
 

--- a/test/payloads/github/projects_v2_item.ts
+++ b/test/payloads/github/projects_v2_item.ts
@@ -3,56 +3,65 @@
 //   https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#webhook-payload-example-when-someone-edits-an-issue.
 
 export default {
-  action: "edited",
+  action: 'edited',
   projects_v2_item: {
     id: 28937214,
-    node_id: "test-node-id",
-    project_node_id: "test-project-node-id",
-    content_node_id: "test-content-node-id",
-    content_type: "Issue",
+    node_id: 'test-node-id',
+    project_node_id: 'test-project-node-id',
+    content_node_id: 'test-content-node-id',
+    content_type: 'Issue',
     creator: {
-      login: "getsantry-bot[bot]",
+      login: 'getsantry-bot[bot]',
       id: 112652482,
-      node_id: "bot-node-id",
-      avatar_url: "https://avatars.githubusercontent.com/u/121066737?v=4",
-      gravatar_id: "",
-      url: "https://api.github.com/users/getsantry-bot%5Bbot%5D",
-      html_url: "https://github.com/apps/getsantry-bot",
-      followers_url: "https://api.github.com/users/getsantry-bot%5Bbot%5D/followers",
-      following_url: "https://api.github.com/users/getsantry-bot%5Bbot%5D/following{/other_user}",
-      gists_url: "https://api.github.com/users/getsantry-bot%5Bbot%5D/gists{/gist_id}",
-      starred_url: "https://api.github.com/users/getsantry-bot%5Bbot%5D/starred{/owner}{/repo}",
-      subscriptions_url: "https://api.github.com/users/getsantry-bot%5Bbot%5D/subscriptions",
-      organizations_url: "https://api.github.com/users/getsantry-bot%5Bbot%5D/orgs",
-      repos_url: "https://api.github.com/users/getsantry-bot%5Bbot%5D/repos",
-      events_url: "https://api.github.com/users/getsantry-bot%5Bbot%5D/events{/privacy}",
-      received_events_url: "https://api.github.com/users/getsantry-bot%5Bbot%5D/received_events",
-      type: "Bot",
-      site_admin: false
+      node_id: 'bot-node-id',
+      avatar_url: 'https://avatars.githubusercontent.com/u/121066737?v=4',
+      gravatar_id: '',
+      url: 'https://api.github.com/users/getsantry-bot%5Bbot%5D',
+      html_url: 'https://github.com/apps/getsantry-bot',
+      followers_url:
+        'https://api.github.com/users/getsantry-bot%5Bbot%5D/followers',
+      following_url:
+        'https://api.github.com/users/getsantry-bot%5Bbot%5D/following{/other_user}',
+      gists_url:
+        'https://api.github.com/users/getsantry-bot%5Bbot%5D/gists{/gist_id}',
+      starred_url:
+        'https://api.github.com/users/getsantry-bot%5Bbot%5D/starred{/owner}{/repo}',
+      subscriptions_url:
+        'https://api.github.com/users/getsantry-bot%5Bbot%5D/subscriptions',
+      organizations_url:
+        'https://api.github.com/users/getsantry-bot%5Bbot%5D/orgs',
+      repos_url: 'https://api.github.com/users/getsantry-bot%5Bbot%5D/repos',
+      events_url:
+        'https://api.github.com/users/getsantry-bot%5Bbot%5D/events{/privacy}',
+      received_events_url:
+        'https://api.github.com/users/getsantry-bot%5Bbot%5D/received_events',
+      type: 'Bot',
+      site_admin: false,
     },
-    created_at: "2023-05-23T16:24:12Z",
-    updated_at: "2023-05-25T23:51:06Z",
-    archived_at: null
+    created_at: '2023-05-23T16:24:12Z',
+    updated_at: '2023-05-25T23:51:06Z',
+    archived_at: null,
   },
   changes: {
     field_value: {
-      field_node_id: "field-id",
-      field_type: "single_select"
-    }
+      field_node_id: 'field-id',
+      field_type: 'single_select',
+    },
   },
   organization: {
-    login: "test-org",
+    login: 'test-org',
     id: 121066737,
-    node_id: "O_kgDMBzdU8Q",
-    url: "https://api.github.com/orgs/test-org",
-    repos_url: "https://api.github.com/orgs/test-org/repos",
-    events_url: "https://api.github.com/orgs/test-org/events",
-    hooks_url: "https://api.github.com/orgs/test-org/hooks",
-    issues_url: "https://api.github.com/orgs/test-org/issues",
-    members_url: "https://api.github.com/orgs/test-org/members{/member}",
-    public_members_url: "https://api.github.com/orgs/test-org/public_members{/member}",
-    avatar_url: "https://avatars.githubusercontent.com/u/121066737?v=4",
-    description: null
+    node_id: 'O_kgDMBzdU8Q',
+    url: 'https://api.github.com/orgs/test-org',
+    repos_url: 'https://api.github.com/orgs/test-org/repos',
+    events_url: 'https://api.github.com/orgs/test-org/events',
+    hooks_url: 'https://api.github.com/orgs/test-org/hooks',
+    issues_url: 'https://api.github.com/orgs/test-org/issues',
+    members_url: 'https://api.github.com/orgs/test-org/members{/member}',
+    public_members_url:
+      'https://api.github.com/orgs/test-org/public_members{/member}',
+    avatar_url: 'https://avatars.githubusercontent.com/u/121066737?v=4',
+    description: null,
   },
   sender: {
     login: 'Picard',
@@ -63,21 +72,19 @@ export default {
     url: 'https://api.github.com/users/Picard',
     html_url: 'https://github.com/Picard',
     followers_url: 'https://api.github.com/users/Picard/followers',
-    following_url:
-      'https://api.github.com/users/Picard/following{/other_user}',
+    following_url: 'https://api.github.com/users/Picard/following{/other_user}',
     gists_url: 'https://api.github.com/users/Picard/gists{/gist_id}',
     starred_url: 'https://api.github.com/users/Picard/starred{/owner}{/repo}',
     subscriptions_url: 'https://api.github.com/users/Picard/subscriptions',
     organizations_url: 'https://api.github.com/users/Picard/orgs',
     repos_url: 'https://api.github.com/users/Picard/repos',
     events_url: 'https://api.github.com/users/Picard/events{/privacy}',
-    received_events_url:
-      'https://api.github.com/users/Picard/received_events',
+    received_events_url: 'https://api.github.com/users/Picard/received_events',
     type: 'User',
     site_admin: false,
   },
   installation: {
     id: 12321321,
-    node_id: "MDIzOkludGVncmK0aW9uSW5zdGFsbGF0aW9uMzcxMTgwNTE="
-  }
+    node_id: 'MDIzOkludGVncmK0aW9uSW5zdGFsbGF0aW9uMzcxMTgwNTE=',
+  },
 };


### PR DESCRIPTION
This moves the due date of responding to issues to `Issues Someone Else Cares About` project instead of getsantry bot comment. 

Why?
The bot shouldn't comment every single time the `Waiting for: *` labels/status change on an issue. That would be way too noisy.