### PR TITLE
Start teaching the app loader about envvar numbers

### DIFF
--- a/src/api/github/getClient.ts
+++ b/src/api/github/getClient.ts
@@ -44,7 +44,7 @@ export async function getClient(type: ClientType, org?: string | null) {
       );
     }
 
-    const app = GH_APPS.load('__tmp_org_placeholder__');
+    const app = GH_APPS.get('__tmp_org_placeholder__');
 
     let client = _CLIENTS_BY_ORG.get(org);
     if (client === undefined) {

--- a/src/brain/issueLabelHandler/followups.ts
+++ b/src/brain/issueLabelHandler/followups.ts
@@ -63,7 +63,7 @@ export async function updateCommunityFollowups({
     name: 'issueLabelHandler.updateCommunityFollowups',
   });
 
-  const app = GH_APPS.loadFromPayload(payload);
+  const app = GH_APPS.getForPayload(payload);
 
   const reasonsToDoNothing = [
     isNotInARepoWeCareAboutForFollowups,
@@ -131,7 +131,7 @@ export async function ensureOneWaitingForLabel({
     name: 'issueLabelHandler.ensureOneWaitingForLabel',
   });
 
-  const app = GH_APPS.loadFromPayload(payload);
+  const app = GH_APPS.getForPayload(payload);
 
   const reasonsToDoNothing = [
     isNotInARepoWeCareAboutForFollowups,

--- a/src/brain/issueLabelHandler/index.test.ts
+++ b/src/brain/issueLabelHandler/index.test.ts
@@ -24,7 +24,7 @@ import { issueLabelHandler } from '.';
 describe('issueLabelHandler', function () {
   let fastify: Fastify;
   let octokit;
-  const app = GH_APPS.load('__tmp_org_placeholder__');
+  const app = GH_APPS.get('__tmp_org_placeholder__');
   const errors = jest.fn();
   let say, respond, client, ack;
   let calculateSLOViolationRouteSpy, calculateSLOViolationTriageSpy;

--- a/src/brain/issueLabelHandler/route.ts
+++ b/src/brain/issueLabelHandler/route.ts
@@ -66,7 +66,7 @@ export async function markWaitingForSupport({
     name: 'issueLabelHandler.markWaitingForSupport',
   });
 
-  const app = GH_APPS.loadFromPayload(payload);
+  const app = GH_APPS.getForPayload(payload);
 
   const reasonsToSkip = [
     isNotInARepoWeCareAboutForRouting,
@@ -127,7 +127,7 @@ export async function markNotWaitingForSupport({
     name: 'issueLabelHandler.markNotWaitingForSupport',
   });
 
-  const app = GH_APPS.loadFromPayload(payload);
+  const app = GH_APPS.getForPayload(payload);
 
   const reasonsToSkip = [isNotInARepoWeCareAboutForRouting, isValidLabel];
   if (await shouldSkip(payload, app, reasonsToSkip)) {

--- a/src/brain/issueLabelHandler/triage.ts
+++ b/src/brain/issueLabelHandler/triage.ts
@@ -48,7 +48,7 @@ export async function markWaitingForProductOwner({
     name: 'issueLabelHandler.markWaitingforProductOwner',
   });
 
-  const app = GH_APPS.loadFromPayload(payload);
+  const app = GH_APPS.getForPayload(payload);
 
   const reasonsToSkipTriage = [
     isNotInARepoWeCareAboutForTriage,
@@ -101,7 +101,7 @@ export async function markNotWaitingForProductOwner({
     name: 'issueLabelHandler.markNotWaitingForProductOwner',
   });
 
-  const app = GH_APPS.loadFromPayload(payload);
+  const app = GH_APPS.getForPayload(payload);
 
   const reasonsToSkip = [
     isNotInARepoWeCareAboutForTriage,

--- a/src/brain/projectsHandler/index.test.ts
+++ b/src/brain/projectsHandler/index.test.ts
@@ -14,7 +14,7 @@ import { projectsHandler } from '.';
 describe('projectsHandler', function () {
   let fastify: Fastify;
   let octokit;
-  const app = GH_APPS.load('__tmp_org_placeholder__');
+  const app = GH_APPS.get('__tmp_org_placeholder__');
   const errors = jest.fn();
 
   beforeAll(async function () {

--- a/src/brain/projectsHandler/project.ts
+++ b/src/brain/projectsHandler/project.ts
@@ -53,7 +53,7 @@ export async function syncLabelsWithProjectField({
     name: 'issueLabelHandler.syncLabelsWithProjectField',
   });
 
-  const app = GH_APPS.loadFromPayload(payload);
+  const app = GH_APPS.getForPayload(payload);
 
   const reasonsToDoNothing = [
     isNotInAProjectWeCareAbout,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,5 @@
 import {
-  GitHubAppsRegistry,
+  GitHubApps,
   loadGitHubAppsFromEnvironment,
 } from './loadGitHubAppsFromEnvironment';
 
@@ -175,9 +175,7 @@ export const GH_USER_TOKEN = process.env.GH_USER_TOKEN || '';
  * getClient calls to use a dynamic owner/org instead of GETSENTRY_ORG as defined above.
  */
 
-export const GH_APPS: GitHubAppsRegistry = loadGitHubAppsFromEnvironment(
-  process.env
-);
+export const GH_APPS: GitHubApps = loadGitHubAppsFromEnvironment(process.env);
 
 /**
  * Business Hours by Office

--- a/src/config/loadGitHubAppsFromEnvironment.test.ts
+++ b/src/config/loadGitHubAppsFromEnvironment.test.ts
@@ -7,6 +7,7 @@ describe('loadGitHubAppsFromEnvironment ', function () {
         [
           '__tmp_org_placeholder__',
           {
+            num: 1,
             org: '__tmp_org_placeholder__',
             auth: {
               appId: 42,
@@ -59,6 +60,7 @@ describe('loadGitHubAppsFromEnvironment ', function () {
         [
           '__tmp_org_placeholder__',
           {
+            num: 1,
             org: '__tmp_org_placeholder__',
             auth: {
               appId: 42,

--- a/src/config/loadGitHubAppsFromEnvironment.test.ts
+++ b/src/config/loadGitHubAppsFromEnvironment.test.ts
@@ -42,7 +42,7 @@ describe('loadGitHubAppsFromEnvironment ', function () {
 
       GH_APP_IDENTIFIER: '42',
       GH_APP_SECRET_KEY: 'cheese',
-    }).load('__tmp_org_placeholder__').auth.appId;
+    }).get('__tmp_org_placeholder__').auth.appId;
     expect(actual).toEqual(42);
   });
 

--- a/src/config/loadGitHubAppsFromEnvironment.test.ts
+++ b/src/config/loadGitHubAppsFromEnvironment.test.ts
@@ -12,9 +12,9 @@ describe('loadGitHubAppsFromEnvironment ', function () {
             auth: {
               appId: 42,
               privateKey: 'cheese',
+              installationId: undefined,
             },
             project: {
-              installationId: undefined,
               node_id: 'bread',
               product_area_field_id: 'wine',
               status_field_id: 'beer',
@@ -65,9 +65,9 @@ describe('loadGitHubAppsFromEnvironment ', function () {
             auth: {
               appId: 42,
               privateKey: 'cheese',
+              installationId: undefined,
             },
             project: {
-              installationId: undefined,
               node_id: 'PVT_kwDOABVQ184AOGW8',
               product_area_field_id: 'PVTSSF_lADOABVQ184AOGW8zgJEBno',
               status_field_id: 'PVTSSF_lADOABVQ184AOGW8zgI_7g0',

--- a/src/config/loadGitHubAppsFromEnvironment.ts
+++ b/src/config/loadGitHubAppsFromEnvironment.ts
@@ -68,7 +68,7 @@ export function loadGitHubAppsFromEnvironment(env) {
 
   if (env.GH_APP_IDENTIFIER && env.GH_APP_SECRET_KEY) {
     // Collect config by (proleptic) envvar number. Once we have GH_APP_1_FOO
-    // this will make more sense. We'll collect shtuff in config and then
+    // this will make more sense. We'll collect stuff in config and then
     // instantiate a GitHubApp once all config has been collected for each
     // (once we've made a full pass through process.env).
 

--- a/src/config/loadGitHubAppsFromEnvironment.ts
+++ b/src/config/loadGitHubAppsFromEnvironment.ts
@@ -64,7 +64,6 @@ export class GitHubAppsRegistry {
   constructor(configs) {
     this.apps = new Map<string, GitHubApp>();
     for (const config of configs.configs.values()) {
-      // 🏛️🍕🍕
       this.apps.set(config.org, new GitHubApp(config));
     }
   }

--- a/src/config/loadGitHubAppsFromEnvironment.ts
+++ b/src/config/loadGitHubAppsFromEnvironment.ts
@@ -42,12 +42,6 @@ export class GitHubAppsRegistry {
     }
   }
 
-  pop(org) {
-    const app = this.load(org);
-    this.apps.delete(org);
-    return app;
-  }
-
   load(org) {
     const app = this.apps.get(org);
     if (app === undefined) {

--- a/src/config/loadGitHubAppsFromEnvironment.ts
+++ b/src/config/loadGitHubAppsFromEnvironment.ts
@@ -30,32 +30,6 @@ class GitHubAppsConfigHelper {
     }
     return this.configs.get(num);
   }
-
-  validateAll() {
-    const allErrors = new Object();
-    for (const [org, app] of Object.entries(this.configs)) {
-      const errors = new Array();
-      [
-        'auth.appId',
-        'auth.privateKey',
-        'project.node_id',
-        'project.product_area_field_id',
-        'project.status_field_id',
-        'project.response_due_date_field_id',
-      ].forEach((group_key) => {
-        const [group, key] = group_key.split('.');
-        if (!app[group][key]) {
-          errors.push(`${group}.${key}.`);
-        }
-      });
-      if (errors.length) {
-        allErrors[org] = errors;
-      }
-    }
-    if (Object.keys(allErrors).length) {
-      throw new Error(`Config missing: ${JSON.stringify(allErrors)}`);
-    }
-  }
 }
 
 export class GitHubAppsRegistry {
@@ -119,10 +93,6 @@ export function loadGitHubAppsFromEnvironment(env) {
         env.RESPONSE_DUE_DATE_FIELD_ID || 'PVTF_lADOABVQ184AOGW8zgLLxGg',
     };
   }
-
-  // Once all configs are parsed, validate them once so we can see all errors
-  // at once (vs. config whack-a-mole).
-  configs.validateAll();
 
   // Now convert them to (strongly-typed) apps now that we know the info is
   // clean.

--- a/src/config/loadGitHubAppsFromEnvironment.ts
+++ b/src/config/loadGitHubAppsFromEnvironment.ts
@@ -1,37 +1,73 @@
 import { AppAuthStrategyOptions } from '@/types';
 
+interface ProjectOptions {
+  node_id: string;
+  product_area_field_id: string;
+  status_field_id: string;
+  response_due_date_field_id: string;
+}
+
 export class GitHubApp {
+  num: number;
   org: string;
   auth: AppAuthStrategyOptions;
-  project;
+  project: ProjectOptions;
 
-  constructor(org: string, opts) {
-    this.org = org;
-    this.auth = {
-      appId: Number(opts.GH_APP_IDENTIFIER),
-      privateKey: opts.GH_APP_SECRET_KEY.replace(/\\n/g, '\n'),
-    };
-    this.project = {
-      node_id: opts.ISSUES_PROJECT_NODE_ID || 'PVT_kwDOABVQ184AOGW8',
-      product_area_field_id:
-        opts.PRODUCT_AREA_FIELD_ID || 'PVTSSF_lADOABVQ184AOGW8zgJEBno',
-      status_field_id: opts.STATUS_FIELD_ID || 'PVTSSF_lADOABVQ184AOGW8zgI_7g0',
-      response_due_date_field_id:
-        opts.RESPONSE_DUE_DATE_FIELD_ID || 'PVTF_lADOABVQ184AOGW8zgLLxGg',
-    };
+  constructor(obj) {
+    this.num = obj.num;
+    this.org = obj.org;
+    this.auth = obj.auth;
+    this.project = obj.project;
   }
 }
 
 export class GitHubAppsRegistry {
-  apps: Map<string, GitHubApp>;
-
   constructor() {
     this.apps = new Map<string, GitHubApp>();
+    this.configs = new Map<number, object>();
   }
 
-  register(app) {
-    this.apps.set(app.org, app);
+  validate() {
+    const allErrors = new Object();
+    for (const [org, app] of this.apps) {
+      const errors = new Array();
+      [
+        'auth.appId',
+        'auth.privateKey',
+        'project.node_id',
+        'project.product_area_field_id',
+        'project.status_field_id',
+        'project.response_due_date_field_id',
+      ].forEach((group_key) => {
+        const [group, key] = group_key.split('.');
+        if (!app[group][key]) {
+          errors.push(`${group}.${key}.`);
+        }
+      });
+      if (errors.length) {
+        allErrors[org] = errors;
+      }
+    }
+    if (Object.keys(allErrors).length) {
+      throw new Error(`Config missing: ${JSON.stringify(allErrors)}`);
+    }
+    delete this.configs; // ¯\_(ツ)_/¯
   }
+
+  // API for number (from envvars, e.g. GH_APP_1_FOO)
+
+  configs?: Map<number, object>;
+
+  configForNumber(num: number): object | undefined {
+    if (!this.configs?.has(num)) {
+      this.configs?.set(num, { num: num });
+    }
+    return this.configs?.get(num);
+  }
+
+  // API for org slug
+
+  apps: Map<string, GitHubApp>;
 
   pop(org) {
     const app = this.load(org);
@@ -47,6 +83,8 @@ export class GitHubAppsRegistry {
     return app;
   }
 
+  // API for payload (JSON struct coming from GitHub)
+
   loadFromPayload(payload) {
     // Soon we aim to support multiple orgs!
     const org = '__tmp_org_placeholder__'; // payload?.organization?.login;
@@ -59,11 +97,37 @@ export class GitHubAppsRegistry {
 
 export function loadGitHubAppsFromEnvironment(env) {
   const apps = new GitHubAppsRegistry();
+  let config;
 
   if (env.GH_APP_IDENTIFIER && env.GH_APP_SECRET_KEY) {
-    const org = '__tmp_org_placeholder__';
-    apps.register(new GitHubApp(org, env));
+    // Collect config by (proleptic) envvar number. Once we have GH_APP_1_FOO
+    // this will make more sense. We'll collect shtuff in config and then
+    // instantiate a GitHubApp once all config has been collected for each
+    // (once we've made a full pass through process.env).
+
+    config = apps.configForNumber(1);
+    config.org = '__tmp_org_placeholder__';
+    config.auth = {
+      appId: Number(env.GH_APP_IDENTIFIER),
+      privateKey: env.GH_APP_SECRET_KEY.replace(/\\n/g, '\n'),
+    };
+    config.project = {
+      node_id: env.ISSUES_PROJECT_NODE_ID || 'PVT_kwDOABVQ184AOGW8',
+      product_area_field_id:
+        env.PRODUCT_AREA_FIELD_ID || 'PVTSSF_lADOABVQ184AOGW8zgJEBno',
+      status_field_id: env.STATUS_FIELD_ID || 'PVTSSF_lADOABVQ184AOGW8zgI_7g0',
+      response_due_date_field_id:
+        env.RESPONSE_DUE_DATE_FIELD_ID || 'PVTF_lADOABVQ184AOGW8zgLLxGg',
+    };
+
+    // File it by org slug since that's how we'll reference it from now on.
+
+    apps.apps.set(config.org, new GitHubApp(config));
   }
 
+  // Once all apps are loaded, validate them once so we can see all errors at
+  // once (vs. config whack-a-mole).
+
+  apps.validate();
   return apps;
 }

--- a/src/config/loadGitHubAppsFromEnvironment.ts
+++ b/src/config/loadGitHubAppsFromEnvironment.ts
@@ -42,20 +42,20 @@ export class GitHubApp {
   auth: AppAuthStrategyOptions;
   project: GitHubIssuesSomeoneElseCaresAbout;
 
-  constructor(obj) {
-    this.num = obj.num;
-    this.org = obj.org;
-    this.auth = obj.auth;
-    this.project = obj.project;
+  constructor(config) {
+    this.num = config.num;
+    this.org = config.org;
+    this.auth = config.auth;
+    this.project = config.project;
   }
 }
 
 export class GitHubApps {
   apps: Map<string, GitHubApp>;
 
-  constructor(configHelper) {
+  constructor(appConfigs) {
     this.apps = new Map<string, GitHubApp>();
-    for (const config of configHelper.configs.values()) {
+    for (const config of appConfigs.configs.values()) {
       this.apps.set(config.org, new GitHubApp(config));
     }
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,6 +35,13 @@ export interface AppAuthStrategyOptions {
   installationId?: number;
 }
 
+export interface GitHubIssuesSomeoneElseCaresAbout {
+  node_id: string;
+  product_area_field_id: string;
+  status_field_id: string;
+  response_due_date_field_id: string;
+}
+
 export type CheckRun = EmitterWebhookEvent<'check_run'>['payload']['check_run'];
 
 // Note we intentionally only pick the pieces of checkRun that is needed to

--- a/src/utils/githubEventHelpers.test.ts
+++ b/src/utils/githubEventHelpers.test.ts
@@ -3,7 +3,7 @@ import { GH_APPS } from '@/config';
 import * as githubEventHelpers from './githubEventHelpers';
 
 describe('githubEventHelpers', function () {
-  const app = GH_APPS.load('__tmp_org_placeholder__');
+  const app = GH_APPS.get('__tmp_org_placeholder__');
 
   it('addIssueToGlobalIssuesProject should return project item id from project', async function () {
     const octokit = {

--- a/src/webhooks/pubsub/index.ts
+++ b/src/webhooks/pubsub/index.ts
@@ -58,7 +58,7 @@ export const pubSubHandler = async (
   // call security warning.
   // https://codeql.github.com/codeql-query-help/javascript/js-unvalidated-dynamic-method-call/
   if (typeof func === 'function') {
-    app = GH_APPS.load('__tmp_org_placeholder__');
+    app = GH_APPS.get('__tmp_org_placeholder__');
     octokit = await getClient(ClientType.App, GETSENTRY_ORG);
     now = moment().utc();
   } else {

--- a/src/webhooks/pubsub/slackNotifications.test.ts
+++ b/src/webhooks/pubsub/slackNotifications.test.ts
@@ -13,7 +13,7 @@ import {
 } from './slackNotifications';
 
 describe('Triage Notification Tests', function () {
-  const app = GH_APPS.load('__tmp_org_placeholder__');
+  const app = GH_APPS.get('__tmp_org_placeholder__');
 
   beforeAll(async function () {
     await db.migrate.latest();

--- a/src/webhooks/pubsub/stalebot.test.ts
+++ b/src/webhooks/pubsub/stalebot.test.ts
@@ -17,7 +17,7 @@ jest.mock('@/config', () => {
 });
 
 describe('Stalebot Tests', function () {
-  const app = GH_APPS.load('__tmp_org_placeholder__');
+  const app = GH_APPS.get('__tmp_org_placeholder__');
 
   const issueInfo = {
     labels: [],


### PR DESCRIPTION
Part of #482, before #524.

We need two passes to parsing, one where we collect configs based on the number in envvars of the form `GH_APP_1_FOO`, and then another where we organize apps by org slug. This PR stubs out this two-pass structure without yet switching to the new envvars.