### PR TITLE
Implement multi-org config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,33 +2,25 @@
 # Follow the instructions in README.md as how to add your personal
 # tokens and secrets in this file
 
-# GitHub App ID
-GH_APP_IDENTIFIER=''
-# Github App Webhook Secret to verify requests come from GitHub
-GH_WEBHOOK_SECRET=''
-# GitHub App Secret Key
-# NOTE: this *must* be on a single line, otherwise it will break
-# reading the secret key.
-GH_APP_SECRET_KEY='-----BEGIN RSA PRIVATE KEY----------END RSA PRIVATE KEY-----'
-# Personal (ie, for your own GitHub account) user access token with the `admin:org`,
-# `admin:org_hook`, `admin: repo_hook`, `project`, `public_repo`, `repo:status`, and
-# `repo_deployment` permissions enabled.
+# GitHub
 GH_USER_TOKEN=''
+GH_WEBHOOK_SECRET=''
 
-# Slack signing secret to verify requests come from Slack
-SLACK_SIGNING_SECRET=
-# Slack Bot user access token -> "Bot User OAuth Token"
-SLACK_BOT_USER_ACCESS_TOKEN=
+# GitHub Apps
+GH_APP_1_ORG_SLUG=''
+GH_APP_1_IDENTIFIER=''
+GH_APP_1_SECRET_KEY='-----BEGIN RSA PRIVATE KEY----------END RSA PRIVATE KEY-----'
+GH_APP_1_ISSUES_PROJECT_NODE_ID=''
+GH_APP_1_PRODUCT_AREA_FIELD_ID=''
+GH_APP_1_STATUS_FIELD_ID=''
+GH_APP_1_RESPONSE_DUE_DATE_FIELD_ID=''
+
+# Slack
+SLACK_SIGNING_SECRET=''
+SLACK_BOT_USER_ACCESS_TOKEN=''
 
 # The name of the personal repository in your personal organization being used for development.
 PERSONAL_TEST_REPO='eng-pipes-dev'
-
-# Application-specific configuration
-# Config for the "GitHub Issues Someone Else Cares About" project board
-ISSUES_PROJECT_NODE_ID=''
-STATUS_FIELD_ID=''
-PRODUCT_AREA_FIELD_ID=''
-RESPONSE_DUE_DATE_FIELD_ID=''
 
 # Silence some GCP noise
 DRY_RUN=true

--- a/.env.test
+++ b/.env.test
@@ -1,9 +1,25 @@
 # GitHub
 FORCE_USER_TOKEN_GITHUB_CLIENT="false"
 GH_USER_TOKEN="ghp_BLAHBLAHBLAH"
-GH_APP_IDENTIFIER="1234"
 GH_WEBHOOK_SECRET="webhooksecret"
-GH_APP_SECRET_KEY="top \nsecret\n key"
+
+# some functionality is org-agnostic
+GH_APP_1_ORG_SLUG="Enterprise"
+GH_APP_1_IDENTIFIER="1234"
+GH_APP_1_SECRET_KEY="top \nsecret\n key"
+GH_APP_1_ISSUES_PROJECT_NODE_ID="PVT_blahblah"
+GH_APP_1_PRODUCT_AREA_FIELD_ID="PVTSSF_flooflah"
+GH_APP_1_STATUS_FIELD_ID="PVTSSF_zimzimzim"
+GH_APP_1_RESPONSE_DUE_DATE_FIELD_ID="PVTF_zamzamzam"
+
+# other functionality is hardwired for getsentry
+GH_APP_2_ORG_SLUG="getsentry"
+GH_APP_2_IDENTIFIER="7890"
+GH_APP_2_SECRET_KEY="super \nsecret\n key"
+GH_APP_2_ISSUES_PROJECT_NODE_ID="PVT_flahflah"
+GH_APP_2_PRODUCT_AREA_FIELD_ID="PVTSSF_moomah"
+GH_APP_2_STATUS_FIELD_ID="PVTSSF_mizmizmi"
+GH_APP_2_RESPONSE_DUE_DATE_FIELD_ID="PVTF_mazmaza"
 
 # Slack
 SLACK_SIGNING_SECRET="slacksigningsecret"

--- a/README.md
+++ b/README.md
@@ -47,20 +47,43 @@ Under Sentry's [webhooks](https://github.com/organizations/getsentry/settings/ho
 ### Setup Secrets
 
 The following secrets are configured in GitHub for this app to function and to deploy to Google.
-You can grab GitHub secrets in their respective configuration pages: [GitHub App](https://github.com/organizations/getsentry/settings/apps/getsantry)
+You can grab GitHub secrets in their respective configuration pages: [getsantry](https://github.com/organizations/getsentry/settings/apps/getsantry), [covecod](https://github.com/organizations/codecov/settings/apps/covecod).
 
 #### Local Secrets (required to run yarn dev)
 
-You will also need to set up some of these environment variables if you want to test this locally, e.g. using `direnv` or something similar
+You will also need to set up some of these environment variables if you want to test this locally, e.g. using `direnv` or something similar. See below for more instructions on [setting up a local environment](#configuring-a-test-environment).
 
-- `GH_APP_IDENTIFIER` - GitHub App identifier
-- `GH_APP_SECRET_KEY` - GitHub App private key
-- `GH_WEBHOOK_SECRET` - GitHub webhook secret to confirm that webhooks come from GitHub
-- `SENTRY_WEBPACK_WEBHOOK_SECRET` - Webhook secret that needs to match secret from CI. Records webpack asset sizes.
+##### GitHub
+
+- `GH_WEBHOOK_SECRET` - GitHub webhook secret to confirm that webhooks come
+  from GitHub
+- `GH_USER_TOKEN` - Personal (ie, for your own GitHub account) user access
+  token with the `read:org` and `read:user` permissions enabled.
+
+##### GitHub Apps
+
+You can configure multiple GitHub Apps to send events to one `eng-pipes`
+installation. The config values are grouped together by number, so
+`GH_APP_1_*`, `GH_APP_2_*`, etc.
+
+- `GH_APP_1_ORG_SLUG` - Slug for the org where the GitHub app is installed
+- `GH_APP_1_IDENTIFIER` - GitHub App identifier
+- `GH_APP_1_SECRET_KEY` - GitHub App private key -  NOTE: this *must* be on a single line, otherwise it will break reading the secret key (however, it can have literal `\n`s in it, which will be replaced with newlines)
+- `GH_APP_1_ISSUES_PROJECT_NODE_ID` - node ID of the "GitHub Issues Someone Else Cares About" project board in the org
+- `GH_APP_1_PRODUCT_AREA_FIELD_ID` - id of the "Product Area" field in the board
+- `GH_APP_1_STATUS_FIELD_ID` - id of the "Status" field in the board
+- `GH_APP_1_RESPONSE_DUE_DATE_FIELD_ID` -  id of the "Response Due" field in the board
+
+##### Slack
+
 - `SLACK_SIGNING_SECRET` - Slack webhook secret to verify payload
 - `SLACK_BOT_USER_ACCESS_TOKEN` - The Slack Bot User OAuth Access Token from the `Oauth & Permissions` section of your Slack app
 
-Optional database configuration
+##### CI
+
+- `SENTRY_WEBPACK_WEBHOOK_SECRET` - Webhook secret that needs to match secret from CI. Records webpack asset sizes.
+
+##### Database (Optional)
 
 - `DB_USER` - Database user
 - `DB_PASSWORD` - Database password
@@ -128,7 +151,7 @@ NOTE: These steps will cover more aspects over time. For now it focuses on testi
 
     - In that organization, create a [new GitHub App](https://github.com/settings/apps/new)
     - Set the webhook to your ngrok tunnel with the GH route (e.g. `<NGROK_INSTANCE>/webhooks/github`)
-    - Place the secrets in your `.env` (see [Setup Secrets](#setup-secrets) below)
+    - Place the secrets in your `.env` (see [Setup Secrets](#setup-secrets) above)
     - Go to the `Permissions & events` sidebar menu entry of the GitHub app configuration, and grant maximum non-`Admin` access (`Read and write` where possible, `Read only` everywhere else) for every line in `Repository permissions` (NOTE: We use a more constrained permission-set in production, but for initial setup enabling maximal permissions is fine; permissions can be whittled down later as needed.)
     - For `Organization permissions`, grant `Read and write` for `Members` and `Projects`
     - In the `Subscribe to events` section, check every possible box

--- a/src/api/github/getClient.test.ts
+++ b/src/api/github/getClient.test.ts
@@ -23,10 +23,10 @@ describe('getClient(ClientType.User)', function () {
   });
 });
 
-describe("getClient(ClientType.App, 'getsentry')", function () {
+describe("getClient(ClientType.App, 'Enterprise')", function () {
   beforeAll(async function () {
     octokitClass.mockClear();
-    await getClient(ClientType.App, 'getsentry');
+    await getClient(ClientType.App, 'Enterprise');
   });
 
   it('is instantiated twice', async function () {
@@ -43,7 +43,7 @@ describe("getClient(ClientType.App, 'getsentry')", function () {
       auth: {
         appId: 1234,
         privateKey: 'top \nsecret\n key',
-        installationId: 'installation-getsentry',
+        installationId: 'installation-Enterprise',
       },
     });
   });

--- a/src/api/github/getClient.test.ts
+++ b/src/api/github/getClient.test.ts
@@ -1,5 +1,6 @@
 import { createAppAuth } from '@octokit/auth-app';
 
+import { GETSENTRY_ORG } from '@/config';
 import { ClientType } from '@api/github/clientType';
 import { getClient } from '@api/github/getClient';
 import { OctokitWithRetries as octokitClass } from '@api/github/octokitWithRetries';
@@ -44,6 +45,21 @@ describe("getClient(ClientType.App, 'Enterprise')", function () {
         appId: 1234,
         privateKey: 'top \nsecret\n key',
         installationId: 'installation-Enterprise',
+      },
+    });
+  });
+});
+
+describe('getClient(ClientType.App, GETSENTRY_ORG)', function () {
+  it('also knows about getsentry', async function () {
+    octokitClass.mockClear();
+    const actual = await getClient(ClientType.App, GETSENTRY_ORG);
+    expect(octokitClass).toHaveBeenLastCalledWith({
+      authStrategy: createAppAuth,
+      auth: {
+        appId: 7890,
+        privateKey: 'super \nsecret\n key',
+        installationId: 'installation-getsentry',
       },
     });
   });

--- a/src/api/github/getClient.ts
+++ b/src/api/github/getClient.ts
@@ -44,11 +44,10 @@ export async function getClient(type: ClientType, org?: string | null) {
       );
     }
 
-    const app = GH_APPS.get('__tmp_org_placeholder__');
-
     let client = _CLIENTS_BY_ORG.get(org);
     if (client === undefined) {
       // Bootstrap with a client not bound to an org.
+      const app = GH_APPS.get(org);
       const appClient = _getAppClient(app.auth);
 
       // Use the unbound client to hydrate a client bound to an org.

--- a/src/brain/ghaCancel/index.test.ts
+++ b/src/brain/ghaCancel/index.test.ts
@@ -20,7 +20,7 @@ describe('gha-test', function () {
   });
   beforeEach(async function () {
     await db('users').delete();
-    octokit = await getClient(ClientType.App, 'getsentry');
+    octokit = await getClient(ClientType.App, 'Enterprise');
     fastify = await buildServer(false);
     ghaCancel();
     // @ts-ignore

--- a/src/brain/githubMetrics/index.test.ts
+++ b/src/brain/githubMetrics/index.test.ts
@@ -66,7 +66,7 @@ describe('github webhook', function () {
 
   beforeEach(async function () {
     fastify = await buildServer(false);
-    octokit = await getClient(ClientType.App, 'getsentry');
+    octokit = await getClient(ClientType.App, 'Enterprise');
     metrics();
   });
 

--- a/src/brain/gocdSlackFeeds/deployFeed.test.ts
+++ b/src/brain/gocdSlackFeeds/deployFeed.test.ts
@@ -516,7 +516,7 @@ describe('DeployFeed', () => {
   });
 
   it('post message with commits in deploy link for getsentry', async () => {
-    const octokit = await getClient(ClientType.App, 'Enterprise');
+    const octokit = await getClient(ClientType.App, GETSENTRY_ORG);
     octokit.repos.getContent.mockImplementation((args) => {
       if (args.owner != 'getsentry') {
         throw new Error(`Unexpected getContent() owner: ${args.owner}`);
@@ -647,7 +647,7 @@ describe('DeployFeed', () => {
   });
 
   it('handle error if get content fails', async () => {
-    const octokit = await getClient(ClientType.App, 'Enterprise');
+    const octokit = await getClient(ClientType.App, GETSENTRY_ORG);
     octokit.repos.getContent.mockImplementation((args) => {
       throw new Error('Injected error');
     });

--- a/src/brain/gocdSlackFeeds/deployFeed.test.ts
+++ b/src/brain/gocdSlackFeeds/deployFeed.test.ts
@@ -516,7 +516,7 @@ describe('DeployFeed', () => {
   });
 
   it('post message with commits in deploy link for getsentry', async () => {
-    const octokit = await getClient(ClientType.App, GETSENTRY_ORG);
+    const octokit = await getClient(ClientType.App, 'Enterprise');
     octokit.repos.getContent.mockImplementation((args) => {
       if (args.owner != 'getsentry') {
         throw new Error(`Unexpected getContent() owner: ${args.owner}`);
@@ -647,7 +647,7 @@ describe('DeployFeed', () => {
   });
 
   it('handle error if get content fails', async () => {
-    const octokit = await getClient(ClientType.App, GETSENTRY_ORG);
+    const octokit = await getClient(ClientType.App, 'Enterprise');
     octokit.repos.getContent.mockImplementation((args) => {
       throw new Error('Injected error');
     });

--- a/src/brain/issueLabelHandler/followups.ts
+++ b/src/brain/issueLabelHandler/followups.ts
@@ -77,8 +77,7 @@ export async function updateCommunityFollowups({
     return;
   }
 
-  const owner = payload.repository.owner.login;
-  const octokit = await getClient(ClientType.App, owner);
+  const octokit = await getClient(ClientType.App, app.org);
   const repo = payload.repository.name;
   const issueNumber = payload.issue.number;
 
@@ -88,16 +87,16 @@ export async function updateCommunityFollowups({
 
   if (isWaitingForCommunityLabelOnIssue) {
     await octokit.issues.removeLabel({
-      owner,
-      repo: repo,
+      owner: app.org,
+      repo,
       issue_number: issueNumber,
       name: WAITING_FOR_COMMUNITY_LABEL,
     });
   }
 
   await octokit.issues.addLabels({
-    owner,
-    repo: repo,
+    owner: app.org,
+    repo,
     issue_number: issueNumber,
     labels: [WAITING_FOR_PRODUCT_OWNER_LABEL],
   });
@@ -142,8 +141,7 @@ export async function ensureOneWaitingForLabel({
   }
 
   const { issue, label } = payload;
-  const owner = payload.repository.owner.login;
-  const octokit = await getClient(ClientType.App, owner);
+  const octokit = await getClient(ClientType.App, app.org);
   const repo = payload.repository.name;
   const issueNumber = payload.issue.number;
   // Here label will never be undefined, ts is erroring here but is handled in the shouldSkip above
@@ -156,8 +154,8 @@ export async function ensureOneWaitingForLabel({
 
   if (labelToRemove != null) {
     await octokit.issues.removeLabel({
-      owner: owner,
-      repo: repo,
+      owner: app.org,
+      repo,
       issue_number: issueNumber,
       name: labelToRemove,
     });

--- a/src/brain/issueLabelHandler/index.test.ts
+++ b/src/brain/issueLabelHandler/index.test.ts
@@ -24,7 +24,7 @@ import { issueLabelHandler } from '.';
 describe('issueLabelHandler', function () {
   let fastify: Fastify;
   let octokit;
-  const app = GH_APPS.get('__tmp_org_placeholder__');
+  const app = GH_APPS.get('Enterprise');
   const errors = jest.fn();
   let say, respond, client, ack;
   let calculateSLOViolationRouteSpy, calculateSLOViolationTriageSpy;

--- a/src/brain/issueLabelHandler/route.ts
+++ b/src/brain/issueLabelHandler/route.ts
@@ -81,18 +81,17 @@ export async function markWaitingForSupport({
   const issueNumber = payload.issue.number;
 
   // New issues get a Waiting for: Support label.
-  const owner = payload.repository.owner.login;
-  const octokit = await getClient(ClientType.App, owner);
+  const octokit = await getClient(ClientType.App, app.org);
   await octokit.issues.addLabels({
-    owner,
-    repo: repo,
+    owner: app.org,
+    repo,
     issue_number: issueNumber,
     labels: [WAITING_FOR_SUPPORT_LABEL],
   });
 
   await octokit.issues.createComment({
-    owner,
-    repo: repo,
+    owner: app.org,
+    repo,
     issue_number: issueNumber,
     body: `Assigning to @${GETSENTRY_ORG}/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️`,
   });
@@ -137,8 +136,7 @@ export async function markNotWaitingForSupport({
   const { issue, label } = payload;
   const productAreaLabel = label;
   const productAreaLabelName = productAreaLabel?.name || PRODUCT_AREA_UNKNOWN;
-  const owner = payload.repository.owner.login;
-  const octokit = await getClient(ClientType.App, owner);
+  const octokit = await getClient(ClientType.App, app.org);
   const labelsToRemove: string[] = [];
   const labelNames = issue?.labels?.map((label) => label.name) || [];
   const isBeingRoutedBySupport = labelNames.includes(WAITING_FOR_SUPPORT_LABEL);
@@ -153,7 +151,7 @@ export async function markNotWaitingForSupport({
   for (const label of labelsToRemove) {
     try {
       await octokit.issues.removeLabel({
-        owner: owner,
+        owner: app.org,
         repo: payload.repository.name,
         issue_number: payload.issue.number,
         name: label,
@@ -175,7 +173,7 @@ export async function markNotWaitingForSupport({
   // Only retriage issues if support is routing
   if (isBeingRoutedBySupport) {
     await octokit.issues.addLabels({
-      owner: owner,
+      owner: app.org,
       repo: payload.repository.name,
       issue_number: payload.issue.number,
       labels: [WAITING_FOR_PRODUCT_OWNER_LABEL],
@@ -185,7 +183,7 @@ export async function markNotWaitingForSupport({
   const comment = await routeIssue(octokit, productAreaLabelName);
 
   await octokit.issues.createComment({
-    owner,
+    owner: app.org,
     repo: payload.repository.name,
     issue_number: payload.issue.number,
     body: comment,

--- a/src/brain/issueLabelHandler/triage.ts
+++ b/src/brain/issueLabelHandler/triage.ts
@@ -9,11 +9,11 @@ import {
 import { ClientType } from '@api/github/clientType';
 import { getClient } from '@api/github/getClient';
 import {
+  addIssueToGlobalIssuesProject,
   isNotFromAnExternalOrGTMUser,
   modifyProjectIssueField,
   shouldSkip,
 } from '@utils/githubEventHelpers';
-import { addIssueToGlobalIssuesProject } from '@utils/githubEventHelpers';
 import { isFromABot } from '@utils/isFromABot';
 
 const REPOS_TO_TRACK_FOR_TRIAGE = new Set(SENTRY_SDK_REPOS);

--- a/src/brain/issueLabelHandler/triage.ts
+++ b/src/brain/issueLabelHandler/triage.ts
@@ -60,14 +60,13 @@ export async function markWaitingForProductOwner({
   }
 
   // New issues get an Untriaged label.
-  const owner = payload.repository.owner.login;
-  const octokit = await getClient(ClientType.App, owner);
+  const octokit = await getClient(ClientType.App, app.org);
   const repo = payload.repository.name;
   const issueNumber = payload.issue.number;
 
   await octokit.issues.addLabels({
-    owner,
-    repo: repo,
+    owner: app.org,
+    repo,
     issue_number: issueNumber,
     labels: [WAITING_FOR_PRODUCT_OWNER_LABEL],
   });
@@ -114,11 +113,10 @@ export async function markNotWaitingForProductOwner({
   }
 
   // Remove Untriaged label when triaged.
-  const owner = payload.repository.owner.login;
-  const octokit = await getClient(ClientType.App, owner);
+  const octokit = await getClient(ClientType.App, app.org);
   try {
     await octokit.issues.removeLabel({
-      owner: owner,
+      owner: app.org,
       repo: payload.repository.name,
       issue_number: payload.issue.number,
       name: WAITING_FOR_PRODUCT_OWNER_LABEL,

--- a/src/brain/notifyOnGoCDStageEvent/index.test.ts
+++ b/src/brain/notifyOnGoCDStageEvent/index.test.ts
@@ -98,7 +98,7 @@ describe('notifyOnGoCDStageEvent', function () {
     await pleaseDeployNotifier();
     await notifyOnGoCDStageEvent();
 
-    octokit = await getClient(ClientType.App, 'getsentry');
+    octokit = await getClient(ClientType.App, 'Enterprise');
     octokit.paginate.mockImplementation(() => {
       return [{ name: 'only frontend changes', conclusion: 'success' }];
     });

--- a/src/brain/pleaseDeployNotifier/index.test.ts
+++ b/src/brain/pleaseDeployNotifier/index.test.ts
@@ -37,7 +37,7 @@ describe('pleaseDeployNotifier', function () {
     jest.spyOn(actions, 'actionViewUndeployedCommits');
 
     pleaseDeployNotifier();
-    octokit = await getClient(ClientType.App, 'getsentry');
+    octokit = await getClient(ClientType.App, 'Enterprise');
     octokit.repos.getCommit.mockImplementation(({ repo, ref }) => {
       const defaultPayload = require('@test/payloads/github/commit').default;
       if (repo === 'sentry') {

--- a/src/brain/projectsHandler/index.test.ts
+++ b/src/brain/projectsHandler/index.test.ts
@@ -14,7 +14,7 @@ import { projectsHandler } from '.';
 describe('projectsHandler', function () {
   let fastify: Fastify;
   let octokit;
-  const app = GH_APPS.load('Enterprise');
+  const app = GH_APPS.get('Enterprise');
   const errors = jest.fn();
 
   beforeAll(async function () {

--- a/src/brain/projectsHandler/index.test.ts
+++ b/src/brain/projectsHandler/index.test.ts
@@ -14,7 +14,7 @@ import { projectsHandler } from '.';
 describe('projectsHandler', function () {
   let fastify: Fastify;
   let octokit;
-  const app = GH_APPS.get('__tmp_org_placeholder__');
+  const app = GH_APPS.load('Enterprise');
   const errors = jest.fn();
 
   beforeAll(async function () {
@@ -38,7 +38,7 @@ describe('projectsHandler', function () {
   beforeEach(async function () {
     fastify = await buildServer(false);
     await projectsHandler();
-    octokit = await getClient(ClientType.App, 'test-org');
+    octokit = await getClient(ClientType.App, 'Enterprise');
   });
 
   afterEach(async function () {
@@ -59,7 +59,7 @@ describe('projectsHandler', function () {
     fieldNodeId?: string
   ) {
     const projectPayload = {
-      organization: { login: 'test-org' },
+      organization: { login: 'Enterprise' },
       projects_v2_item: {
         project_node_id: projectNodeId || 'test-project-node-id',
         node_id: 'test-node-id',

--- a/src/brain/projectsHandler/project.ts
+++ b/src/brain/projectsHandler/project.ts
@@ -64,8 +64,7 @@ export async function syncLabelsWithProjectField({
     return;
   }
 
-  const owner = payload?.organization?.login || '';
-  const octokit = await getClient(ClientType.App, owner);
+  const octokit = await getClient(ClientType.App, app.org);
   const fieldName = getFieldName(payload, app);
   const fieldValue = await getKeyValueFromProjectField(
     payload.projects_v2_item.node_id,
@@ -84,7 +83,7 @@ export async function syncLabelsWithProjectField({
   );
 
   await octokit.issues.addLabels({
-    owner,
+    owner: app.org,
     repo: issueInfo.repo,
     issue_number: issueInfo.number,
     labels: [

--- a/src/brain/projectsHandler/project.ts
+++ b/src/brain/projectsHandler/project.ts
@@ -4,10 +4,10 @@ import * as Sentry from '@sentry/node';
 import { GH_APPS, PRODUCT_AREA_LABEL_PREFIX } from '@/config';
 import { ClientType } from '@api/github/clientType';
 import { getClient } from '@api/github/getClient';
-import { shouldSkip } from '@utils/githubEventHelpers';
 import {
   getIssueDetailsFromNodeId,
   getKeyValueFromProjectField,
+  shouldSkip,
 } from '@utils/githubEventHelpers';
 
 function isNotInAProjectWeCareAbout(payload, app) {

--- a/src/brain/requiredChecks/getAnnotations.test.ts
+++ b/src/brain/requiredChecks/getAnnotations.test.ts
@@ -1,3 +1,4 @@
+import { GETSENTRY_ORG } from '@/config';
 import { ClientType } from '@api/github/clientType';
 import { getClient } from '@api/github/getClient';
 
@@ -7,7 +8,7 @@ describe('getAnnotations', function () {
   let octokit;
 
   beforeAll(async function () {
-    octokit = await getClient(ClientType.App, 'getsentry');
+    octokit = await getClient(ClientType.App, GETSENTRY_ORG);
   });
 
   beforeEach(function () {

--- a/src/brain/requiredChecks/index.test.ts
+++ b/src/brain/requiredChecks/index.test.ts
@@ -22,6 +22,7 @@ import { createGitHubEvent } from '@test/utils/github';
 import { buildServer } from '@/buildServer';
 import {
   BuildStatus,
+  GETSENTRY_ORG,
   REQUIRED_CHECK_CHANNEL,
   REQUIRED_CHECK_NAME,
 } from '@/config';
@@ -66,7 +67,7 @@ describe('requiredChecks', function () {
   beforeEach(async function () {
     fastify = await buildServer(false);
     await requiredChecks();
-    octokit = await getClient(ClientType.App, 'getsentry');
+    octokit = await getClient(ClientType.App, GETSENTRY_ORG);
 
     octokit.repos.getCommit.mockImplementation(({ repo, ref }) => {
       const defaultPayload = require('@test/payloads/github/commit').default;

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -1,0 +1,47 @@
+import { GH_APPS } from '@/config';
+
+describe('GH_APPS', function () {
+  it('get errors out for unknown org', function () {
+    expect(() => GH_APPS.get('CheezWhiz')).toThrow(
+      "No app is registered for 'CheezWhiz'",
+      ''
+    );
+  });
+
+  it.each([
+    ['bad payload', {}, "Could not find an org in 'undefined' or 'undefined'."],
+    [
+      'bad payload.organization',
+      { organization: {} },
+      "Could not find an org in '{}' or 'undefined'.",
+    ],
+    [
+      'unknown org in payload.organization',
+      { organization: { login: 'foo' } },
+      "No app is registered for 'foo'.",
+    ],
+    [
+      'bad payload.repository',
+      { repository: {} },
+      "Could not find an org in 'undefined' or 'undefined'.",
+    ],
+    [
+      'bad payload.repository.owner',
+      { repository: { owner: {} } },
+      "Could not find an org in 'undefined' or '{}'.",
+    ],
+
+    [
+      'user as payload.repository.owner',
+      { repository: { owner: { login: 'foo', type: 'User' } } },
+      'Could not find an org in \'undefined\' or \'{\n  "login": "foo",\n  "type": "User"\n}\'.',
+    ],
+    [
+      'unknown org in payload.repository.owner',
+      { repository: { owner: { login: 'foo', type: 'Organization' } } },
+      "No app is registered for 'foo'.",
+    ],
+  ])('getForPayload errors out for %s', (description, payload, error) => {
+    expect(() => GH_APPS.getForPayload(payload)).toThrow(error);
+  });
+});

--- a/src/config/loadGitHubAppsFromEnvironment.test.ts
+++ b/src/config/loadGitHubAppsFromEnvironment.test.ts
@@ -5,10 +5,10 @@ describe('loadGitHubAppsFromEnvironment ', function () {
     const expected = {
       apps: new Map([
         [
-          '__tmp_org_placeholder__',
+          'Enterprise',
           {
             num: 1,
-            org: '__tmp_org_placeholder__',
+            org: 'Enterprise',
             auth: {
               appId: 42,
               privateKey: 'cheese',
@@ -25,12 +25,13 @@ describe('loadGitHubAppsFromEnvironment ', function () {
       ]),
     };
     const actual = loadGitHubAppsFromEnvironment({
-      GH_APP_IDENTIFIER: '42',
-      GH_APP_SECRET_KEY: 'cheese',
-      ISSUES_PROJECT_NODE_ID: 'bread',
-      PRODUCT_AREA_FIELD_ID: 'wine',
-      STATUS_FIELD_ID: 'beer',
-      RESPONSE_DUE_DATE_FIELD_ID: 'olives',
+      GH_APP_1_ORG_SLUG: 'Enterprise',
+      GH_APP_1_IDENTIFIER: '42',
+      GH_APP_1_SECRET_KEY: 'cheese',
+      GH_APP_1_ISSUES_PROJECT_NODE_ID: 'bread',
+      GH_APP_1_PRODUCT_AREA_FIELD_ID: 'wine',
+      GH_APP_1_STATUS_FIELD_ID: 'beer',
+      GH_APP_1_RESPONSE_DUE_DATE_FIELD_ID: 'olives',
     });
     expect(actual).toEqual(expected);
   });
@@ -40,9 +41,14 @@ describe('loadGitHubAppsFromEnvironment ', function () {
       RANDOM: 'garbage',
       AND_EXTRA: 'stuff',
 
-      GH_APP_IDENTIFIER: '42',
-      GH_APP_SECRET_KEY: 'cheese',
-    }).get('__tmp_org_placeholder__').auth.appId;
+      GH_APP_1_ORG_SLUG: 'Enterprise',
+      GH_APP_1_IDENTIFIER: '42',
+      GH_APP_1_SECRET_KEY: 'cheese',
+      GH_APP_1_ISSUES_PROJECT_NODE_ID: 'bread',
+      GH_APP_1_PRODUCT_AREA_FIELD_ID: 'wine',
+      GH_APP_1_STATUS_FIELD_ID: 'beer',
+      GH_APP_1_RESPONSE_DUE_DATE_FIELD_ID: 'olives',
+    }).get('Enterprise').auth.appId;
     expect(actual).toEqual(42);
   });
 
@@ -54,33 +60,18 @@ describe('loadGitHubAppsFromEnvironment ', function () {
     expect(actual).toEqual({ apps: new Map() });
   });
 
-  it('loads defaults for project board if auth is present', async function () {
-    const expected = {
-      apps: new Map([
-        [
-          '__tmp_org_placeholder__',
-          {
-            num: 1,
-            org: '__tmp_org_placeholder__',
-            auth: {
-              appId: 42,
-              privateKey: 'cheese',
-              installationId: undefined,
-            },
-            project: {
-              node_id: 'PVT_kwDOABVQ184AOGW8',
-              product_area_field_id: 'PVTSSF_lADOABVQ184AOGW8zgJEBno',
-              status_field_id: 'PVTSSF_lADOABVQ184AOGW8zgI_7g0',
-              response_due_date_field_id: 'PVTF_lADOABVQ184AOGW8zgLLxGg',
-            },
-          },
-        ],
-      ]),
+  it('errors out on partial config', async function () {
+    const t = () => {
+      loadGitHubAppsFromEnvironment({
+        GH_APP_1_ORG_SLUG: 'Enterprise',
+        GH_APP_1_IDENTIFIER: '42',
+        GH_APP_1_SECRET_KEY: 'cheese',
+        GH_APP_1_ISSUES_PROJECT_NODE_ID: '', // empty still fails
+      });
     };
-    const actual = loadGitHubAppsFromEnvironment({
-      GH_APP_IDENTIFIER: '42',
-      GH_APP_SECRET_KEY: 'cheese',
-    });
-    expect(actual).toEqual(expected);
+    expect(t).toThrow(Error);
+    expect(t).toThrow(
+      'Config missing: {"1":["project.node_id","project.product_area_field_id","project.status_field_id","project.response_due_date_field_id"]}'
+    );
   });
 });

--- a/src/config/loadGitHubAppsFromEnvironment.ts
+++ b/src/config/loadGitHubAppsFromEnvironment.ts
@@ -13,6 +13,12 @@ class GitHubAppConfig {
   org: any;
   auth: any;
   project: any;
+
+  constructor(num) {
+    this.num = num;
+    this.auth = {};
+    this.project = {};
+  }
 }
 
 class GitHubAppConfigs {
@@ -24,8 +30,7 @@ class GitHubAppConfigs {
 
   getOrCreate(num: number): object {
     if (!this.configs.has(num)) {
-      const config = new GitHubAppConfig();
-      config.num = num;
+      const config = new GitHubAppConfig(num);
       this.configs.set(num, config);
     }
     return this.configs.get(num);

--- a/src/config/loadGitHubAppsFromEnvironment.ts
+++ b/src/config/loadGitHubAppsFromEnvironment.ts
@@ -103,15 +103,24 @@ export class GitHubApps {
   getForPayload(gitHubEventPayload) {
     // Org slug is differently accessed in org-scoped APIs vs. repo-scoped APIs
     let org: string;
-    if (gitHubEventPayload.organization) {
+    if (gitHubEventPayload.organization?.login) {
       org = gitHubEventPayload.organization.login;
-    } else if (gitHubEventPayload.repository?.owner?.type === 'Organization') {
+    } else if (
+      gitHubEventPayload.repository?.owner?.login &&
+      gitHubEventPayload.repository?.owner?.type === 'Organization'
+    ) {
       org = gitHubEventPayload.repository.owner.login;
     } else {
       throw new Error(
         `Could not find an org in '${JSON.stringify(
-          gitHubEventPayload.organization
-        )}' or '${JSON.stringify(gitHubEventPayload.repository?.owner)}'.`
+          gitHubEventPayload.organization,
+          null,
+          2
+        )}' or '${JSON.stringify(
+          gitHubEventPayload.repository?.owner,
+          null,
+          2
+        )}'.`
       );
     }
     return this.get(org);

--- a/src/utils/db/getFailureMessages.test.ts
+++ b/src/utils/db/getFailureMessages.test.ts
@@ -1,3 +1,4 @@
+import { GETSENTRY_ORG } from '@/config';
 import { SlackMessage } from '@/config/slackMessage';
 import { ClientType } from '@api/github/clientType';
 import { getClient } from '@api/github/getClient';
@@ -13,7 +14,7 @@ describe('getFailureMessages', function () {
   });
 
   beforeEach(async function () {
-    octokit = await getClient(ClientType.App, 'getsentry');
+    octokit = await getClient(ClientType.App, GETSENTRY_ORG);
   });
 
   afterAll(async function () {

--- a/src/utils/githubEventHelpers.test.ts
+++ b/src/utils/githubEventHelpers.test.ts
@@ -3,7 +3,7 @@ import { GH_APPS } from '@/config';
 import * as githubEventHelpers from './githubEventHelpers';
 
 describe('githubEventHelpers', function () {
-  const app = GH_APPS.get('__tmp_org_placeholder__');
+  const app = GH_APPS.get('Enterprise');
 
   it('addIssueToGlobalIssuesProject should return project item id from project', async function () {
     const octokit = {

--- a/src/webhooks/pubsub/index.test.ts
+++ b/src/webhooks/pubsub/index.test.ts
@@ -1,0 +1,61 @@
+import { Reply } from 'fastify';
+
+import { buildServer } from '@/buildServer';
+import { GETSENTRY_ORG } from '@/config';
+import { Fastify } from '@/types';
+
+import { pubSubHandler } from './';
+
+describe('projectsHandler', function () {
+  let fastify: Fastify;
+
+  beforeEach(async function () {
+    fastify = await buildServer(false);
+  });
+
+  afterEach(async function () {
+    fastify.close();
+    jest.clearAllMocks();
+  });
+
+  async function callWith(name: string) {
+    const payload = Buffer(JSON.stringify({ name })).toString('base64');
+    const request = { body: { message: { data: payload } } };
+    const reply = { code: jest.fn(), send: jest.fn() };
+    const cheeser = jest.fn();
+    const breader = jest.fn();
+    const funcMap = new Map([
+      ['cheese', cheeser],
+      ['bread', breader],
+    ]);
+    await pubSubHandler(request, reply, funcMap);
+    return [reply.code.mock.calls[0][0], cheeser, breader];
+  }
+
+  describe('pubSubHandler', function () {
+    it('basically works', async function () {
+      const [code, cheeser, breader] = await callWith('cheese');
+      expect(code).toBe(204);
+      expect(cheeser).toHaveBeenCalled();
+      expect(breader).not.toHaveBeenCalled();
+    });
+    it('handles a different task', async function () {
+      const [code, cheeser, breader] = await callWith('bread');
+      expect(code).toBe(204);
+      expect(cheeser).not.toHaveBeenCalled();
+      expect(breader).toHaveBeenCalled();
+    });
+    it('sends 400 for unknown tasks', async function () {
+      const [code, cheeser, breader] = await callWith('wine');
+      expect(code).toBe(400);
+      expect(cheeser).not.toHaveBeenCalled();
+      expect(breader).not.toHaveBeenCalled();
+    });
+    it('is called twice, once for each app', async function () {
+      const [code, cheeser, breader] = await callWith('cheese');
+      expect(cheeser.mock.calls.length).toBe(2);
+      expect(cheeser.mock.calls[0][0].org).toBe('Enterprise');
+      expect(cheeser.mock.calls[1][0].org).toBe(GETSENTRY_ORG);
+    });
+  });
+});

--- a/src/webhooks/pubsub/index.ts
+++ b/src/webhooks/pubsub/index.ts
@@ -62,10 +62,9 @@ export const pubSubHandler = async (
 
   // `if (func)` is not enough to fool CodeQL.
   // https://codeql.github.com/codeql-query-help/javascript/js-unvalidated-dynamic-method-call/
-  if (typeof func === 'undefined') {
-    reply.code(400);
-    reply.send();
-  } else {
+  // https://github.com/github/codeql/tree/main/javascript/ql/src/Security/CWE-754/examples
+
+  if (typeof func === 'function') {
     reply.code(204);
     reply.send(); // before real work to avoid blocking
     const now = moment().utc();
@@ -73,6 +72,9 @@ export const pubSubHandler = async (
       const octokit = await getClient(ClientType.App, org);
       await func(app, octokit, now);
     }
+  } else {
+    reply.code(400);
+    reply.send();
   }
 
   tx.finish();

--- a/src/webhooks/pubsub/index.ts
+++ b/src/webhooks/pubsub/index.ts
@@ -58,7 +58,7 @@ export const pubSubHandler = async (
   // call security warning.
   // https://codeql.github.com/codeql-query-help/javascript/js-unvalidated-dynamic-method-call/
   if (typeof func === 'function') {
-    app = GH_APPS.get('__tmp_org_placeholder__');
+    app = GH_APPS.get(GETSENTRY_ORG);
     octokit = await getClient(ClientType.App, GETSENTRY_ORG);
     now = moment().utc();
   } else {

--- a/src/webhooks/pubsub/slackNotifications.test.ts
+++ b/src/webhooks/pubsub/slackNotifications.test.ts
@@ -13,7 +13,7 @@ import {
 } from './slackNotifications';
 
 describe('Triage Notification Tests', function () {
-  const app = GH_APPS.get('__tmp_org_placeholder__');
+  const app = GH_APPS.get('Enterprise');
 
   beforeAll(async function () {
     await db.migrate.latest();

--- a/src/webhooks/pubsub/slackNotifications.ts
+++ b/src/webhooks/pubsub/slackNotifications.ts
@@ -407,7 +407,7 @@ export const notifyProductOwnersForUntriagedIssues = async (
     repo: string
   ): Promise<IssueSLOInfo[]> => {
     const untriagedIssues = await octokit.paginate(octokit.issues.listForRepo, {
-      owner: GETSENTRY_ORG,
+      owner: app.org,
       repo,
       state: 'open',
       labels: WAITING_FOR_PRODUCT_OWNER_LABEL,

--- a/src/webhooks/pubsub/stalebot.test.ts
+++ b/src/webhooks/pubsub/stalebot.test.ts
@@ -17,7 +17,7 @@ jest.mock('@/config', () => {
 });
 
 describe('Stalebot Tests', function () {
-  const app = GH_APPS.get('__tmp_org_placeholder__');
+  const app = GH_APPS.get('Enterprise');
 
   const issueInfo = {
     labels: [],

--- a/src/webhooks/pubsub/stalebot.ts
+++ b/src/webhooks/pubsub/stalebot.ts
@@ -85,7 +85,7 @@ export const triggerStaleBot = async (
   // Get all open issues and pull requests that are Waiting for Community
   REPOS_TO_TRACK_FOR_STALEBOT.forEach(async (repo: string) => {
     const issues = await octokit.paginate(octokit.issues.listForRepo, {
-      owner: GETSENTRY_ORG,
+      owner: app.org,
       repo,
       state: 'open',
       labels: WAITING_FOR_COMMUNITY_LABEL,


### PR DESCRIPTION
Part of #482, after #523.

This implements parsing of multiple apps from the environment. I may decide to replace `__tmp_org_placeholder__` on a separate PR first.

- [x] replace `__tmp_org_placeholder__` throughout
- [x] possibly expand testing
- [x] better error handling on config errors (envvars instead of path keys, better formatting)
- [x] address reviews
- [ ] put protection around places where we want to require GETSENTRY_ORG
- [x] ~clean up names (`GH_APPS` ⇒ `GH_ORGS`, envvars, etc.)~ _punting_