### PR TITLE
Tidy up getClient usage

### DIFF
--- a/src/api/github/getChangedStack.ts
+++ b/src/api/github/getChangedStack.ts
@@ -12,14 +12,9 @@ const BACKEND_CHANGE_CHECK_NAME = 'only backend changes';
  * Given a commit and repo, check GitHub Checks to see what type of changes
  * were made in the commit (frontend, backend, fullstack)
  */
-export async function getChangedStack(
-  ref: string,
-  repo: string,
-  client?: Octokit
-) {
+export async function getChangedStack(ref: string, repo: string) {
   try {
-    // We can save on making extra calls to get GH client
-    const octokit = client || (await getClient(ClientType.App, OWNER));
+    const octokit = await getClient(ClientType.App, OWNER);
 
     const check_runs = await octokit.paginate(octokit.checks.listForRef, {
       owner: OWNER,

--- a/src/api/github/getChangedStack.ts
+++ b/src/api/github/getChangedStack.ts
@@ -1,4 +1,3 @@
-import { Octokit } from '@octokit/rest';
 import * as Sentry from '@sentry/node';
 
 import { ClientType } from '@/api/github/clientType';

--- a/src/api/github/getClient.ts
+++ b/src/api/github/getClient.ts
@@ -26,7 +26,7 @@ function _getAppClient(auth: AppAuthStrategyOptions) {
  *
  * Only org is required, as we can assume the GH App is installed org-wide.
  */
-export async function getClient(type: ClientType, org: string | null) {
+export async function getClient(type: ClientType, org?: string | null) {
   if (process.env.FORCE_USER_TOKEN_GITHUB_CLIENT == 'true') {
     return _getUserClient();
   }

--- a/src/api/github/getRelevantCommit.ts
+++ b/src/api/github/getRelevantCommit.ts
@@ -12,10 +12,9 @@ import { getClient } from '@api/github/getClient';
  * caused a bump commit in getsentry (whose commit message references the sentry commit).
  * In this case, it will return the sentry commit.
  */
-export async function getRelevantCommit(ref: string, client?: Octokit) {
+export async function getRelevantCommit(ref: string) {
   try {
-    // We can save on making extra calls to get GH client
-    const octokit = client || (await getClient(ClientType.App, OWNER));
+    const octokit = await getClient(ClientType.App, OWNER);
 
     // Attempt to get the getsentry commit first
     const { data: commit } = await octokit.repos.getCommit({

--- a/src/api/github/getRelevantCommit.ts
+++ b/src/api/github/getRelevantCommit.ts
@@ -1,4 +1,3 @@
-import { Octokit } from '@octokit/rest';
 import * as Sentry from '@sentry/node';
 
 import { ClientType } from '@/api/github/clientType';

--- a/src/api/github/getSentryPullRequestsForGetsentryRange.test.ts
+++ b/src/api/github/getSentryPullRequestsForGetsentryRange.test.ts
@@ -5,18 +5,18 @@ import { getClient } from '@api/github/getClient';
 import { getSentryPullRequestsForGetsentryRange } from './getSentryPullRequestsForGetsentryRange';
 
 describe('getSentryPullRequestsForGetsentryRange', function () {
-  let getsentry;
+  let octokit;
 
   beforeAll(async function () {});
 
   afterAll(async function () {});
 
   beforeEach(async function () {
-    getsentry = await getClient(ClientType.App, 'getsentry');
+    octokit = await getClient(ClientType.App, 'getsentry');
   });
 
   afterEach(function () {
-    [getsentry].forEach((c) => {
+    [octokit].forEach((c) => {
       c.git.getCommit.mockClear();
       c.repos.listPullRequestsAssociatedWithCommit.mockClear();
       c.repos.compareCommits.mockClear();
@@ -24,7 +24,7 @@ describe('getSentryPullRequestsForGetsentryRange', function () {
   });
 
   it('single commit, sentry', async function () {
-    getsentry.repos.listPullRequestsAssociatedWithCommit.mockImplementation(
+    octokit.repos.listPullRequestsAssociatedWithCommit.mockImplementation(
       ({ repo }) => {
         if (repo === 'sentry') {
           return {
@@ -35,7 +35,7 @@ describe('getSentryPullRequestsForGetsentryRange', function () {
         return undefined;
       }
     );
-    getsentry.git.getCommit.mockImplementation(() => ({
+    octokit.git.getCommit.mockImplementation(() => ({
       status: 200,
       data: {
         committer: {
@@ -50,10 +50,10 @@ describe('getSentryPullRequestsForGetsentryRange', function () {
       { foo: 1 },
     ]);
     expect(
-      getsentry.repos.listPullRequestsAssociatedWithCommit
+      octokit.repos.listPullRequestsAssociatedWithCommit
     ).toHaveBeenCalledTimes(1);
     expect(
-      getsentry.repos.listPullRequestsAssociatedWithCommit
+      octokit.repos.listPullRequestsAssociatedWithCommit
     ).toHaveBeenCalledWith({
       owner: 'getsentry',
       repo: 'sentry',
@@ -62,7 +62,7 @@ describe('getSentryPullRequestsForGetsentryRange', function () {
   });
 
   it('multiple commits, sentry', async function () {
-    getsentry.repos.listPullRequestsAssociatedWithCommit.mockImplementation(
+    octokit.repos.listPullRequestsAssociatedWithCommit.mockImplementation(
       ({ repo }) => {
         if (repo === 'sentry') {
           return {
@@ -74,7 +74,7 @@ describe('getSentryPullRequestsForGetsentryRange', function () {
       }
     );
 
-    getsentry.repos.compareCommits.mockImplementation(() => ({
+    octokit.repos.compareCommits.mockImplementation(() => ({
       status: 200,
       data: {
         commits: [
@@ -95,17 +95,17 @@ describe('getSentryPullRequestsForGetsentryRange', function () {
     expect(
       await getSentryPullRequestsForGetsentryRange('f00123', 'deadbeef')
     ).toEqual([{ foo: 1 }]);
-    expect(getsentry.repos.compareCommits).toHaveBeenLastCalledWith({
+    expect(octokit.repos.compareCommits).toHaveBeenLastCalledWith({
       owner: 'getsentry',
       repo: 'getsentry',
       base: 'deadbeef',
       head: 'f00123',
     });
     expect(
-      getsentry.repos.listPullRequestsAssociatedWithCommit
+      octokit.repos.listPullRequestsAssociatedWithCommit
     ).toHaveBeenCalledTimes(1);
     expect(
-      getsentry.repos.listPullRequestsAssociatedWithCommit
+      octokit.repos.listPullRequestsAssociatedWithCommit
     ).toHaveBeenCalledWith({
       owner: 'getsentry',
       repo: 'sentry',
@@ -114,7 +114,7 @@ describe('getSentryPullRequestsForGetsentryRange', function () {
   });
 
   it('single commit, getsentry', async function () {
-    getsentry.repos.listPullRequestsAssociatedWithCommit.mockImplementation(
+    octokit.repos.listPullRequestsAssociatedWithCommit.mockImplementation(
       ({ repo }) => {
         if (repo === 'getsentry') {
           return {
@@ -125,7 +125,7 @@ describe('getSentryPullRequestsForGetsentryRange', function () {
         return undefined;
       }
     );
-    getsentry.git.getCommit.mockImplementation(() => ({
+    octokit.git.getCommit.mockImplementation(() => ({
       status: 200,
       data: {
         committer: {
@@ -139,10 +139,10 @@ describe('getSentryPullRequestsForGetsentryRange', function () {
       await getSentryPullRequestsForGetsentryRange('f00123', null, true)
     ).toEqual([{ foo: 1 }]);
     expect(
-      getsentry.repos.listPullRequestsAssociatedWithCommit
+      octokit.repos.listPullRequestsAssociatedWithCommit
     ).toHaveBeenCalledTimes(1);
     expect(
-      getsentry.repos.listPullRequestsAssociatedWithCommit
+      octokit.repos.listPullRequestsAssociatedWithCommit
     ).toHaveBeenCalledWith({
       owner: 'getsentry',
       repo: 'getsentry',
@@ -151,14 +151,14 @@ describe('getSentryPullRequestsForGetsentryRange', function () {
   });
 
   it('multiple commits, getsentry', async function () {
-    getsentry.repos.listPullRequestsAssociatedWithCommit.mockImplementation(
+    octokit.repos.listPullRequestsAssociatedWithCommit.mockImplementation(
       ({ repo }) => {
         return repo === 'getsentry'
           ? { data: [{ bar: 2 }] }
           : { data: [{ foo: 1 }] };
       }
     );
-    getsentry.repos.compareCommits.mockImplementation(() => ({
+    octokit.repos.compareCommits.mockImplementation(() => ({
       status: 200,
       data: {
         commits: [
@@ -189,18 +189,18 @@ describe('getSentryPullRequestsForGetsentryRange', function () {
     expect(
       await getSentryPullRequestsForGetsentryRange('f00123', 'deadbeef', true)
     ).toEqual([{ foo: 1 }, { bar: 2 }]);
-    expect(getsentry.repos.compareCommits).toHaveBeenLastCalledWith({
+    expect(octokit.repos.compareCommits).toHaveBeenLastCalledWith({
       owner: 'getsentry',
       repo: 'getsentry',
       base: 'deadbeef',
       head: 'f00123',
     });
     expect(
-      getsentry.repos.listPullRequestsAssociatedWithCommit
+      octokit.repos.listPullRequestsAssociatedWithCommit
     ).toHaveBeenCalledTimes(2);
 
     expect(
-      getsentry.repos.listPullRequestsAssociatedWithCommit
+      octokit.repos.listPullRequestsAssociatedWithCommit
     ).toHaveBeenCalledWith({
       owner: 'getsentry',
       repo: 'sentry',

--- a/src/brain/notifyOnGoCDStageEvent/index.ts
+++ b/src/brain/notifyOnGoCDStageEvent/index.ts
@@ -172,11 +172,11 @@ async function updateCommitQueue(
 // Depending on whether `getsentry-frontend` or `getsentry-backend`
 // is being deployed, only certain commits (FE/BE) will be
 // affected. Filter the sha list to just FE or BE commits.
-async function filterCommits(octokit, pipeline, commits) {
+async function filterCommits(pipeline, commits) {
   const relevantCommitShas: string[] = [];
   const commitShas = commits.map(({ sha }) => sha);
   for (const sha of commitShas) {
-    const relevantCommit = await getRelevantCommit(sha, octokit);
+    const relevantCommit = await getRelevantCommit(sha);
     // Commit should exist, but if not log and move on
     if (!relevantCommit) {
       Sentry.setContext('commit', {
@@ -285,11 +285,7 @@ export async function handler(resBody: GoCDResponse) {
       sha,
       firstMaterialSHA(latestDeploy)
     );
-    const relevantCommitShas: string[] = await filterCommits(
-      octokit,
-      pipeline,
-      commits
-    );
+    const relevantCommitShas: string[] = await filterCommits(pipeline, commits);
 
     await Promise.all([
       updateCommitQueue(pipeline, sha, commits),

--- a/src/brain/pleaseDeployNotifier/actionViewUndeployedCommits.ts
+++ b/src/brain/pleaseDeployNotifier/actionViewUndeployedCommits.ts
@@ -87,7 +87,7 @@ export async function actionViewUndeployedCommits({
   // Get the "relevant" commits from either sentry or getsentry
   // We include `base` here as `compareCommits` does not
   const relevantCommits = await Promise.all(
-    data.commits.map(({ sha }) => getRelevantCommit(sha, octokit))
+    data.commits.map(({ sha }) => getRelevantCommit(sha))
   );
 
   const commitBlocks = (

--- a/src/utils/getOssUserType.ts
+++ b/src/utils/getOssUserType.ts
@@ -29,7 +29,6 @@ export async function getOssUserType(
   }
 
   const org = owner.login;
-  const octokit = await getClient(ClientType.User, org);
   const username = payload.sender.login;
 
   const cachedResult = _USER_CACHE.get(username);
@@ -53,6 +52,8 @@ export async function getOssUserType(
   let type: UserType | null = null;
   let status: number | null;
   let check: 'Org' | 'Team';
+
+  const octokit = await getClient(ClientType.User);
 
   // https://docs.github.com/en/rest/reference/orgs#check-organization-membership-for-a-user
   check = 'Org';


### PR DESCRIPTION
Part of #482, after #503, before #505.

Noticed these in https://github.com/getsentry/eng-pipes/issues/482#issuecomment-1613944724. By getting rid of some of this noise around `getClient`, it should hopefully be a bit easier to tackle the `owner`/`OWNER` discrepancy, which is the primary blocker for https://github.com/getsentry/eng-pipes/issues/482 atm.