### PR TITLE
Add more setup instructions to README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,15 +3,32 @@
 # tokens and secrets in this file
 
 # GitHub App ID
-GH_APP_IDENTIFIER=""
+GH_APP_IDENTIFIER=''
 # Github App Webhook Secret to verify requests come from GitHub
-GH_WEBHOOK_SECRET=""
+GH_WEBHOOK_SECRET=''
 # GitHub App Secret Key
 # NOTE: this *must* be on a single line, otherwise it will break
 # reading the secret key.
 GH_APP_SECRET_KEY='-----BEGIN RSA PRIVATE KEY----------END RSA PRIVATE KEY-----'
+# Personal (ie, for your own GitHub account) user access token with the `admin:org`,
+# `admin:org_hook`, `admin: repo_hook`, `project`, `public_repo`, `repo:status`, and
+# `repo_deployment` permissions enabled.
+GH_USER_TOKEN=''
 
 # Slack signing secret to verify requests come from Slack
 SLACK_SIGNING_SECRET=
 # Slack Bot user access token -> "Bot User OAuth Token"
 SLACK_BOT_USER_ACCESS_TOKEN=
+
+# The name of the personal repository in your personal organization being used for development.
+PERSONAL_TEST_REPO='eng-pipes-dev'
+
+# Application-specific configuration
+# Config for the "GitHub Issues Someone Else Cares About" project board
+ISSUES_PROJECT_NODE_ID=''
+STATUS_FIELD_ID=''
+PRODUCT_AREA_FIELD_ID=''
+RESPONSE_DUE_DATE_FIELD_ID=''
+
+# Silence some GCP noise
+DRY_RUN=1

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -101,7 +101,12 @@ export const WAITING_FOR_PRODUCT_OWNER_LABEL = 'Waiting for: Product Owner';
 export const MAX_TRIAGE_DAYS = 2;
 export const MAX_ROUTE_DAYS = 1;
 
-export const SENTRY_MONOREPOS = ['sentry', 'sentry-docs'];
+// Only add the `PERSONAL_TEST_REPO` to the array of `SENTRY_MONOREPOS` if it has actually been set
+// in the instantiating environment.
+export const PERSONAL_TEST_REPO = process.env.PERSONAL_TEST_REPO;
+export const PERSONAL_TEST_REPOS = PERSONAL_TEST_REPO ? [ PERSONAL_TEST_REPO ] : [];
+
+export const SENTRY_MONOREPOS = [ 'sentry', 'sentry-docs', ...PERSONAL_TEST_REPOS ];
 export const SENTRY_REPOS = [
   'arroyo',
   'cdc',


### PR DESCRIPTION
Clearer instructions on which orgs, projects, and tokens to setup, and which GraphQL queries to make to do so.