### PR TITLE
Fix numbering bug

### DIFF
--- a/src/webhooks/pubsub/slackNotifications.test.ts
+++ b/src/webhooks/pubsub/slackNotifications.test.ts
@@ -271,7 +271,7 @@ describe('Triage Notification Tests', function () {
           {
             fields: [
               {
-                text: '2. <https://test.com/issues/2|#2 Open Source Issue>',
+                text: '1. <https://test.com/issues/2|#2 Open Source Issue>',
                 type: 'mrkdwn',
               },
               { text: '1 hour 0 minutes overdue', type: 'mrkdwn' },
@@ -281,7 +281,7 @@ describe('Triage Notification Tests', function () {
           {
             fields: [
               {
-                text: '1. <https://test.com/issues/1|#1 Test Issue>',
+                text: '2. <https://test.com/issues/1|#1 Test Issue>',
                 type: 'mrkdwn',
               },
               { text: '0 minutes overdue', type: 'mrkdwn' },
@@ -293,12 +293,11 @@ describe('Triage Notification Tests', function () {
         text: '👋 Triage Reminder ⏰',
       });
     });
-    // TODO(https://github.com/getsentry/eng-pipes/issues/409): Test reproducing breakage in #409,
-    // fix will land in subsequent commit.
-    it('should sort issues before numbering them', async function () {
+    it('should sort issues before assigning ordinals to them', async function () {
       const notificationChannels = {
         channel1: ['Product Area: Test', 'Product Area: Other'],
       };
+
       // Note that these issues come in in reverse order.
       const productAreaToIssuesMap = {
         'Product Area: Other': [
@@ -356,7 +355,7 @@ describe('Triage Notification Tests', function () {
           {
             fields: [
               {
-                text: '2. <https://test.com/issues/2|#2 Open Source Issue>',
+                text: '1. <https://test.com/issues/2|#2 Open Source Issue>',
                 type: 'mrkdwn',
               },
               { text: '1 hour 0 minutes overdue', type: 'mrkdwn' },
@@ -366,10 +365,142 @@ describe('Triage Notification Tests', function () {
           {
             fields: [
               {
-                text: '1. <https://test.com/issues/1|#1 Test Issue>',
+                text: '2. <https://test.com/issues/1|#1 Test Issue>',
                 type: 'mrkdwn',
               },
               { text: '0 minutes overdue', type: 'mrkdwn' },
+            ],
+            type: 'section',
+          },
+        ],
+        channel: 'channel1',
+        text: '👋 Triage Reminder ⏰',
+      });
+    });
+    it('should maintain independent and properly sorted ordinals for adjacent issue lists', async function () {
+      const notificationChannels = {
+        channel1: ['Product Area: Test', 'Product Area: Other'],
+      };
+
+      // Note that the orders of the two lists are flipped relative to one another: one is
+      // ascending, the other is descending. This let's us validate that the final ordinal
+      // assignment is done independent of the ordering of the array we receive.
+      const productAreaToIssuesMap = {
+        'Product Area: Test': [
+          {
+            url: 'https://test.com/issues/3',
+            number: 3,
+            title: 'Test Issue Overdue',
+            productAreaLabel: 'Product Area: Test',
+            triageBy: '2022-12-12T15:00:00.000Z',
+            createdAt: '2022-12-10T21:00:00.000Z',
+          },
+          {
+            url: 'https://test.com/issues/1',
+            number: 1,
+            title: 'Test Issue Almost Due',
+            productAreaLabel: 'Product Area: Test',
+            triageBy: '2022-12-12T19:00:00.000Z',
+            createdAt: '2022-12-10T21:00:00.000Z',
+          },
+        ],
+        'Product Area: Other': [
+          {
+            url: 'https://test.com/issues/2',
+            number: 2,
+            title: 'Open Source Issue Almost Due',
+            productAreaLabel: 'Product Area: Other',
+            triageBy: '2022-12-12T18:00:00.000Z',
+            createdAt: '2022-12-10T21:00:00.000Z',
+          },
+          {
+            url: 'https://test.com/issues/4',
+            number: 4,
+            title: 'Open Source Issue Overdue',
+            productAreaLabel: 'Product Area: Other',
+            triageBy: '2022-12-12T16:00:00.000Z',
+            createdAt: '2022-12-10T21:00:00.000Z',
+          },
+        ],
+      };
+      const now = moment('2022-12-12T16:58:00.000Z');
+      const postMessageSpy = jest.spyOn(bolt.client.chat, 'postMessage');
+      await Promise.all(
+        constructSlackMessage(notificationChannels, productAreaToIssuesMap, now)
+      );
+      expect(postMessageSpy).toHaveBeenCalledTimes(1);
+      expect(postMessageSpy).toHaveBeenCalledWith({
+        blocks: [
+          {
+            text: {
+              text: 'Hey! You have some tickets to triage:',
+              type: 'plain_text',
+            },
+            type: 'header',
+          },
+          {
+            type: 'divider',
+          },
+          {
+            fields: [
+              {
+                text: '🚨 *Overdue*',
+                type: 'mrkdwn',
+              },
+              { text: '😰', type: 'mrkdwn' },
+            ],
+            type: 'section',
+          },
+          {
+            fields: [
+              {
+                text: '1. <https://test.com/issues/3|#3 Test Issue Overdue>',
+                type: 'mrkdwn',
+              },
+              { text: '1 hour 58 minutes overdue', type: 'mrkdwn' },
+            ],
+            type: 'section',
+          },
+          {
+            fields: [
+              {
+                text: '2. <https://test.com/issues/4|#4 Open Source Issue Overdue>',
+                type: 'mrkdwn',
+              },
+              { text: '58 minutes overdue', type: 'mrkdwn' },
+            ],
+            type: 'section',
+          },
+          {
+            fields: [
+              {
+                text: '⌛️ *Act fast!*',
+                type: 'mrkdwn',
+              },
+              {
+                text: '😨',
+                type: 'mrkdwn',
+              },
+            ],
+            type: 'section',
+          },
+          {
+            fields: [
+              {
+                text: '1. <https://test.com/issues/2|#2 Open Source Issue Almost Due>',
+                type: 'mrkdwn',
+              },
+              { text: '1 hour 2 minutes left', type: 'mrkdwn' },
+            ],
+            type: 'section',
+          },
+          {
+            fields: [
+              {
+                text: '2. <https://test.com/issues/1|#1 Test Issue Almost Due>',
+                type: 'mrkdwn',
+              },
+              { text: '2 hours 2 minutes left', type: 'mrkdwn' },
             ],
             type: 'section',
           },
@@ -615,7 +746,7 @@ describe('Triage Notification Tests', function () {
           {
             fields: [
               {
-                text: '2. <https://test.com/issues/2|#2 Open Source Issue>',
+                text: '1. <https://test.com/issues/2|#2 Open Source Issue>',
                 type: 'mrkdwn',
               },
               { text: '3 hours 0 minutes left', type: 'mrkdwn' },
@@ -625,7 +756,7 @@ describe('Triage Notification Tests', function () {
           {
             fields: [
               {
-                text: '1. <https://test.com/issues/1|#1 Test Issue>',
+                text: '2. <https://test.com/issues/1|#1 Test Issue>',
                 type: 'mrkdwn',
               },
               { text: '4 hours 0 minutes left', type: 'mrkdwn' },
@@ -810,7 +941,7 @@ describe('Triage Notification Tests', function () {
           {
             fields: [
               {
-                text: '2. <https://test.com/issues/2|#2 Open Source Issue>',
+                text: '1. <https://test.com/issues/2|#2 Open Source Issue>',
                 type: 'mrkdwn',
               },
               { text: '1 day left', type: 'mrkdwn' },
@@ -820,7 +951,7 @@ describe('Triage Notification Tests', function () {
           {
             fields: [
               {
-                text: '1. <https://test.com/issues/1|#1 Test Issue>',
+                text: '2. <https://test.com/issues/1|#1 Test Issue>',
                 type: 'mrkdwn',
               },
               { text: '1 day left', type: 'mrkdwn' },

--- a/src/webhooks/pubsub/slackNotifications.ts
+++ b/src/webhooks/pubsub/slackNotifications.ts
@@ -13,7 +13,15 @@ const GH_API_PER_PAGE = 100;
 const DEFAULT_PRODUCT_AREA_LABEL = 'Product Area: Other';
 const getChannelLastNotifiedTable = () => db('channel_last_notified');
 
-type SlackMessageIssueItem = {
+// An item with all of its relevant properties stringified as markdown.
+type SlackMessageUnorderedIssueItem = {
+  triageBy: string;
+  issueLink: string;
+  timeLeft: string;
+}
+
+// Like the above, but the numerical prefix to each row now has a correct numerical ordering.
+type SlackMessageOrderedIssueItem = {
   triageBy: string;
   fields: [
     // Issue title and link
@@ -74,6 +82,30 @@ const getIssueProductAreaLabel = (issue: Issue) => {
   return getLabelName(label) || DEFAULT_PRODUCT_AREA_LABEL;
 };
 
+// Note that the `ordinal` field is the literal number that will show up, not the index in the
+// owning array. For example, it is the caller's responsibility to offset the 0-indexed entries of
+// an array if a 1-indexed list is what we want the user to see (it almost always is).
+const addOrderingToSlackMessageItem = (
+  item: SlackMessageUnorderedIssueItem,
+  ordinal: number
+): SlackMessageOrderedIssueItem => {
+  return {
+    triageBy: item.triageBy,
+    fields: [
+      // Issue title and link
+      {
+        text: `${ordinal}. ${item.issueLink}`,
+        type: "mrkdwn",
+      },
+      // Time until issue is due
+      {
+        text: item.timeLeft,
+        type: "mrkdwn",
+      },
+    ],
+  };
+};
+
 export const getTriageSLOTimestamp = async (
   octokit: Octokit,
   repo: string,
@@ -116,9 +148,9 @@ export const constructSlackMessage = (
   return Object.keys(notificationChannels).flatMap(async (channelId) => {
     // Group issues into buckets based on time left until SLA
     let hasEnoughTimePassedSinceIssueCreation = false;
-    const overdueIssues: SlackMessageIssueItem[] = [];
-    const actFastIssues: SlackMessageIssueItem[] = [];
-    const triageQueueIssues: SlackMessageIssueItem[] = [];
+    const overdueIssues: SlackMessageUnorderedIssueItem[] = [];
+    const actFastIssues: SlackMessageUnorderedIssueItem[] = [];
+    const triageQueueIssues: SlackMessageUnorderedIssueItem[] = [];
     if (await isChannelInBusinessHours(channelId, now)) {
       notificationChannels[channelId].map((productArea) => {
         productAreaToIssuesMap[productArea].forEach(
@@ -141,15 +173,8 @@ export const constructSlackMessage = (
                   : `${daysLeft * -1} days`;
               overdueIssues.push({
                 triageBy,
-                fields: [
-                  {
-                    text: `${
-                      overdueIssues.length + 1
-                    }. <${url}|#${number} ${escapedIssueTitle}>`,
-                    type: 'mrkdwn',
-                  },
-                  { text: `${daysText} overdue`, type: 'mrkdwn' },
-                ],
+                issueLink: `<${url}|#${number} ${escapedIssueTitle}>`,
+                timeLeft: `${daysText} overdue`,
               });
             } else if (hoursLeft < -4) {
               const hoursText =
@@ -158,15 +183,8 @@ export const constructSlackMessage = (
                   : `${hoursLeft * -1} hours`;
               overdueIssues.push({
                 triageBy,
-                fields: [
-                  {
-                    text: `${
-                      overdueIssues.length + 1
-                    }. <${url}|#${number} ${escapedIssueTitle}>`,
-                    type: 'mrkdwn',
-                  },
-                  { text: `${hoursText} overdue`, type: 'mrkdwn' },
-                ],
+                issueLink: `<${url}|#${number} ${escapedIssueTitle}>`,
+                timeLeft: `${hoursText} overdue`,
               });
             } else if (hoursLeft <= -1) {
               const minutesText =
@@ -179,18 +197,8 @@ export const constructSlackMessage = (
                   : `${hoursLeft * -1} hours`;
               overdueIssues.push({
                 triageBy,
-                fields: [
-                  {
-                    text: `${
-                      overdueIssues.length + 1
-                    }. <${url}|#${number} ${escapedIssueTitle}>`,
-                    type: 'mrkdwn',
-                  },
-                  {
-                    text: `${hoursText} ${minutesText} overdue`,
-                    type: 'mrkdwn',
-                  },
-                ],
+                issueLink: `<${url}|#${number} ${escapedIssueTitle}>`,
+                timeLeft: `${hoursText} ${minutesText} overdue`,
               });
             } else if (hoursLeft == 0 && minutesLeft <= 0) {
               const minutesText =
@@ -199,15 +207,8 @@ export const constructSlackMessage = (
                   : `${minutesLeft * -1} minutes`;
               overdueIssues.push({
                 triageBy,
-                fields: [
-                  {
-                    text: `${
-                      overdueIssues.length + 1
-                    }. <${url}|#${number} ${escapedIssueTitle}>`,
-                    type: 'mrkdwn',
-                  },
-                  { text: `${minutesText} overdue`, type: 'mrkdwn' },
-                ],
+                issueLink: `<${url}|#${number} ${escapedIssueTitle}>`,
+                timeLeft: `${minutesText} overdue`,
               });
             } else if (hoursLeft == 0 && minutesLeft >= 0) {
               const minutesText =
@@ -216,15 +217,8 @@ export const constructSlackMessage = (
                   : `${minutesLeft} minutes`;
               actFastIssues.push({
                 triageBy,
-                fields: [
-                  {
-                    text: `${
-                      actFastIssues.length + 1
-                    }. <${url}|#${number} ${escapedIssueTitle}>`,
-                    type: 'mrkdwn',
-                  },
-                  { text: `${minutesText} left`, type: 'mrkdwn' },
-                ],
+                issueLink: `<${url}|#${number} ${escapedIssueTitle}>`,
+                timeLeft: `${minutesText} left`,
               });
             } else if (hoursLeft <= 4) {
               const minutesText =
@@ -235,58 +229,41 @@ export const constructSlackMessage = (
                 hoursLeft === 1 ? `${hoursLeft} hour` : `${hoursLeft} hours`;
               actFastIssues.push({
                 triageBy,
-                fields: [
-                  {
-                    text: `${
-                      actFastIssues.length + 1
-                    }. <${url}|#${number} ${escapedIssueTitle}>`,
-                    type: 'mrkdwn',
-                  },
-                  { text: `${hoursText} ${minutesText} left`, type: 'mrkdwn' },
-                ],
+                issueLink: `<${url}|#${number} ${escapedIssueTitle}>`,
+                timeLeft: `${hoursText} ${minutesText} left`,
               });
             } else {
               if (daysLeft < 1) {
                 triageQueueIssues.push({
                   triageBy,
-                  fields: [
-                    {
-                      text: `${
-                        triageQueueIssues.length + 1
-                      }. <${url}|#${number} ${escapedIssueTitle}>`,
-                      type: 'mrkdwn',
-                    },
-                    { text: `${hoursLeft} hours left`, type: 'mrkdwn' },
-                  ],
+                  issueLink: `<${url}|#${number} ${escapedIssueTitle}>`,
+                  timeLeft: `${hoursLeft} hours left`,
                 });
               } else {
                 const daysText =
                   daysLeft === 1 ? `${daysLeft} day` : `${daysLeft} days`;
                 triageQueueIssues.push({
                   triageBy,
-                  fields: [
-                    {
-                      text: `${
-                        triageQueueIssues.length + 1
-                      }. <${url}|#${number} ${escapedIssueTitle}>`,
-                      type: 'mrkdwn',
-                    },
-                    { text: `${daysText} left`, type: 'mrkdwn' },
-                  ],
+                  issueLink: `<${url}|#${number} ${escapedIssueTitle}>`,
+                  timeLeft: `${daysText} left`,
                 });
               }
             }
           }
         );
       });
+  
       const sortAndFlattenIssuesArray = (issues) =>
         issues
           .sort(
             (a, b) =>
               moment(a.triageBy).valueOf() - moment(b.triageBy).valueOf()
           )
-          .map((item) => item.fields)
+          .map((item, index) => {
+            return addOrderingToSlackMessageItem(item, index + 1).fields;
+          })
           .flat();
+  
       const messageBlocks: SlackMessageBlocks[] = [
         {
           type: 'header',


### PR DESCRIPTION
The bug appeared because numbers were assigned to the output text before
sorting occurred. In addition to some DRY cleanup, we now create a
`SlackMessageUnorderedIssueItem` which stores all of the output strings
we'll need without numbering. Once we sort, we then map over the
now-sorted list to map all of our `SlackMessageUnorderedIssueItem`s to
`SlackMessageOrderedIssueItem`s via the new
`addOrderingToSlackMessageItem` helper function.