### PR TITLE
Revert "Move tracking issue due dates to `Issues Someone Else Cares About` project"

### DIFF
--- a/src/brain/issueLabelHandler/index.test.ts
+++ b/src/brain/issueLabelHandler/index.test.ts
@@ -3,8 +3,6 @@ import { createGitHubEvent } from '@test/utils/github';
 import { getLabelsTable, slackHandler } from '@/brain/issueNotifier';
 import { buildServer } from '@/buildServer';
 import {
-  RESPONSE_DUE_DATE_FIELD_ID,
-  STATUS_FIELD_ID,
   UNROUTED_LABEL,
   UNTRIAGED_LABEL,
   WAITING_FOR_COMMUNITY_LABEL,
@@ -211,7 +209,9 @@ describe('issueLabelHandler', function () {
     beforeAll(function () {
       addIssueToGlobalIssuesProjectSpy = jest
         .spyOn(helpers, 'addIssueToGlobalIssuesProject')
-        .mockReturnValue('itemId');
+        .mockReturnValue({
+          addProjectV2ItemById: { item: { id: 'PROJECT_ID' } },
+        });
     });
     afterEach(function () {
       jest.clearAllMocks();
@@ -359,7 +359,7 @@ describe('issueLabelHandler', function () {
       // Simulate GitHub adding Waiting for Support Label to send webhook
       await addLabel(WAITING_FOR_SUPPORT_LABEL);
       expect(octokit.issues._comments).toEqual([
-        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️',
+        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route), due by **<time datetime=2022-12-20T00:00:00.000Z>Monday, December 19th at 4:00 pm</time> (sfo)**. ⏲️',
       ]);
       expect(addIssueToGlobalIssuesProjectSpy).toHaveBeenCalled();
     });
@@ -371,7 +371,7 @@ describe('issueLabelHandler', function () {
       // Simulate GitHub adding Waiting for Support Label to send webhook
       await addLabel(WAITING_FOR_SUPPORT_LABEL);
       expect(octokit.issues._comments).toEqual([
-        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️',
+        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route), due by **<time datetime=2022-12-20T00:00:00.000Z>Monday, December 19th at 4:00 pm</time> (sfo)**. ⏲️',
       ]);
       expect(addIssueToGlobalIssuesProjectSpy).toHaveBeenCalled();
     });
@@ -400,8 +400,8 @@ describe('issueLabelHandler', function () {
       expect(octokit.issues._labels).not.toContain(WAITING_FOR_SUPPORT_LABEL);
       expect(octokit.issues._labels).toContain(WAITING_FOR_PRODUCT_OWNER_LABEL);
       expect(octokit.issues._comments).toEqual([
-        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️',
-        'Routing to @getsentry/product-owners-test for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️',
+        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route), due by **<time datetime=2022-12-20T00:00:00.000Z>Monday, December 19th at 4:00 pm</time> (sfo)**. ⏲️',
+        'Routing to @getsentry/product-owners-test for [triage](https://develop.sentry.dev/processing-tickets/#3-triage), due by **<time datetime=2022-12-21T00:00:00.000Z>Tuesday, December 20th at 4:00 pm</time> (sfo)**. ⏲️',
       ]);
       expect(modifyProjectIssueFieldSpy).toHaveBeenCalled();
     });
@@ -414,7 +414,7 @@ describe('issueLabelHandler', function () {
       // Simulate GitHub adding Waiting for Support Label to send webhook
       await addLabel(WAITING_FOR_SUPPORT_LABEL);
       expect(octokit.issues._comments).toEqual([
-        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️',
+        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route), due by **<time datetime=2022-12-20T00:00:00.000Z>Monday, December 19th at 4:00 pm</time> (sfo)**. ⏲️',
       ]);
       expect(modifyProjectIssueFieldSpy).toHaveBeenCalled();
     });
@@ -427,8 +427,8 @@ describe('issueLabelHandler', function () {
       expect(octokit.issues._labels).not.toContain(WAITING_FOR_SUPPORT_LABEL);
       expect(octokit.issues._labels).toContain(WAITING_FOR_PRODUCT_OWNER_LABEL);
       expect(octokit.issues._comments).toEqual([
-        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️',
-        'Failed to route for Product Area: Does Not Exist. Defaulting to @getsentry/open-source for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️',
+        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route), due by **<time datetime=2022-12-20T00:00:00.000Z>Monday, December 19th at 4:00 pm</time> (sfo)**. ⏲️',
+        'Failed to route for Product Area: Does Not Exist. Defaulting to @getsentry/open-source for [triage](https://develop.sentry.dev/processing-tickets/#3-triage), due by **<time datetime=2022-12-21T00:00:00.000Z>Tuesday, December 20th at 4:00 pm</time> (sfo)**. ⏲️',
       ]);
       expect(modifyProjectIssueFieldSpy).toHaveBeenCalled();
     });
@@ -442,9 +442,9 @@ describe('issueLabelHandler', function () {
       expect(octokit.issues._labels).toContain('Product Area: Rerouted');
       expect(octokit.issues._labels).not.toContain('Product Area: Test');
       expect(octokit.issues._comments).toEqual([
-        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️',
-        'Routing to @getsentry/product-owners-test for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️',
-        'Routing to @getsentry/product-owners-rerouted for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️',
+        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route), due by **<time datetime=2022-12-20T00:00:00.000Z>Monday, December 19th at 4:00 pm</time> (sfo)**. ⏲️',
+        'Routing to @getsentry/product-owners-test for [triage](https://develop.sentry.dev/processing-tickets/#3-triage), due by **<time datetime=2022-12-21T00:00:00.000Z>Tuesday, December 20th at 4:00 pm</time> (sfo)**. ⏲️',
+        'Routing to @getsentry/product-owners-rerouted for [triage](https://develop.sentry.dev/processing-tickets/#3-triage), due by **<time datetime=2022-12-21T00:00:00.000Z>Tuesday, December 20th at 4:00 pm</time> (sfo)**. ⏲️',
       ]);
       expect(modifyProjectIssueFieldSpy).toHaveBeenCalled();
     });
@@ -458,13 +458,11 @@ describe('issueLabelHandler', function () {
       await addLabel('Product Area: Rerouted', 'sentry-docs');
       expect(octokit.issues._labels).toContain('Product Area: Rerouted');
       expect(octokit.issues._labels).toContain('Waiting for: Community');
-      expect(octokit.issues._labels).not.toContain(
-        'Waiting for: Product Owner'
-      );
+      expect(octokit.issues._labels).not.toContain('Waiting for: Product Owner');
       expect(octokit.issues._comments).toEqual([
-        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️',
-        'Routing to @getsentry/product-owners-test for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️',
-        'Routing to @getsentry/product-owners-rerouted for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️',
+        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route), due by **<time datetime=2022-12-20T00:00:00.000Z>Monday, December 19th at 4:00 pm</time> (sfo)**. ⏲️',
+        'Routing to @getsentry/product-owners-test for [triage](https://develop.sentry.dev/processing-tickets/#3-triage), due by **<time datetime=2022-12-21T00:00:00.000Z>Tuesday, December 20th at 4:00 pm</time> (sfo)**. ⏲️',
+        'Routing to @getsentry/product-owners-rerouted for [triage](https://develop.sentry.dev/processing-tickets/#3-triage), due by **<time datetime=2022-12-21T00:00:00.000Z>Tuesday, December 20th at 4:00 pm</time> (sfo)**. ⏲️',
       ]);
       expect(modifyProjectIssueFieldSpy).toHaveBeenCalled();
     });
@@ -479,8 +477,8 @@ describe('issueLabelHandler', function () {
       expect(octokit.issues._labels).toContain('Product Area: Rerouted');
       expect(octokit.issues._labels).toContain('Product Area: Test');
       expect(octokit.issues._comments).toEqual([
-        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️',
-        'Routing to @getsentry/product-owners-test for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️',
+        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route), due by **<time datetime=2022-12-20T00:00:00.000Z>Monday, December 19th at 4:00 pm</time> (sfo)**. ⏲️',
+        'Routing to @getsentry/product-owners-test for [triage](https://develop.sentry.dev/processing-tickets/#3-triage), due by **<time datetime=2022-12-21T00:00:00.000Z>Tuesday, December 20th at 4:00 pm</time> (sfo)**. ⏲️',
       ]);
       expect(modifyProjectIssueFieldSpy).toHaveBeenCalled();
     });
@@ -495,8 +493,8 @@ describe('issueLabelHandler', function () {
       expect(octokit.issues._labels).toContain('Product Area: Rerouted');
       expect(octokit.issues._labels).toContain('Product Area: Test');
       expect(octokit.issues._comments).toEqual([
-        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️',
-        'Routing to @getsentry/product-owners-test for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️',
+        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route), due by **<time datetime=2022-12-20T00:00:00.000Z>Monday, December 19th at 4:00 pm</time> (sfo)**. ⏲️',
+        'Routing to @getsentry/product-owners-test for [triage](https://develop.sentry.dev/processing-tickets/#3-triage), due by **<time datetime=2022-12-21T00:00:00.000Z>Tuesday, December 20th at 4:00 pm</time> (sfo)**. ⏲️',
       ]);
       expect(modifyProjectIssueFieldSpy).toHaveBeenCalled();
     });
@@ -510,31 +508,41 @@ describe('issueLabelHandler', function () {
       expect(octokit.issues._labels).toContain('Product Area: Rerouted');
       expect(octokit.issues._labels).toContain('Product Area: Test');
       expect(octokit.issues._comments).toEqual([
-        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️',
-        'Routing to @getsentry/product-owners-test for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️',
+        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route), due by **<time datetime=2022-12-20T00:00:00.000Z>Monday, December 19th at 4:00 pm</time> (sfo)**. ⏲️',
+        'Routing to @getsentry/product-owners-test for [triage](https://develop.sentry.dev/processing-tickets/#3-triage), due by **<time datetime=2022-12-21T00:00:00.000Z>Tuesday, December 20th at 4:00 pm</time> (sfo)**. ⏲️',
       ]);
       expect(modifyProjectIssueFieldSpy).toHaveBeenCalled();
+    });
+
+    it('uses different timestamp for eu office', async function () {
+      await createIssue('sentry-docs');
+      const command = {
+        channel_id: 'CHNLIDRND1',
+        text: 'Test vie',
+      };
+      const client = {
+        conversations: {
+          info: jest
+            .fn()
+            .mockReturnValue({ channel: { name: 'test', is_member: true } }),
+          join: jest.fn(),
+        },
+      };
+      await slackHandler({ command, ack, say, respond, client });
+      jest
+        .spyOn(businessHourFunctions, 'calculateSLOViolationTriage')
+        .mockReturnValue('2022-12-21T13:00:00.000Z');
+      await addLabel('Product Area: Test', 'sentry-docs');
+      expectUntriaged();
+      expectRouted();
+      expect(octokit.issues._comments).toEqual([
+        'Assigning to @getsentry/support for [routing](https://open.sentry.io/triage/#2-route), due by **<time datetime=2022-12-20T00:00:00.000Z>Monday, December 19th at 4:00 pm</time> (sfo)**. ⏲️',
+        'Routing to @getsentry/product-owners-test for [triage](https://develop.sentry.dev/processing-tickets/#3-triage), due by **<time datetime=2022-12-21T13:00:00.000Z>Wednesday, December 21st at 14:00</time> (vie)**. ⏲️',
+      ]);
     });
   });
 
   describe('followups test cases', function () {
-    let modifyProjectIssueFieldSpy,
-      modifyDueByDateSpy,
-      addIssueToGlobalIssuesProjectSpy;
-    beforeAll(function () {
-      modifyProjectIssueFieldSpy = jest
-        .spyOn(helpers, 'modifyProjectIssueField')
-        .mockImplementation(jest.fn());
-      modifyDueByDateSpy = jest
-        .spyOn(helpers, 'modifyDueByDate')
-        .mockImplementation(jest.fn());
-      addIssueToGlobalIssuesProjectSpy = jest
-        .spyOn(helpers, 'addIssueToGlobalIssuesProject')
-        .mockReturnValue('itemId');
-    });
-    afterEach(function () {
-      jest.clearAllMocks();
-    });
     const setupIssue = async () => {
       await createIssue('sentry-docs');
       await addLabel('Product Area: Test', 'sentry-docs');
@@ -565,18 +573,6 @@ describe('issueLabelHandler', function () {
           WAITING_FOR_SUPPORT_LABEL,
         ])
       );
-      expect(modifyProjectIssueFieldSpy).toHaveBeenLastCalledWith(
-        'itemId',
-        WAITING_FOR_SUPPORT_LABEL,
-        STATUS_FIELD_ID,
-        octokit
-      );
-      expect(modifyDueByDateSpy).toHaveBeenLastCalledWith(
-        'itemId',
-        '2022-12-20T00:00:00.000Z',
-        RESPONSE_DUE_DATE_FIELD_ID,
-        octokit
-      );
     });
 
     it('should not add `Waiting for: Product Owner` label when product owner/GTM member comments and issue is waiting for community', async function () {
@@ -591,18 +587,6 @@ describe('issueLabelHandler', function () {
           WAITING_FOR_COMMUNITY_LABEL,
         ])
       );
-      expect(modifyProjectIssueFieldSpy).toHaveBeenLastCalledWith(
-        'itemId',
-        WAITING_FOR_COMMUNITY_LABEL,
-        STATUS_FIELD_ID,
-        octokit
-      );
-      expect(modifyDueByDateSpy).toHaveBeenLastCalledWith(
-        'itemId',
-        '',
-        RESPONSE_DUE_DATE_FIELD_ID,
-        octokit
-      );
     });
 
     it('should not add `Waiting for: Product Owner` label when contractor comments and issue is waiting for community', async function () {
@@ -610,25 +594,6 @@ describe('issueLabelHandler', function () {
       await addLabel(WAITING_FOR_COMMUNITY_LABEL, 'sentry-docs');
       jest.spyOn(helpers, 'isNotFromAnExternalOrGTMUser').mockReturnValue(true);
       await addComment('sentry-docs', 'Picard', 'COLLABORATOR');
-      expect(octokit.issues._labels).toEqual(
-        new Set([
-          UNTRIAGED_LABEL,
-          'Product Area: Test',
-          WAITING_FOR_COMMUNITY_LABEL,
-        ])
-      );
-      expect(modifyProjectIssueFieldSpy).toHaveBeenLastCalledWith(
-        'itemId',
-        WAITING_FOR_COMMUNITY_LABEL,
-        STATUS_FIELD_ID,
-        octokit
-      );
-      expect(modifyDueByDateSpy).toHaveBeenLastCalledWith(
-        'itemId',
-        '',
-        RESPONSE_DUE_DATE_FIELD_ID,
-        octokit
-      );
     });
 
     it('should not add `Waiting for: Product Owner` label when community member comments and issue is not waiting for community', async function () {
@@ -636,26 +601,14 @@ describe('issueLabelHandler', function () {
       jest
         .spyOn(helpers, 'isNotFromAnExternalOrGTMUser')
         .mockReturnValue(false);
-      await addLabel(WAITING_FOR_SUPPORT_LABEL, 'sentry-docs');
+      await addLabel(WAITING_FOR_SUPPORT_LABEL, 'sentry-docs')
       await addComment('sentry-docs', 'Picard');
       expect(octokit.issues._labels).toEqual(
         new Set([
           UNTRIAGED_LABEL,
           'Product Area: Test',
-          WAITING_FOR_SUPPORT_LABEL,
+          WAITING_FOR_SUPPORT_LABEL
         ])
-      );
-      expect(modifyProjectIssueFieldSpy).toHaveBeenLastCalledWith(
-        'itemId',
-        WAITING_FOR_SUPPORT_LABEL,
-        STATUS_FIELD_ID,
-        octokit
-      );
-      expect(modifyDueByDateSpy).toHaveBeenLastCalledWith(
-        'itemId',
-        '2022-12-20T00:00:00.000Z',
-        RESPONSE_DUE_DATE_FIELD_ID,
-        octokit
       );
     });
 
@@ -673,20 +626,6 @@ describe('issueLabelHandler', function () {
           WAITING_FOR_PRODUCT_OWNER_LABEL,
         ])
       );
-      // Simulate GH webhook being thrown when Waiting for: Product Owner label is added
-      await addLabel(WAITING_FOR_PRODUCT_OWNER_LABEL);
-      expect(modifyProjectIssueFieldSpy).toHaveBeenLastCalledWith(
-        'itemId',
-        WAITING_FOR_PRODUCT_OWNER_LABEL,
-        STATUS_FIELD_ID,
-        octokit
-      );
-      expect(modifyDueByDateSpy).toHaveBeenLastCalledWith(
-        'itemId',
-        '2022-12-21T00:00:00.000Z',
-        RESPONSE_DUE_DATE_FIELD_ID,
-        octokit
-      );
     });
 
     it('should not modify labels when community member comments and issue is waiting for product owner', async function () {
@@ -702,18 +641,6 @@ describe('issueLabelHandler', function () {
           'Product Area: Test',
           WAITING_FOR_PRODUCT_OWNER_LABEL,
         ])
-      );
-      expect(modifyProjectIssueFieldSpy).toHaveBeenLastCalledWith(
-        'itemId',
-        WAITING_FOR_PRODUCT_OWNER_LABEL,
-        STATUS_FIELD_ID,
-        octokit
-      );
-      expect(modifyDueByDateSpy).toHaveBeenLastCalledWith(
-        'itemId',
-        '2022-12-21T00:00:00.000Z',
-        RESPONSE_DUE_DATE_FIELD_ID,
-        octokit
       );
     });
   });

--- a/src/brain/issueLabelHandler/route.ts
+++ b/src/brain/issueLabelHandler/route.ts
@@ -1,15 +1,19 @@
 import { EmitterWebhookEvent } from '@octokit/webhooks';
 import * as Sentry from '@sentry/node';
+import moment from 'moment-timezone';
 
 import {
   BACKLOG_LABEL,
   IN_PROGRESS_LABEL,
+  SENTRY_MONOREPOS,
+  OFFICE_TIME_ZONES,
+  OFFICES_24_HOUR,
   PRODUCT_AREA_FIELD_ID,
   PRODUCT_AREA_LABEL_PREFIX,
   PRODUCT_AREA_UNKNOWN,
-  SENTRY_MONOREPOS,
   SENTRY_ORG,
   STATUS_LABEL_PREFIX,
+  UNKNOWN_LABEL,
   UNROUTED_LABEL,
   UNTRIAGED_LABEL,
   WAITING_FOR_PRODUCT_OWNER_LABEL,
@@ -21,6 +25,12 @@ import {
   modifyProjectIssueField,
   shouldSkip,
 } from '@/utils/githubEventHelpers';
+import {
+  calculateSLOViolationRoute,
+  calculateSLOViolationTriage,
+  getSortedOffices,
+  isTimeInBusinessHours,
+} from '@utils/businessHours';
 import { slugizeProductArea } from '@utils/slugizeProductArea';
 
 const REPOS_TO_TRACK_FOR_ROUTING = new Set(SENTRY_MONOREPOS);
@@ -91,11 +101,14 @@ export async function markUnrouted({
     labels: [UNROUTED_LABEL, WAITING_FOR_SUPPORT_LABEL],
   });
 
+  const timeToRouteBy = await calculateSLOViolationRoute(UNROUTED_LABEL);
+  const { readableDueByDate, lastOfficeInBusinessHours } =
+    await getReadableTimeStamp(timeToRouteBy, UNKNOWN_LABEL);
   await octokit.issues.createComment({
     owner,
     repo: repo,
     issue_number: issueNumber,
-    body: `Assigning to @${SENTRY_ORG}/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️`,
+    body: `Assigning to @${SENTRY_ORG}/support for [routing](https://open.sentry.io/triage/#2-route), due by **<time datetime=${timeToRouteBy}>${readableDueByDate}</time> (${lastOfficeInBusinessHours})**. ⏲️`,
   });
 
   tx.finish();
@@ -103,19 +116,47 @@ export async function markUnrouted({
 
 async function routeIssue(octokit, productAreaLabelName) {
   try {
-    const productArea = productAreaLabelName?.substr(
-      PRODUCT_AREA_LABEL_PREFIX.length
-    );
+    const productArea = productAreaLabelName?.substr(PRODUCT_AREA_LABEL_PREFIX.length);
     const ghTeamSlug = 'product-owners-' + slugizeProductArea(productArea);
     await octokit.teams.getByName({
       org: SENTRY_ORG,
       team_slug: ghTeamSlug,
     }); // expected to throw if team doesn't exist
-    return `Routing to @${SENTRY_ORG}/${ghTeamSlug} for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️`;
+    return `Routing to @${SENTRY_ORG}/${ghTeamSlug} for [triage](https://develop.sentry.dev/processing-tickets/#3-triage)`;
   } catch (error) {
     Sentry.captureException(error);
-    return `Failed to route for ${productAreaLabelName}. Defaulting to @${SENTRY_ORG}/open-source for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️`;
+    return `Failed to route for ${productAreaLabelName}. Defaulting to @${SENTRY_ORG}/open-source for [triage](https://develop.sentry.dev/processing-tickets/#3-triage)`;
   }
+}
+
+async function getReadableTimeStamp(timeToTriageBy, productAreaLabelName) {
+  const dueByMoment = moment(timeToTriageBy).utc();
+  const officesForProductArea = await getSortedOffices(productAreaLabelName);
+  let lastOfficeInBusinessHours;
+  (officesForProductArea.length > 0 ? officesForProductArea : ['sfo']).forEach(
+    (office) => {
+      if (isTimeInBusinessHours(dueByMoment, office)) {
+        lastOfficeInBusinessHours = office;
+      }
+    }
+  );
+  if (lastOfficeInBusinessHours == null) {
+    lastOfficeInBusinessHours = 'sfo';
+    Sentry.captureMessage(
+      `Unable to find an office in business hours for ${productAreaLabelName} for time ${timeToTriageBy}`
+    );
+  }
+  const officeDateFormat =
+    lastOfficeInBusinessHours &&
+    OFFICES_24_HOUR.includes(lastOfficeInBusinessHours)
+      ? 'dddd, MMMM Do [at] HH:mm'
+      : 'dddd, MMMM Do [at] h:mm a';
+  return {
+    readableDueByDate: dueByMoment
+      .tz(OFFICE_TIME_ZONES[lastOfficeInBusinessHours])
+      .format(officeDateFormat),
+    lastOfficeInBusinessHours,
+  };
 }
 
 export async function markRouted({
@@ -140,7 +181,7 @@ export async function markRouted({
   const owner = payload.repository.owner.login;
   const octokit = await getClient(ClientType.App, owner);
   const labelsToRemove: string[] = [];
-  const labelNames = issue?.labels?.map((label) => label.name) || [];
+  const labelNames = issue?.labels?.map(label => label.name) || [];
   const isBeingRoutedBySupport = labelNames.includes(WAITING_FOR_SUPPORT_LABEL);
 
   // When routing, remove all Status and Product Area labels that currently exist on issue
@@ -189,8 +230,16 @@ export async function markRouted({
     });
   }
 
-  const comment = await routeIssue(octokit, productAreaLabelName);
+  const routedTeam = await routeIssue(octokit, productAreaLabelName);
 
+  const timeToTriageBy = await calculateSLOViolationTriage(UNTRIAGED_LABEL, [
+    productAreaLabel,
+  ]);
+
+  const { readableDueByDate, lastOfficeInBusinessHours } =
+    await getReadableTimeStamp(timeToTriageBy, productAreaLabelName);
+  const dueBy = `due by **<time datetime=${timeToTriageBy}>${readableDueByDate}</time> (${lastOfficeInBusinessHours})**. ⏲️`;
+  const comment = `${routedTeam}, ${dueBy}`;
   await octokit.issues.createComment({
     owner,
     repo: payload.repository.name,
@@ -208,9 +257,7 @@ export async function markRouted({
     payload.issue.number,
     octokit
   );
-  const productArea = productAreaLabelName?.substr(
-    PRODUCT_AREA_LABEL_PREFIX.length
-  );
+  const productArea = productAreaLabelName?.substr(PRODUCT_AREA_LABEL_PREFIX.length);
   await modifyProjectIssueField(
     itemId,
     productArea,

--- a/src/brain/issueLabelHandler/triage.ts
+++ b/src/brain/issueLabelHandler/triage.ts
@@ -1,21 +1,22 @@
 import { EmitterWebhookEvent } from '@octokit/webhooks';
 import * as Sentry from '@sentry/node';
 
-import { ClientType } from '@/api/github/clientType';
-import { SENTRY_REPOS } from '@/config';
-import {
-  STATUS_FIELD_ID,
-  UNTRIAGED_LABEL,
-  WAITING_FOR_PRODUCT_OWNER_LABEL,
-} from '@/config';
 import {
   isNotFromAnExternalOrGTMUser,
-  modifyProjectIssueField,
   shouldSkip,
+  modifyProjectIssueField,
 } from '@/utils/githubEventHelpers';
-import { addIssueToGlobalIssuesProject } from '@/utils/githubEventHelpers';
-import { getClient } from '@api/github/getClient';
 import { isFromABot } from '@utils/isFromABot';
+import { SENTRY_REPOS } from '@/config';
+
+import { ClientType } from '@/api/github/clientType';
+import {
+  UNTRIAGED_LABEL,
+  WAITING_FOR_PRODUCT_OWNER_LABEL,
+  STATUS_FIELD_ID,
+} from '@/config';
+import { getClient } from '@api/github/getClient';
+import { addIssueToGlobalIssuesProject } from '@/utils/githubEventHelpers';
 
 const REPOS_TO_TRACK_FOR_TRIAGE = new Set(SENTRY_REPOS);
 
@@ -69,12 +70,7 @@ export async function markUntriaged({
     labels: [UNTRIAGED_LABEL, WAITING_FOR_PRODUCT_OWNER_LABEL],
   });
 
-  const itemId: string = await addIssueToGlobalIssuesProject(
-    payload.issue.node_id,
-    repo,
-    issueNumber,
-    octokit
-  );
+  const itemId: string = await addIssueToGlobalIssuesProject(payload.issue.node_id, repo, issueNumber, octokit);
 
   await modifyProjectIssueField(
     itemId,

--- a/src/brain/projectsHandler/index.test.ts
+++ b/src/brain/projectsHandler/index.test.ts
@@ -1,11 +1,7 @@
 import { createGitHubEvent } from '@test/utils/github';
 
 import { buildServer } from '@/buildServer';
-import {
-  ISSUES_PROJECT_NODE_ID,
-  PRODUCT_AREA_FIELD_ID,
-  STATUS_FIELD_ID,
-} from '@/config';
+import { ISSUES_PROJECT_NODE_ID, PRODUCT_AREA_FIELD_ID, STATUS_FIELD_ID } from '@/config';
 import { Fastify } from '@/types';
 import { defaultErrorHandler, githubEvents } from '@api/github';
 import { ClientType } from '@api/github/clientType';

--- a/src/brain/projectsHandler/project.ts
+++ b/src/brain/projectsHandler/project.ts
@@ -3,10 +3,10 @@ import * as Sentry from '@sentry/node';
 
 import { ClientType } from '@/api/github/clientType';
 import {
-  ISSUES_PROJECT_NODE_ID,
-  PRODUCT_AREA_FIELD_ID,
   PRODUCT_AREA_LABEL_PREFIX,
   STATUS_FIELD_ID,
+  ISSUES_PROJECT_NODE_ID,
+  PRODUCT_AREA_FIELD_ID,
 } from '@/config';
 import { shouldSkip } from '@/utils/githubEventHelpers';
 import { getClient } from '@api/github/getClient';
@@ -20,19 +20,17 @@ function isNotInAProjectWeCareAbout(payload) {
 }
 
 function isNotAProjectFieldWeCareAbout(payload) {
-  return (
-    payload?.changes?.field_value?.field_node_id !== PRODUCT_AREA_FIELD_ID &&
-    payload?.changes?.field_value?.field_node_id !== STATUS_FIELD_ID
-  );
+  return payload?.changes?.field_value?.field_node_id !== PRODUCT_AREA_FIELD_ID && payload?.changes?.field_value?.field_node_id !== STATUS_FIELD_ID;
 }
 
 function getFieldName(payload) {
   if (payload?.changes?.field_value?.field_node_id === PRODUCT_AREA_FIELD_ID) {
-    return 'Product Area';
-  } else if (payload?.changes?.field_value?.field_node_id === STATUS_FIELD_ID) {
-    return 'Status';
+    return "Product Area";
   }
-  return '';
+  else if (payload?.changes?.field_value?.field_node_id === STATUS_FIELD_ID) {
+    return "Status";
+  }
+  return "";
 }
 
 function isMissingNodeId(payload) {
@@ -84,11 +82,7 @@ export async function syncLabelsWithProjectField({
     owner,
     repo: issueInfo.repo,
     issue_number: issueInfo.number,
-    labels: [
-      `${
-        fieldName === 'Product Area' ? PRODUCT_AREA_LABEL_PREFIX : ''
-      }${fieldValue}`,
-    ],
+    labels: [`${fieldName === "Product Area" ? PRODUCT_AREA_LABEL_PREFIX : ""}${fieldValue}`],
   });
 
   tx.finish();

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -101,7 +101,7 @@ export const WAITING_FOR_PRODUCT_OWNER_LABEL = 'Waiting for: Product Owner';
 export const MAX_TRIAGE_DAYS = 2;
 export const MAX_ROUTE_DAYS = 1;
 
-export const SENTRY_MONOREPOS = ['sentry', 'sentry-docs'];
+export const SENTRY_MONOREPOS = [ 'sentry', 'sentry-docs' ];
 export const SENTRY_REPOS = [
   'arroyo',
   'cdc',
@@ -141,14 +141,9 @@ export const SENTRY_REPOS = [
  * Issues Someone Else Cares About Project
  */
 
-export const ISSUES_PROJECT_NODE_ID =
-  process.env.ISSUES_PROJECT_NODE_ID || 'PVT_kwDOABVQ184AOGW8';
-export const PRODUCT_AREA_FIELD_ID =
-  process.env.PRODUCT_AREA_FIELD_ID || 'PVTSSF_lADOABVQ184AOGW8zgJEBno';
-export const STATUS_FIELD_ID =
-  process.env.STATUS_FIELD_ID || 'PVTSSF_lADOABVQ184AOGW8zgI_7g0';
-export const RESPONSE_DUE_DATE_FIELD_ID =
-  process.env.RESPONSE_DUE_DATE_FIELD_ID || 'PVTF_lADOABVQ184AOGW8zgLLxGg';
+export const ISSUES_PROJECT_NODE_ID = process.env.ISSUES_PROJECT_NODE_ID || "PVT_kwDOABVQ184AOGW8";
+export const PRODUCT_AREA_FIELD_ID = process.env.PRODUCT_AREA_FIELD_ID || "PVTSSF_lADOABVQ184AOGW8zgJEBno";
+export const STATUS_FIELD_ID = process.env.STATUS_FIELD_ID || "PVTSSF_lADOABVQ184AOGW8zgI_7g0";
 
 /**
  * Personal Access Token for the Sentry bot used to do things that aren't possible with the App account, e.g. querying org membership

--- a/src/utils/businessHours.test.ts
+++ b/src/utils/businessHours.test.ts
@@ -272,9 +272,7 @@ describe('businessHours tests', function () {
     });
 
     it('should not calculate SLO violation if label is waiting for product owner', async function () {
-      const result = await calculateSLOViolationRoute(
-        WAITING_FOR_PRODUCT_OWNER_LABEL
-      );
+      const result = await calculateSLOViolationRoute(WAITING_FOR_PRODUCT_OWNER_LABEL);
       expect(result).toEqual(null);
     });
 
@@ -406,10 +404,9 @@ describe('businessHours tests', function () {
     });
 
     it('should calculate SLO violation if label is waiting for product owner', async function () {
-      const result = await calculateSLOViolationTriage(
-        WAITING_FOR_PRODUCT_OWNER_LABEL,
-        [{ name: 'Product Area: Test' }]
-      );
+      const result = await calculateSLOViolationTriage(WAITING_FOR_PRODUCT_OWNER_LABEL, [
+        { name: 'Product Area: Test' },
+      ]);
       expect(result).not.toEqual(null);
     });
 

--- a/src/utils/businessHours.ts
+++ b/src/utils/businessHours.ts
@@ -54,10 +54,7 @@ export async function calculateTimeToRespondBy(
 
 export async function calculateSLOViolationTriage(target_name, labels) {
   // calculate time to triage for issues that come in with untriaged label
-  if (
-    target_name === UNTRIAGED_LABEL ||
-    target_name === WAITING_FOR_PRODUCT_OWNER_LABEL
-  ) {
+  if (target_name === UNTRIAGED_LABEL || target_name === WAITING_FOR_PRODUCT_OWNER_LABEL) {
     const productArea = labels?.find((label) =>
       label.name.startsWith(PRODUCT_AREA_LABEL_PREFIX)
     )?.name;
@@ -66,11 +63,7 @@ export async function calculateSLOViolationTriage(target_name, labels) {
   // calculate time to triage for issues that are rerouted
   else if (
     target_name.startsWith(PRODUCT_AREA_LABEL_PREFIX) &&
-    labels?.some(
-      (label) =>
-        label.name === UNTRIAGED_LABEL ||
-        label.name === WAITING_FOR_PRODUCT_OWNER_LABEL
-    )
+    labels?.some((label) => label.name === UNTRIAGED_LABEL || label.name === WAITING_FOR_PRODUCT_OWNER_LABEL)
   ) {
     return calculateTimeToRespondBy(MAX_TRIAGE_DAYS, target_name);
   }
@@ -78,10 +71,7 @@ export async function calculateSLOViolationTriage(target_name, labels) {
 }
 
 export async function calculateSLOViolationRoute(target_name) {
-  if (
-    target_name === UNROUTED_LABEL ||
-    target_name === WAITING_FOR_SUPPORT_LABEL
-  ) {
+  if (target_name === UNROUTED_LABEL || target_name === WAITING_FOR_SUPPORT_LABEL) {
     return calculateTimeToRespondBy(MAX_ROUTE_DAYS, 'Product Area: Unknown');
   }
   return null;

--- a/src/utils/githubEventHelpers.ts
+++ b/src/utils/githubEventHelpers.ts
@@ -1,7 +1,9 @@
 import { Octokit } from '@octokit/rest';
 import * as Sentry from '@sentry/node';
 
-import { ISSUES_PROJECT_NODE_ID } from '@/config';
+import {
+  ISSUES_PROJECT_NODE_ID,
+} from '@/config';
 import { getOssUserType } from '@utils/getOssUserType';
 
 // Validation Helpers
@@ -58,20 +60,13 @@ export async function addIssueToGlobalIssuesProject(
   const data = {
     repo,
     issueNumber,
-  };
-  const response = await sendQuery(
-    addIssueToGlobalIssuesProjectMutation,
-    data,
-    octokit
-  );
+  }
+  const response = await sendQuery(addIssueToGlobalIssuesProjectMutation, data, octokit);
 
   return response?.addProjectV2ItemById.item.id;
 }
 
-export async function getAllProjectFieldNodeIds(
-  projectFieldId: string,
-  octokit: Octokit
-) {
+export async function getAllProjectFieldNodeIds(projectFieldId: string, octokit: Octokit) {
   const queryForProjectFieldNodeIDs = `query{
     node(id: "${projectFieldId}") {
       ... on ProjectV2SingleSelectField {
@@ -85,7 +80,7 @@ export async function getAllProjectFieldNodeIds(
 
   const data = {
     projectFieldId,
-  };
+  }
   const response = await sendQuery(queryForProjectFieldNodeIDs, data, octokit);
 
   return response?.node.options.reduce((acc, { name, id }) => {
@@ -100,12 +95,9 @@ export async function modifyProjectIssueField(
   fieldId: string,
   octokit: Octokit
 ) {
-  const projectFieldNodeIDMapping = await getAllProjectFieldNodeIds(
-    fieldId,
-    octokit
-  );
+  const projectFieldNodeIDMapping = await getAllProjectFieldNodeIds(fieldId, octokit);
   const singleSelectOptionId = projectFieldNodeIDMapping[projectFieldOption];
-  const modifyProjectIssueFieldMutation = `mutation {
+  const addIssueToGlobalIssuesProjectMutation = `mutation {
     updateProjectV2ItemFieldValue(
       input: {
         projectId: "${ISSUES_PROJECT_NODE_ID}"
@@ -125,39 +117,8 @@ export async function modifyProjectIssueField(
     itemId,
     projectFieldOption,
     fieldId,
-  };
-  await sendQuery(modifyProjectIssueFieldMutation, data, octokit);
-}
-
-export async function modifyDueByDate(
-  itemId: string,
-  projectFieldOption: string,
-  fieldId: string,
-  octokit: Octokit
-) {
-  const modifyDueByDateMutation = `mutation {
-    updateProjectV2ItemFieldValue(
-      input: {
-        projectId: "${ISSUES_PROJECT_NODE_ID}"
-        itemId: "${itemId}"
-        fieldId: "${fieldId}"
-        value: {
-          text: "${projectFieldOption}"
-        }
-      }
-    ) {
-      projectV2Item {
-        id
-      }
-    }
-  }`;
-
-  const data = {
-    itemId,
-    projectFieldOption,
-    fieldId,
-  };
-  await sendQuery(modifyDueByDateMutation, data, octokit);
+  }
+  await sendQuery(addIssueToGlobalIssuesProjectMutation, data, octokit);
 }
 
 export async function getKeyValueFromProjectField(
@@ -186,7 +147,7 @@ export async function getKeyValueFromProjectField(
   const data = {
     issueNodeId,
     fieldName,
-  };
+  }
   const response = await sendQuery(query, data, octokit);
 
   return response?.node.fieldValueByName?.name;
@@ -209,7 +170,7 @@ export async function getIssueDetailsFromNodeId(
 
   const data = {
     issueNodeId,
-  };
+  }
   const response = await sendQuery(query, data, octokit);
 
   return {

--- a/src/utils/metrics.test.ts
+++ b/src/utils/metrics.test.ts
@@ -19,9 +19,9 @@ import { getLabelsTable } from '@/brain/issueNotifier';
 import {
   UNROUTED_LABEL,
   UNTRIAGED_LABEL,
-  WAITING_FOR_COMMUNITY_LABEL,
   WAITING_FOR_PRODUCT_OWNER_LABEL,
   WAITING_FOR_SUPPORT_LABEL,
+  WAITING_FOR_COMMUNITY_LABEL
 } from '@/config';
 import { db } from '@utils/db';
 

--- a/test/payloads/github/projects_v2_item.ts
+++ b/test/payloads/github/projects_v2_item.ts
@@ -3,65 +3,56 @@
 //   https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#webhook-payload-example-when-someone-edits-an-issue.
 
 export default {
-  action: 'edited',
+  action: "edited",
   projects_v2_item: {
     id: 28937214,
-    node_id: 'test-node-id',
-    project_node_id: 'test-project-node-id',
-    content_node_id: 'test-content-node-id',
-    content_type: 'Issue',
+    node_id: "test-node-id",
+    project_node_id: "test-project-node-id",
+    content_node_id: "test-content-node-id",
+    content_type: "Issue",
     creator: {
-      login: 'getsantry-bot[bot]',
+      login: "getsantry-bot[bot]",
       id: 112652482,
-      node_id: 'bot-node-id',
-      avatar_url: 'https://avatars.githubusercontent.com/u/121066737?v=4',
-      gravatar_id: '',
-      url: 'https://api.github.com/users/getsantry-bot%5Bbot%5D',
-      html_url: 'https://github.com/apps/getsantry-bot',
-      followers_url:
-        'https://api.github.com/users/getsantry-bot%5Bbot%5D/followers',
-      following_url:
-        'https://api.github.com/users/getsantry-bot%5Bbot%5D/following{/other_user}',
-      gists_url:
-        'https://api.github.com/users/getsantry-bot%5Bbot%5D/gists{/gist_id}',
-      starred_url:
-        'https://api.github.com/users/getsantry-bot%5Bbot%5D/starred{/owner}{/repo}',
-      subscriptions_url:
-        'https://api.github.com/users/getsantry-bot%5Bbot%5D/subscriptions',
-      organizations_url:
-        'https://api.github.com/users/getsantry-bot%5Bbot%5D/orgs',
-      repos_url: 'https://api.github.com/users/getsantry-bot%5Bbot%5D/repos',
-      events_url:
-        'https://api.github.com/users/getsantry-bot%5Bbot%5D/events{/privacy}',
-      received_events_url:
-        'https://api.github.com/users/getsantry-bot%5Bbot%5D/received_events',
-      type: 'Bot',
-      site_admin: false,
+      node_id: "bot-node-id",
+      avatar_url: "https://avatars.githubusercontent.com/u/121066737?v=4",
+      gravatar_id: "",
+      url: "https://api.github.com/users/getsantry-bot%5Bbot%5D",
+      html_url: "https://github.com/apps/getsantry-bot",
+      followers_url: "https://api.github.com/users/getsantry-bot%5Bbot%5D/followers",
+      following_url: "https://api.github.com/users/getsantry-bot%5Bbot%5D/following{/other_user}",
+      gists_url: "https://api.github.com/users/getsantry-bot%5Bbot%5D/gists{/gist_id}",
+      starred_url: "https://api.github.com/users/getsantry-bot%5Bbot%5D/starred{/owner}{/repo}",
+      subscriptions_url: "https://api.github.com/users/getsantry-bot%5Bbot%5D/subscriptions",
+      organizations_url: "https://api.github.com/users/getsantry-bot%5Bbot%5D/orgs",
+      repos_url: "https://api.github.com/users/getsantry-bot%5Bbot%5D/repos",
+      events_url: "https://api.github.com/users/getsantry-bot%5Bbot%5D/events{/privacy}",
+      received_events_url: "https://api.github.com/users/getsantry-bot%5Bbot%5D/received_events",
+      type: "Bot",
+      site_admin: false
     },
-    created_at: '2023-05-23T16:24:12Z',
-    updated_at: '2023-05-25T23:51:06Z',
-    archived_at: null,
+    created_at: "2023-05-23T16:24:12Z",
+    updated_at: "2023-05-25T23:51:06Z",
+    archived_at: null
   },
   changes: {
     field_value: {
-      field_node_id: 'field-id',
-      field_type: 'single_select',
-    },
+      field_node_id: "field-id",
+      field_type: "single_select"
+    }
   },
   organization: {
-    login: 'test-org',
+    login: "test-org",
     id: 121066737,
-    node_id: 'O_kgDMBzdU8Q',
-    url: 'https://api.github.com/orgs/test-org',
-    repos_url: 'https://api.github.com/orgs/test-org/repos',
-    events_url: 'https://api.github.com/orgs/test-org/events',
-    hooks_url: 'https://api.github.com/orgs/test-org/hooks',
-    issues_url: 'https://api.github.com/orgs/test-org/issues',
-    members_url: 'https://api.github.com/orgs/test-org/members{/member}',
-    public_members_url:
-      'https://api.github.com/orgs/test-org/public_members{/member}',
-    avatar_url: 'https://avatars.githubusercontent.com/u/121066737?v=4',
-    description: null,
+    node_id: "O_kgDMBzdU8Q",
+    url: "https://api.github.com/orgs/test-org",
+    repos_url: "https://api.github.com/orgs/test-org/repos",
+    events_url: "https://api.github.com/orgs/test-org/events",
+    hooks_url: "https://api.github.com/orgs/test-org/hooks",
+    issues_url: "https://api.github.com/orgs/test-org/issues",
+    members_url: "https://api.github.com/orgs/test-org/members{/member}",
+    public_members_url: "https://api.github.com/orgs/test-org/public_members{/member}",
+    avatar_url: "https://avatars.githubusercontent.com/u/121066737?v=4",
+    description: null
   },
   sender: {
     login: 'Picard',
@@ -72,19 +63,21 @@ export default {
     url: 'https://api.github.com/users/Picard',
     html_url: 'https://github.com/Picard',
     followers_url: 'https://api.github.com/users/Picard/followers',
-    following_url: 'https://api.github.com/users/Picard/following{/other_user}',
+    following_url:
+      'https://api.github.com/users/Picard/following{/other_user}',
     gists_url: 'https://api.github.com/users/Picard/gists{/gist_id}',
     starred_url: 'https://api.github.com/users/Picard/starred{/owner}{/repo}',
     subscriptions_url: 'https://api.github.com/users/Picard/subscriptions',
     organizations_url: 'https://api.github.com/users/Picard/orgs',
     repos_url: 'https://api.github.com/users/Picard/repos',
     events_url: 'https://api.github.com/users/Picard/events{/privacy}',
-    received_events_url: 'https://api.github.com/users/Picard/received_events',
+    received_events_url:
+      'https://api.github.com/users/Picard/received_events',
     type: 'User',
     site_admin: false,
   },
   installation: {
     id: 12321321,
-    node_id: 'MDIzOkludGVncmK0aW9uSW5zdGFsbGF0aW9uMzcxMTgwNTE=',
-  },
+    node_id: "MDIzOkludGVncmK0aW9uSW5zdGFsbGF0aW9uMzcxMTgwNTE="
+  }
 };


### PR DESCRIPTION
Reverts getsentry/eng-pipes#481

This is now sending slack notifications for timestamp of issues not being able to be parsed since comments don't have timestamps in them right now, this PR will have to wait to go in when we cutover to send slack notifications based on the timestamp in project fields.