### PR TITLE
Don't warn dev-infra when checks fail in GoCD piplines

### DIFF
--- a/src/brain/gocdSlackFeeds/index.ts
+++ b/src/brain/gocdSlackFeeds/index.ts
@@ -39,6 +39,12 @@ const devinfraFeed = new DeployFeed({
       return false;
     }
 
+    // Checks failing typically indicate GitHub flaking or a temporary
+    // issue with master. We have sentry alerts to monitor this.
+    if (pipeline.stage.name == 'checks') {
+      return false;
+    }
+
     // We only really care about creating new messages if the pipeline has
     // failed.
     return pipeline.stage.result.toLowerCase() === 'failed';


### PR DESCRIPTION
We have extra alerts for CI consistently failing, so removing this will reduce the noise in feed-dev-infra.