### PR TITLE
Rename OWNER to GETSENTRY_ORG

### DIFF
--- a/src/api/github/getChangedStack.ts
+++ b/src/api/github/getChangedStack.ts
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/node';
 
 import { ClientType } from '@/api/github/clientType';
-import { OWNER } from '@/config';
+import { GETSENTRY_ORG } from '@/config';
 import { getClient } from '@api/github/getClient';
 
 const FRONTEND_CHANGE_CHECK_NAME = 'only frontend changes';
@@ -13,10 +13,10 @@ const BACKEND_CHANGE_CHECK_NAME = 'only backend changes';
  */
 export async function getChangedStack(ref: string, repo: string) {
   try {
-    const octokit = await getClient(ClientType.App, OWNER);
+    const octokit = await getClient(ClientType.App, GETSENTRY_ORG);
 
     const check_runs = await octokit.paginate(octokit.checks.listForRef, {
-      owner: OWNER,
+      owner: GETSENTRY_ORG,
       repo,
       ref,
       per_page: 100,
@@ -36,7 +36,7 @@ export async function getChangedStack(ref: string, repo: string) {
       // Track this event in case the check status name changes in the future.
       Sentry.captureMessage(`Failed to identify the type of commit`, {
         extra: {
-          Commit: `https://github.com/${OWNER}/${repo}/commit/${ref}`,
+          Commit: `https://github.com/${GETSENTRY_ORG}/${repo}/commit/${ref}`,
           'GH Check Runs': check_runs.map((c) => c.name),
         },
       });

--- a/src/api/github/getRelevantCommit.ts
+++ b/src/api/github/getRelevantCommit.ts
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/node';
 
 import { ClientType } from '@/api/github/clientType';
-import { GETSENTRY_REPO, OWNER, SENTRY_REPO } from '@/config';
+import { GETSENTRY_ORG, GETSENTRY_REPO, SENTRY_REPO } from '@/config';
 import { getClient } from '@api/github/getClient';
 
 /**
@@ -13,11 +13,11 @@ import { getClient } from '@api/github/getClient';
  */
 export async function getRelevantCommit(ref: string) {
   try {
-    const octokit = await getClient(ClientType.App, OWNER);
+    const octokit = await getClient(ClientType.App, GETSENTRY_ORG);
 
     // Attempt to get the getsentry commit first
     const { data: commit } = await octokit.repos.getCommit({
-      owner: OWNER,
+      owner: GETSENTRY_ORG,
       repo: GETSENTRY_REPO,
       ref,
     });
@@ -39,7 +39,7 @@ export async function getRelevantCommit(ref: string) {
     //
     // In this case, fetch the sentry commit to display
     const { data } = await octokit.repos.getCommit({
-      owner: OWNER,
+      owner: GETSENTRY_ORG,
       repo: SENTRY_REPO,
       ref: sentryCommitSha,
     });

--- a/src/api/github/isGetsentryRequiredCheck/index.ts
+++ b/src/api/github/isGetsentryRequiredCheck/index.ts
@@ -1,6 +1,6 @@
 import { EmitterWebhookEvent } from '@octokit/webhooks';
 
-import { GETSENTRY_REPO, OWNER, REQUIRED_CHECK_NAME } from '@/config';
+import { GETSENTRY_ORG, GETSENTRY_REPO, REQUIRED_CHECK_NAME } from '@/config';
 
 /**
  * Checks payload to see if:
@@ -12,7 +12,7 @@ export function isGetsentryRequiredCheck({
   payload,
 }: EmitterWebhookEvent<'check_run'>) {
   // Only on `getsentry` repo
-  if (payload.repository?.full_name !== `${OWNER}/${GETSENTRY_REPO}`) {
+  if (payload.repository?.full_name !== `${GETSENTRY_ORG}/${GETSENTRY_REPO}`) {
     return false;
   }
 

--- a/src/brain/gocdSlackFeeds/deployFeed.test.ts
+++ b/src/brain/gocdSlackFeeds/deployFeed.test.ts
@@ -3,7 +3,7 @@ import merge from 'lodash.merge';
 import payload from '@test/payloads/gocd/gocd-stage-building.json';
 
 import * as slackblocks from '@/blocks/slackBlocks';
-import { Color, OWNER } from '@/config';
+import { Color, GETSENTRY_ORG } from '@/config';
 import { SlackMessage } from '@/config/slackMessage';
 import { GoCDPipeline } from '@/types';
 import { ClientType } from '@api/github/clientType';
@@ -516,7 +516,7 @@ describe('DeployFeed', () => {
   });
 
   it('post message with commits in deploy link for getsentry', async () => {
-    const octokit = await getClient(ClientType.App, OWNER);
+    const octokit = await getClient(ClientType.App, GETSENTRY_ORG);
     octokit.repos.getContent.mockImplementation((args) => {
       if (args.owner != 'getsentry') {
         throw new Error(`Unexpected getContent() owner: ${args.owner}`);
@@ -647,7 +647,7 @@ describe('DeployFeed', () => {
   });
 
   it('handle error if get content fails', async () => {
-    const octokit = await getClient(ClientType.App, OWNER);
+    const octokit = await getClient(ClientType.App, GETSENTRY_ORG);
     octokit.repos.getContent.mockImplementation((args) => {
       throw new Error('Injected error');
     });

--- a/src/brain/gocdSlackFeeds/deployFeed.ts
+++ b/src/brain/gocdSlackFeeds/deployFeed.ts
@@ -5,7 +5,12 @@ import { getUser } from '@/api/getUser';
 import { ClientType } from '@/api/github/clientType';
 import { bolt } from '@/api/slack';
 import * as slackblocks from '@/blocks/slackBlocks';
-import { GETSENTRY_REPO, GOCD_ORIGIN, OWNER, SENTRY_REPO } from '@/config';
+import {
+  GETSENTRY_ORG,
+  GETSENTRY_REPO,
+  GOCD_ORIGIN,
+  SENTRY_REPO,
+} from '@/config';
 import { SlackMessage } from '@/config/slackMessage';
 import { GoCDModification, GoCDPipeline, GoCDResponse } from '@/types';
 import { getLastGetSentryGoCDDeploy } from '@/utils/db/getLatestDeploy';
@@ -73,7 +78,7 @@ export class DeployFeed {
     prevDeploySHA: string,
     currentDeploySHA
   ) {
-    const octokit = await getClient(ClientType.App, OWNER);
+    const octokit = await getClient(ClientType.App, GETSENTRY_ORG);
     const responses = await Promise.all([
       octokit.repos.getContent({
         owner,

--- a/src/brain/issueLabelHandler/route.ts
+++ b/src/brain/issueLabelHandler/route.ts
@@ -3,12 +3,12 @@ import * as Sentry from '@sentry/node';
 
 import {
   BACKLOG_LABEL,
+  GETSENTRY_ORG,
   IN_PROGRESS_LABEL,
   PRODUCT_AREA_FIELD_ID,
   PRODUCT_AREA_LABEL_PREFIX,
   PRODUCT_AREA_UNKNOWN,
   SENTRY_MONOREPOS,
-  SENTRY_ORG,
   STATUS_LABEL_PREFIX,
   UNROUTED_LABEL,
   UNTRIAGED_LABEL,
@@ -95,7 +95,7 @@ export async function markUnrouted({
     owner,
     repo: repo,
     issue_number: issueNumber,
-    body: `Assigning to @${SENTRY_ORG}/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️`,
+    body: `Assigning to @${GETSENTRY_ORG}/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️`,
   });
 
   tx.finish();
@@ -108,13 +108,13 @@ async function routeIssue(octokit, productAreaLabelName) {
     );
     const ghTeamSlug = 'product-owners-' + slugizeProductArea(productArea);
     await octokit.teams.getByName({
-      org: SENTRY_ORG,
+      org: GETSENTRY_ORG,
       team_slug: ghTeamSlug,
     }); // expected to throw if team doesn't exist
-    return `Routing to @${SENTRY_ORG}/${ghTeamSlug} for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️`;
+    return `Routing to @${GETSENTRY_ORG}/${ghTeamSlug} for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️`;
   } catch (error) {
     Sentry.captureException(error);
-    return `Failed to route for ${productAreaLabelName}. Defaulting to @${SENTRY_ORG}/open-source for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️`;
+    return `Failed to route for ${productAreaLabelName}. Defaulting to @${GETSENTRY_ORG}/open-source for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️`;
   }
 }
 

--- a/src/brain/notifyOnGoCDStageEvent/index.ts
+++ b/src/brain/notifyOnGoCDStageEvent/index.ts
@@ -15,10 +15,10 @@ import { getRelevantCommit } from '@/api/github/getRelevantCommit';
 import { gocdevents } from '@/api/gocdevents';
 import { getUpdatedGoCDDeployMessage } from '@/blocks/getUpdatedDeployMessage';
 import {
+  GETSENTRY_ORG,
   GETSENTRY_REPO,
   GOCD_SENTRYIO_BE_PIPELINE_NAME,
   GOCD_SENTRYIO_FE_PIPELINE_NAME,
-  OWNER,
   SENTRY_REPO,
 } from '@/config';
 import { SlackMessage } from '@/config/slackMessage';
@@ -212,7 +212,7 @@ async function getCommitsInDeployment(
 ): Promise<CompareCommits['commits']> {
   if (prevsha && prevsha !== sha) {
     const { data } = await octokit.repos.compareCommits({
-      owner: OWNER,
+      owner: GETSENTRY_ORG,
       repo: GETSENTRY_REPO,
       head: sha,
       base: prevsha,
@@ -220,7 +220,7 @@ async function getCommitsInDeployment(
     return data.commits;
   }
   const resp = await octokit.repos.getCommit({
-    owner: OWNER,
+    owner: GETSENTRY_ORG,
     repo: GETSENTRY_REPO,
     ref: sha,
   });
@@ -233,7 +233,7 @@ function getGetsentrySHA(buildcauses: Array<GoCDBuildCause>) {
       continue;
     }
     const url = bc.material['git-configuration'].url;
-    if (url.indexOf(`${OWNER}/${GETSENTRY_REPO}`) != -1) {
+    if (url.indexOf(`${GETSENTRY_ORG}/${GETSENTRY_REPO}`) != -1) {
       return bc.modifications[0].revision;
     }
   }
@@ -273,7 +273,7 @@ export async function handler(resBody: GoCDResponse) {
   Sentry.configureScope((scope) => scope.setSpan(tx));
 
   // Get the range of commits for this payload
-  const octokit = await getClient(ClientType.App, OWNER);
+  const octokit = await getClient(ClientType.App, GETSENTRY_ORG);
 
   try {
     const latestDeploy = await getLastGetSentryGoCDDeploy(

--- a/src/brain/pleaseDeployNotifier/actionViewUndeployedCommits.ts
+++ b/src/brain/pleaseDeployNotifier/actionViewUndeployedCommits.ts
@@ -2,10 +2,10 @@ import * as Sentry from '@sentry/node';
 
 import { ClientType } from '@/api/github/clientType';
 import {
+  GETSENTRY_ORG,
   GETSENTRY_REPO,
   GOCD_SENTRYIO_BE_PIPELINE_GROUP,
   GOCD_SENTRYIO_BE_PIPELINE_NAME,
-  OWNER,
 } from '@/config';
 import { firstMaterialSHA } from '@/utils/gocdHelpers';
 import { getBlocksForCommit } from '@api/getBlocksForCommit';
@@ -68,7 +68,7 @@ export async function actionViewUndeployedCommits({
     return;
   }
 
-  const octokit = await getClient(ClientType.App, OWNER);
+  const octokit = await getClient(ClientType.App, GETSENTRY_ORG);
   const base = firstMaterialSHA(lastDeploy);
   if (!base) {
     // Failed to get base sha
@@ -78,7 +78,7 @@ export async function actionViewUndeployedCommits({
 
   // Get all getsentry commits between `base` and `head`
   const { data } = await octokit.repos.compareCommits({
-    owner: OWNER,
+    owner: GETSENTRY_ORG,
     repo: GETSENTRY_REPO,
     base,
     head,

--- a/src/brain/pleaseDeployNotifier/index.ts
+++ b/src/brain/pleaseDeployNotifier/index.ts
@@ -10,10 +10,10 @@ import { muteDeployNotificationsButton } from '@/blocks/muteDeployNotificationsB
 import { viewUndeployedCommits } from '@/blocks/viewUndeployedCommits';
 import {
   Color,
+  GETSENTRY_ORG,
   GETSENTRY_REPO,
   GOCD_SENTRYIO_BE_PIPELINE_NAME,
   GOCD_SENTRYIO_FE_PIPELINE_NAME,
-  OWNER,
   SENTRY_REPO,
 } from '@/config';
 import { SlackMessage } from '@/config/slackMessage';
@@ -130,7 +130,7 @@ async function handler({
 
   // Author of commit found
   const commit = checkRun.head_sha;
-  const commitLink = `https://github.com/${OWNER}/${GETSENTRY_REPO}/commits/${commit}`;
+  const commitLink = `https://github.com/${GETSENTRY_ORG}/${GETSENTRY_REPO}/commits/${commit}`;
   const commitLinkText = `${commit.slice(0, 7)}`;
 
   // checkRun.head_sha will always be from getsentry, so if relevantCommit's

--- a/src/brain/requiredChecks/getAnnotations.ts
+++ b/src/brain/requiredChecks/getAnnotations.ts
@@ -1,5 +1,5 @@
 import { ClientType } from '@/api/github/clientType';
-import { GETSENTRY_REPO, OWNER } from '@/config';
+import { GETSENTRY_ORG, GETSENTRY_REPO } from '@/config';
 import { Annotation } from '@/types';
 import { getClient } from '@api/github/getClient';
 
@@ -82,7 +82,7 @@ function filterAnnotations(annotations: Annotation[]) {
 export async function getAnnotations(
   jobs: string[][]
 ): Promise<Record<string, Annotation[]>> {
-  const octokit = await getClient(ClientType.App, OWNER);
+  const octokit = await getClient(ClientType.App, GETSENTRY_ORG);
 
   const annotations = await Promise.all(
     jobs
@@ -92,7 +92,7 @@ export async function getAnnotations(
       .filter(([, runId]) => runId)
       .map(async ([jobLink, checkRunId]) => {
         const { data: annotations } = await octokit.checks.listAnnotations({
-          owner: OWNER,
+          owner: GETSENTRY_ORG,
           repo: GETSENTRY_REPO,
           check_run_id: parseInt(checkRunId ?? '0', 10),
         });

--- a/src/brain/requiredChecks/getTextParts.ts
+++ b/src/brain/requiredChecks/getTextParts.ts
@@ -1,4 +1,4 @@
-import { GETSENTRY_REPO, OWNER } from '@/config';
+import { GETSENTRY_ORG, GETSENTRY_REPO } from '@/config';
 import { CheckRunForRequiredChecksText } from '@/types';
 
 /**
@@ -7,7 +7,7 @@ import { CheckRunForRequiredChecksText } from '@/types';
  * @param checkRun CheckRun from GitHub
  */
 export function getTextParts(checkRun: CheckRunForRequiredChecksText) {
-  const commitLink = `https://github.com/${OWNER}/${GETSENTRY_REPO}/commits/${checkRun.head_sha}`;
+  const commitLink = `https://github.com/${GETSENTRY_ORG}/${GETSENTRY_REPO}/commits/${checkRun.head_sha}`;
   const commitLinkText = `${checkRun.head_sha.slice(0, 7)}`;
   const buildLink = `<${checkRun.html_url}|View Build>`;
 

--- a/src/brain/typescript/getProgress.ts
+++ b/src/brain/typescript/getProgress.ts
@@ -1,5 +1,5 @@
 import { ClientType } from '@/api/github/clientType';
-import { OWNER, SENTRY_REPO } from '@/config';
+import { GETSENTRY_ORG, SENTRY_REPO } from '@/config';
 import { getClient } from '@api/github/getClient';
 
 /**
@@ -18,7 +18,7 @@ export default async function getProgress({
   appDir?: string;
   date?: string;
 }) {
-  const octokit = await getClient(ClientType.App, OWNER);
+  const octokit = await getClient(ClientType.App, GETSENTRY_ORG);
 
   const getContentsParams: {
     owner: string;
@@ -26,14 +26,14 @@ export default async function getProgress({
     path: string;
     ref?: string;
   } = {
-    owner: OWNER,
+    owner: GETSENTRY_ORG,
     repo,
     path: basePath,
   };
 
   if (date) {
     const commits = await octokit.repos.listCommits({
-      owner: OWNER,
+      owner: GETSENTRY_ORG,
       repo,
       until: date,
       per_page: 1,
@@ -57,7 +57,7 @@ export default async function getProgress({
   }
 
   const tree = await octokit.git.getTree({
-    owner: OWNER,
+    owner: GETSENTRY_ORG,
     repo,
     tree_sha: app.sha,
     recursive: '1',

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -8,7 +8,7 @@ export const DEFAULT_PORT = 3000;
 export const DAY_IN_MS = 1000 * 60 * 60 * 24;
 
 export const SENTRY_ORG = 'getsentry';
-export const OWNER = process.env.OWNER || 'getsentry';
+export const GETSENTRY_ORG = process.env.GETSENTRY_ORG || 'getsentry';
 export const SENTRY_REPO = process.env.SENTRY_REPO || 'sentry';
 export const GETSENTRY_REPO = process.env.GETSENTRY_REPO || 'getsentry';
 export const GETSENTRY_BOT_ID = 10587625;
@@ -183,7 +183,7 @@ export const GH_USER_TOKEN = process.env.GH_USER_TOKEN || '';
  * from the environment.
  *
  * TODO: Expand from a single app/org to multiple. First we need to clean up
- * getClient calls to use a dynamic owner/org instead of OWNER as defined above.
+ * getClient calls to use a dynamic owner/org instead of GETSENTRY_ORG as defined above.
  */
 
 export interface AppAuthStrategyOptions {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -7,7 +7,6 @@ export const DEFAULT_PORT = 3000;
 
 export const DAY_IN_MS = 1000 * 60 * 60 * 24;
 
-export const SENTRY_ORG = 'getsentry';
 export const GETSENTRY_ORG = process.env.GETSENTRY_ORG || 'getsentry';
 export const SENTRY_REPO = process.env.SENTRY_REPO || 'sentry';
 export const GETSENTRY_REPO = process.env.GETSENTRY_REPO || 'getsentry';

--- a/src/utils/db/getFailureMessages.ts
+++ b/src/utils/db/getFailureMessages.ts
@@ -1,5 +1,5 @@
 import { ClientType } from '@/api/github/clientType';
-import { GETSENTRY_REPO, OWNER } from '@/config';
+import { GETSENTRY_ORG, GETSENTRY_REPO } from '@/config';
 import { BuildStatus } from '@/config';
 import { SlackMessage } from '@/config/slackMessage';
 import { getClient } from '@api/github/getClient';
@@ -40,7 +40,7 @@ export async function getFailureMessages(
 
   const onlyOlderFailedMessages = await Promise.all(
     messages.map(async (message) => {
-      const octokit = await getClient(ClientType.App, OWNER);
+      const octokit = await getClient(ClientType.App, GETSENTRY_ORG);
       // We *ONLY* want failed builds before `headSha` - when calling GH's
       // `compareCommits`, we use `headSha` as the head commit, so we only want
       // the messages for failed builds that came before `headSha`.
@@ -48,7 +48,7 @@ export async function getFailureMessages(
       // This happens when say build A starts, and then after build B starts
       // and fails before A completes. In this case, build A should not mark B as being fixed
       const { data } = await octokit.repos.compareCommits({
-        owner: OWNER,
+        owner: GETSENTRY_ORG,
         repo: GETSENTRY_REPO,
         base: message.refId,
         head: headSha,

--- a/src/webhooks/pubsub/index.ts
+++ b/src/webhooks/pubsub/index.ts
@@ -3,7 +3,7 @@ import { FastifyReply, FastifyRequest } from 'fastify';
 import moment from 'moment-timezone';
 
 import { ClientType } from '@/api/github/clientType';
-import { OWNER, SENTRY_REPO } from '@/config';
+import { GETSENTRY_ORG, SENTRY_REPO } from '@/config';
 import { notifyProductOwnersForUntriagedIssues } from '@/webhooks/pubsub/slackNotifications';
 import { getClient } from '@api/github/getClient';
 
@@ -50,7 +50,7 @@ export const pubSubHandler = async (
   );
 
   const repos: string[] = payload.repos || DEFAULT_REPOS;
-  const octokit = await getClient(ClientType.App, OWNER);
+  const octokit = await getClient(ClientType.App, GETSENTRY_ORG);
   const now = moment().utc();
 
   // This is to make this endpoint accept different payloads and actions

--- a/src/webhooks/pubsub/slackNotifications.ts
+++ b/src/webhooks/pubsub/slackNotifications.ts
@@ -5,7 +5,7 @@ import moment from 'moment-timezone';
 import { getLabelsTable } from '@/brain/issueNotifier';
 import {
   BACKLOG_LABEL,
-  OWNER,
+  GETSENTRY_ORG,
   PRODUCT_AREA_LABEL_PREFIX,
   WAITING_FOR_PRODUCT_OWNER_LABEL,
 } from '@/config';
@@ -142,7 +142,7 @@ export const getTriageSLOTimestamp = async (
   if (dueByDate == null || !moment(dueByDate).isValid()) {
     // TODO: delete week of Jun 26
     const issues = await octokit.paginate(octokit.issues.listComments, {
-      owner: OWNER,
+      owner: GETSENTRY_ORG,
       repo,
       issue_number: issueNumber,
       per_page: GH_API_PER_PAGE,
@@ -423,7 +423,7 @@ export const notifyProductOwnersForUntriagedIssues = async (
     repo: string
   ): Promise<IssueSLOInfo[]> => {
     const untriagedIssues = await octokit.paginate(octokit.issues.listForRepo, {
-      owner: OWNER,
+      owner: GETSENTRY_ORG,
       repo,
       state: 'open',
       labels: WAITING_FOR_PRODUCT_OWNER_LABEL,

--- a/src/webhooks/pubsub/stalebot.ts
+++ b/src/webhooks/pubsub/stalebot.ts
@@ -1,7 +1,11 @@
 import { Octokit } from '@octokit/rest';
 import moment from 'moment-timezone';
 
-import { OWNER, STALE_LABEL, WAITING_FOR_COMMUNITY_LABEL } from '@/config';
+import {
+  GETSENTRY_ORG,
+  STALE_LABEL,
+  WAITING_FOR_COMMUNITY_LABEL,
+} from '@/config';
 
 const GH_API_PER_PAGE = 100;
 const DAYS_BEFORE_STALE = 21;
@@ -23,14 +27,14 @@ const staleStatusUpdater = async (
         if (now.diff(issue.updated_at, 'days') >= DAYS_BEFORE_CLOSE) {
           // Interestingly enough, this api works for both issues and pull requests
           return octokit.issues.update({
-            owner: OWNER,
+            owner: GETSENTRY_ORG,
             repo: repo,
             issue_number: issue.number,
             state: 'closed',
           });
         } else if (now.diff(issue.updated_at, 'days') < DAYS_BEFORE_CLOSE) {
           return octokit.issues.removeLabel({
-            owner: OWNER,
+            owner: GETSENTRY_ORG,
             repo: repo,
             issue_number: issue.number,
             name: STALE_LABEL,
@@ -41,13 +45,13 @@ const staleStatusUpdater = async (
         if (now.diff(issue.updated_at, 'days') >= DAYS_BEFORE_STALE) {
           return Promise.all([
             octokit.issues.addLabels({
-              owner: OWNER,
+              owner: GETSENTRY_ORG,
               repo: repo,
               issue_number: issue.number,
               labels: [STALE_LABEL],
             }),
             octokit.issues.createComment({
-              owner: OWNER,
+              owner: GETSENTRY_ORG,
               repo: repo,
               issue_number: issue.number,
               body: `This ${
@@ -76,7 +80,7 @@ export const triggerStaleBot = async (
   // Get all open issues and pull requests that are Waiting for Community
   repos.forEach(async (repo: string) => {
     const issues = await octokit.paginate(octokit.issues.listForRepo, {
-      owner: OWNER,
+      owner: GETSENTRY_ORG,
       repo,
       state: 'open',
       labels: WAITING_FOR_COMMUNITY_LABEL,

--- a/test/payloads/github/issue_comment.ts
+++ b/test/payloads/github/issue_comment.ts
@@ -59,7 +59,7 @@ export default {
     created_at: '2019-05-15T15:20:18Z',
     updated_at: '2019-05-15T15:20:18Z',
     closed_at: null,
-    author_association: 'OWNER',
+    author_association: 'GETSENTRY_ORG',
     body: "It looks like you accidently spelled 'commit' with two 't's.",
   },
   changes: {},

--- a/test/payloads/github/issues.ts
+++ b/test/payloads/github/issues.ts
@@ -59,7 +59,7 @@ export default {
     created_at: '2019-05-15T15:20:18Z',
     updated_at: '2019-05-15T15:20:18Z',
     closed_at: null,
-    author_association: 'OWNER',
+    author_association: 'GETSENTRY_ORG',
     body: "It looks like you accidently spelled 'commit' with two 't's.",
   },
   changes: {},

--- a/test/payloads/github/pull_request.ts
+++ b/test/payloads/github/pull_request.ts
@@ -405,7 +405,7 @@ const payload = {
         href: 'https://api.github.com/repos/Codertocat/Hello-World/statuses/ec26c3e57ca3a959ca5aad62de7213c562f8c821',
       },
     },
-    author_association: 'OWNER',
+    author_association: 'GETSENTRY_ORG',
     draft: false,
     merged: false,
     mergeable: null,


### PR DESCRIPTION
Part of #482, after #511, before #513.

This makes it clearer what the knob means, and it fits with `GETSENTRY_REPO` and `SENTRY_REPO`. I expect I'll add a `CODECOV_ORG` and utilize that in pubsub and potentially elsewhere.

This also folds the `SENTRY_ORG` knob into `GETSENTRY_ORG` since it was the same as `OWNER` (but `OWNER` was much more popular).