### PR TITLE
Start refactoring to put app on org

### DIFF
--- a/src/api/github/getClient.ts
+++ b/src/api/github/getClient.ts
@@ -1,6 +1,6 @@
 import { createAppAuth } from '@octokit/auth-app';
 
-import { GH_APPS } from '@/config/index';
+import { GH_ORGS } from '@/config/index';
 import { GH_USER_TOKEN } from '@/config/index';
 import { AppAuthStrategyOptions } from '@/types';
 
@@ -44,7 +44,7 @@ export async function getClient(type: ClientType, org?: string | null) {
       );
     }
 
-    const app = GH_APPS.get('__tmp_org_placeholder__');
+    const app = GH_ORGS.get('__tmp_org_placeholder__');
 
     let client = _CLIENTS_BY_ORG.get(org);
     if (client === undefined) {

--- a/src/brain/issueLabelHandler/followups.ts
+++ b/src/brain/issueLabelHandler/followups.ts
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/node';
 import moment from 'moment-timezone';
 
 import {
-  GH_APPS,
+  GH_ORGS,
   SENTRY_REPOS,
   WAITING_FOR_COMMUNITY_LABEL,
   WAITING_FOR_LABEL_PREFIX,
@@ -57,7 +57,7 @@ export async function updateCommunityFollowups({
     name: 'issueLabelHandler.updateCommunityFollowups',
   });
 
-  const app = GH_APPS.getForPayload(payload);
+  const app = GH_ORGS.getForPayload(payload);
 
   const reasonsToDoNothing = [
     isNotInARepoWeCareAboutForFollowups,
@@ -125,7 +125,7 @@ export async function ensureOneWaitingForLabel({
     name: 'issueLabelHandler.ensureOneWaitingForLabel',
   });
 
-  const app = GH_APPS.getForPayload(payload);
+  const app = GH_ORGS.getForPayload(payload);
 
   const reasonsToDoNothing = [
     isNotInARepoWeCareAboutForFollowups,

--- a/src/brain/issueLabelHandler/index.test.ts
+++ b/src/brain/issueLabelHandler/index.test.ts
@@ -5,7 +5,7 @@ import { createGitHubEvent } from '@test/utils/github';
 import { getLabelsTable, slackHandler } from '@/brain/issueNotifier';
 import { buildServer } from '@/buildServer';
 import {
-  GH_APPS,
+  GH_ORGS,
   WAITING_FOR_COMMUNITY_LABEL,
   WAITING_FOR_PRODUCT_OWNER_LABEL,
   WAITING_FOR_SUPPORT_LABEL,
@@ -24,7 +24,7 @@ import { issueLabelHandler } from '.';
 describe('issueLabelHandler', function () {
   let fastify: Fastify;
   let octokit;
-  const app = GH_APPS.get('__tmp_org_placeholder__');
+  const app = GH_ORGS.get('__tmp_org_placeholder__');
   const errors = jest.fn();
   let say, respond, client, ack;
   let calculateSLOViolationRouteSpy, calculateSLOViolationTriageSpy;

--- a/src/brain/issueLabelHandler/route.ts
+++ b/src/brain/issueLabelHandler/route.ts
@@ -4,7 +4,7 @@ import * as Sentry from '@sentry/node';
 import {
   BACKLOG_LABEL,
   GETSENTRY_ORG,
-  GH_APPS,
+  GH_ORGS,
   IN_PROGRESS_LABEL,
   PRODUCT_AREA_LABEL_PREFIX,
   PRODUCT_AREA_UNKNOWN,
@@ -63,7 +63,7 @@ export async function markWaitingForSupport({
     name: 'issueLabelHandler.markWaitingForSupport',
   });
 
-  const app = GH_APPS.getForPayload(payload);
+  const app = GH_ORGS.getForPayload(payload);
 
   const reasonsToSkip = [
     isNotInARepoWeCareAboutForRouting,
@@ -124,7 +124,7 @@ export async function markNotWaitingForSupport({
     name: 'issueLabelHandler.markNotWaitingForSupport',
   });
 
-  const app = GH_APPS.getForPayload(payload);
+  const app = GH_ORGS.getForPayload(payload);
 
   const reasonsToSkip = [isNotInARepoWeCareAboutForRouting, isValidLabel];
   if (await shouldSkip(payload, app, reasonsToSkip)) {

--- a/src/brain/issueLabelHandler/triage.ts
+++ b/src/brain/issueLabelHandler/triage.ts
@@ -2,7 +2,7 @@ import { EmitterWebhookEvent } from '@octokit/webhooks';
 import * as Sentry from '@sentry/node';
 
 import {
-  GH_APPS,
+  GH_ORGS,
   SENTRY_REPOS_WITHOUT_ROUTING,
   WAITING_FOR_PRODUCT_OWNER_LABEL,
 } from '@/config';
@@ -46,7 +46,7 @@ export async function markWaitingForProductOwner({
     name: 'issueLabelHandler.markWaitingforProductOwner',
   });
 
-  const app = GH_APPS.getForPayload(payload);
+  const app = GH_ORGS.getForPayload(payload);
 
   const reasonsToSkipTriage = [
     isNotInARepoWeCareAboutForTriage,
@@ -99,7 +99,7 @@ export async function markNotWaitingForProductOwner({
     name: 'issueLabelHandler.markNotWaitingForProductOwner',
   });
 
-  const app = GH_APPS.getForPayload(payload);
+  const app = GH_ORGS.getForPayload(payload);
 
   const reasonsToSkip = [
     isNotInARepoWeCareAboutForTriage,

--- a/src/brain/projectsHandler/index.test.ts
+++ b/src/brain/projectsHandler/index.test.ts
@@ -1,7 +1,7 @@
 import { createGitHubEvent } from '@test/utils/github';
 
 import { buildServer } from '@/buildServer';
-import { GH_APPS } from '@/config';
+import { GH_ORGS } from '@/config';
 import { Fastify } from '@/types';
 import { defaultErrorHandler, githubEvents } from '@api/github';
 import { ClientType } from '@api/github/clientType';
@@ -14,7 +14,7 @@ import { projectsHandler } from '.';
 describe('projectsHandler', function () {
   let fastify: Fastify;
   let octokit;
-  const app = GH_APPS.get('__tmp_org_placeholder__');
+  const app = GH_ORGS.get('__tmp_org_placeholder__');
   const errors = jest.fn();
 
   beforeAll(async function () {

--- a/src/brain/projectsHandler/project.ts
+++ b/src/brain/projectsHandler/project.ts
@@ -1,7 +1,7 @@
 import { EmitterWebhookEvent } from '@octokit/webhooks';
 import * as Sentry from '@sentry/node';
 
-import { GH_APPS, PRODUCT_AREA_LABEL_PREFIX } from '@/config';
+import { GH_ORGS, PRODUCT_AREA_LABEL_PREFIX } from '@/config';
 import { ClientType } from '@api/github/clientType';
 import { getClient } from '@api/github/getClient';
 import { shouldSkip } from '@utils/githubEventHelpers';
@@ -53,7 +53,7 @@ export async function syncLabelsWithProjectField({
     name: 'issueLabelHandler.syncLabelsWithProjectField',
   });
 
-  const app = GH_APPS.getForPayload(payload);
+  const app = GH_ORGS.getForPayload(payload);
 
   const reasonsToDoNothing = [
     isNotInAProjectWeCareAbout,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,7 +1,7 @@
 import {
-  GitHubApps,
-  loadGitHubAppsFromEnvironment,
-} from './loadGitHubAppsFromEnvironment';
+  GitHubOrgs,
+  loadGitHubOrgsFromEnvironment,
+} from './loadGitHubOrgsFromEnvironment';
 
 export const SENTRY_DSN =
   (process.env.ENV === 'production' &&
@@ -168,19 +168,10 @@ export const SENTRY_REPOS: Set<string> = new Set([
 export const GH_USER_TOKEN = process.env.GH_USER_TOKEN || '';
 
 /**
- * App auth strategy options. For branding purposes, we have one app per org
- * (getsantry for getsentry, covecod for codecov, etc). Down in getClient we
- * will instantiate a GitHub octokit client for each org the first time we need
- * it, then cache it for the duration of our server process as it seems to be
- * smart enough to renew auth tokens as needed. When we do that, we will set
- * installationId. Here in config we need to populate the appId and privateKey
- * from the environment.
- *
- * TODO: Expand from a single app/org to multiple. First we need to clean up
- * getClient calls to use a dynamic owner/org instead of GETSENTRY_ORG as defined above.
+ * Load GitHubOrgs. We support processing events coming at us from multiple
+ * GitHub orgs and this is how we encapsulate it all.
  */
-
-export const GH_APPS: GitHubApps = loadGitHubAppsFromEnvironment(process.env);
+export const GH_ORGS: GitHubOrgs = loadGitHubOrgsFromEnvironment(process.env);
 
 /**
  * Business Hours by Office

--- a/src/config/loadGitHubOrgsFromEnvironment.test.ts
+++ b/src/config/loadGitHubOrgsFromEnvironment.test.ts
@@ -1,6 +1,6 @@
-import { loadGitHubAppsFromEnvironment } from './loadGitHubAppsFromEnvironment';
+import { loadGitHubOrgsFromEnvironment } from './loadGitHubOrgsFromEnvironment';
 
-describe('loadGitHubAppsFromEnvironment ', function () {
+describe('loadGitHubOrgsFromEnvironment ', function () {
   it('basically works', async function () {
     const expected = {
       apps: new Map([
@@ -24,7 +24,7 @@ describe('loadGitHubAppsFromEnvironment ', function () {
         ],
       ]),
     };
-    const actual = loadGitHubAppsFromEnvironment({
+    const actual = loadGitHubOrgsFromEnvironment({
       GH_APP_IDENTIFIER: '42',
       GH_APP_SECRET_KEY: 'cheese',
       ISSUES_PROJECT_NODE_ID: 'bread',
@@ -36,7 +36,7 @@ describe('loadGitHubAppsFromEnvironment ', function () {
   });
 
   it('ignores the rest of the environment', async function () {
-    const actual = loadGitHubAppsFromEnvironment({
+    const actual = loadGitHubOrgsFromEnvironment({
       RANDOM: 'garbage',
       AND_EXTRA: 'stuff',
 
@@ -47,7 +47,7 @@ describe('loadGitHubAppsFromEnvironment ', function () {
   });
 
   it('is fine with no app configured', async function () {
-    const actual = loadGitHubAppsFromEnvironment({
+    const actual = loadGitHubOrgsFromEnvironment({
       RANDOM: 'garbage',
       AND_EXTRA: 'stuff',
     });
@@ -77,7 +77,7 @@ describe('loadGitHubAppsFromEnvironment ', function () {
         ],
       ]),
     };
-    const actual = loadGitHubAppsFromEnvironment({
+    const actual = loadGitHubOrgsFromEnvironment({
       GH_APP_IDENTIFIER: '42',
       GH_APP_SECRET_KEY: 'cheese',
     });

--- a/src/config/loadGitHubOrgsFromEnvironment.ts
+++ b/src/config/loadGitHubOrgsFromEnvironment.ts
@@ -5,17 +5,17 @@ import {
 
 // Config - loosely typed and ephemeral, used for collecting values found in
 // the environment. We check for missing values using this but not for types,
-// that is what GitHubApp is for (below). Configs are stored by number taken
+// that is what GitHubOrg is for (below). Configs are stored by number taken
 // from envvars. Roughly, `GH_APP_1_FOO=bar` becomes `{1: {FOO: "bar"}}`.
 
-class GitHubAppConfig {
+class GitHubOrgConfig {
   num: any;
   org: any;
   auth: any;
   project: any;
 }
 
-class GitHubAppConfigs {
+class GitHubOrgConfigs {
   configs: Map<number, any>;
 
   constructor() {
@@ -24,7 +24,7 @@ class GitHubAppConfigs {
 
   getOrCreate(num: number): object | undefined {
     if (!this.configs.has(num)) {
-      const config = new GitHubAppConfig();
+      const config = new GitHubOrgConfig();
       config.num = num;
       this.configs.set(num, config);
     }
@@ -32,11 +32,11 @@ class GitHubAppConfigs {
   }
 }
 
-// App - strongly typed and permanent, these are used throughout the codebase
-// via `{ import GH_APPS } from '/@config'`. They are accessed by org slug,
+// Org - strongly typed and permanent, these are used throughout the codebase
+// via `{ import GH_ORGS } from '/@config'`. They are accessed by org slug,
 // usually taken from a GitHub event payload.
 
-export class GitHubApp {
+export class GitHubOrg {
   num: number;
   org: string;
   auth: AppAuthStrategyOptions;
@@ -50,13 +50,13 @@ export class GitHubApp {
   }
 }
 
-export class GitHubApps {
-  apps: Map<string, GitHubApp>;
+export class GitHubOrgs {
+  apps: Map<string, GitHubOrg>;
 
   constructor(appConfigs) {
-    this.apps = new Map<string, GitHubApp>();
+    this.apps = new Map<string, GitHubOrg>();
     for (const config of appConfigs.configs.values()) {
-      this.apps.set(config.org, new GitHubApp(config));
+      this.apps.set(config.org, new GitHubOrg(config));
     }
   }
 
@@ -80,16 +80,16 @@ export class GitHubApps {
   }
 }
 
-// Loader - called in @/config to populate the GH_APPS global.
+// Loader - called in @/config to populate the GH_ORGS global.
 
-export function loadGitHubAppsFromEnvironment(env) {
-  const configs = new GitHubAppConfigs();
+export function loadGitHubOrgsFromEnvironment(env) {
+  const configs = new GitHubOrgConfigs();
   let config;
 
   if (env.GH_APP_IDENTIFIER && env.GH_APP_SECRET_KEY) {
     // Collect config by (proleptic) envvar number. Once we have GH_APP_1_FOO
     // this will make more sense. We'll collect stuff in config and then
-    // instantiate a GitHubApp once all config has been collected for each
+    // instantiate a GitHubOrg once all config has been collected for each
     // (once we've made a full pass through process.env).
 
     config = configs.getOrCreate(1);
@@ -110,5 +110,5 @@ export function loadGitHubAppsFromEnvironment(env) {
 
   // Now convert them to (strongly-typed) apps now that we know the info is
   // clean.
-  return new GitHubApps(configs);
+  return new GitHubOrgs(configs);
 }

--- a/src/utils/githubEventHelpers.test.ts
+++ b/src/utils/githubEventHelpers.test.ts
@@ -1,9 +1,9 @@
-import { GH_APPS } from '@/config';
+import { GH_ORGS } from '@/config';
 
 import * as githubEventHelpers from './githubEventHelpers';
 
 describe('githubEventHelpers', function () {
-  const app = GH_APPS.get('__tmp_org_placeholder__');
+  const app = GH_ORGS.get('__tmp_org_placeholder__');
 
   it('addIssueToGlobalIssuesProject should return project item id from project', async function () {
     const octokit = {

--- a/src/utils/githubEventHelpers.ts
+++ b/src/utils/githubEventHelpers.ts
@@ -1,12 +1,12 @@
 import { Octokit } from '@octokit/rest';
 import * as Sentry from '@sentry/node';
 
-import { GitHubApp } from '@/config/loadGitHubAppsFromEnvironment';
+import { GitHubOrg } from '@/config/loadGitHubOrgsFromEnvironment';
 import { getOssUserType } from '@utils/getOssUserType';
 
 // Validation Helpers
 
-export async function shouldSkip(payload, app: GitHubApp, reasonsToSkip) {
+export async function shouldSkip(payload, app: GitHubOrg, reasonsToSkip) {
   // Could do Promise-based async here, but that was getting complicated[1] and
   // there's not really a performance concern (famous last words).
   //
@@ -37,7 +37,7 @@ async function sendQuery(query: string, data: object, octokit: Octokit) {
 }
 
 export async function addIssueToGlobalIssuesProject(
-  app: GitHubApp,
+  app: GitHubOrg,
   issueNodeId: string | undefined,
   repo: string,
   issueNumber: number,
@@ -96,7 +96,7 @@ export async function getAllProjectFieldNodeIds(
 }
 
 export async function modifyProjectIssueField(
-  app: GitHubApp,
+  app: GitHubOrg,
   itemId: string,
   projectFieldOption: string,
   fieldId: string,
@@ -132,7 +132,7 @@ export async function modifyProjectIssueField(
 }
 
 export async function modifyDueByDate(
-  app: GitHubApp,
+  app: GitHubOrg,
   itemId: string,
   projectFieldOption: string,
   fieldId: string,
@@ -196,7 +196,7 @@ export async function getKeyValueFromProjectField(
 }
 
 export async function getIssueDueDateFromProject(
-  app: GitHubApp,
+  app: GitHubOrg,
   issueNodeId: string,
   octokit: Octokit
 ) {

--- a/src/webhooks/pubsub/index.ts
+++ b/src/webhooks/pubsub/index.ts
@@ -3,7 +3,7 @@ import { FastifyReply, FastifyRequest } from 'fastify';
 import moment from 'moment-timezone';
 
 import { ClientType } from '@/api/github/clientType';
-import { GETSENTRY_ORG, GH_APPS } from '@/config';
+import { GETSENTRY_ORG, GH_ORGS } from '@/config';
 import { notifyProductOwnersForUntriagedIssues } from '@/webhooks/pubsub/slackNotifications';
 import { getClient } from '@api/github/getClient';
 
@@ -58,7 +58,7 @@ export const pubSubHandler = async (
   // call security warning.
   // https://codeql.github.com/codeql-query-help/javascript/js-unvalidated-dynamic-method-call/
   if (typeof func === 'function') {
-    app = GH_APPS.get('__tmp_org_placeholder__');
+    app = GH_ORGS.get('__tmp_org_placeholder__');
     octokit = await getClient(ClientType.App, GETSENTRY_ORG);
     now = moment().utc();
   } else {

--- a/src/webhooks/pubsub/slackNotifications.test.ts
+++ b/src/webhooks/pubsub/slackNotifications.test.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/node';
 import moment from 'moment-timezone';
 
 import { getLabelsTable } from '@/brain/issueNotifier';
-import { GH_APPS } from '@/config';
+import { GH_ORGS } from '@/config';
 import * as githubEventHelpers from '@/utils/githubEventHelpers';
 import { bolt } from '@api/slack';
 import { db } from '@utils/db';
@@ -13,7 +13,7 @@ import {
 } from './slackNotifications';
 
 describe('Triage Notification Tests', function () {
-  const app = GH_APPS.get('__tmp_org_placeholder__');
+  const app = GH_ORGS.get('__tmp_org_placeholder__');
 
   beforeAll(async function () {
     await db.migrate.latest();

--- a/src/webhooks/pubsub/slackNotifications.ts
+++ b/src/webhooks/pubsub/slackNotifications.ts
@@ -10,7 +10,7 @@ import {
   SENTRY_REPOS_WITH_ROUTING,
   WAITING_FOR_PRODUCT_OWNER_LABEL,
 } from '@/config';
-import { GitHubApp } from '@/config/loadGitHubAppsFromEnvironment';
+import { GitHubOrg } from '@/config/loadGitHubOrgsFromEnvironment';
 import { Issue } from '@/types';
 import { isChannelInBusinessHours } from '@/utils/businessHours';
 import {
@@ -126,7 +126,7 @@ const addOrderingToSlackMessageItem = (
 };
 
 export const getTriageSLOTimestamp = async (
-  app: GitHubApp,
+  app: GitHubOrg,
   octokit: Octokit,
   repo: string,
   issueNumber: number,
@@ -394,7 +394,7 @@ export const constructSlackMessage = (
 };
 
 export const notifyProductOwnersForUntriagedIssues = async (
-  app: GitHubApp,
+  app: GitHubOrg,
   octokit: Octokit,
   now: moment.Moment
 ) => {

--- a/src/webhooks/pubsub/stalebot.test.ts
+++ b/src/webhooks/pubsub/stalebot.test.ts
@@ -1,7 +1,7 @@
 import moment from 'moment-timezone';
 
 import { STALE_LABEL } from '@/config';
-import { GH_APPS } from '@/config';
+import { GH_ORGS } from '@/config';
 import { ClientType } from '@api/github/clientType';
 import { getClient } from '@api/github/getClient';
 
@@ -16,7 +16,7 @@ jest.mock('@/config', () => {
 });
 
 describe('Stalebot Tests', function () {
-  const app = GH_APPS.get('__tmp_org_placeholder__');
+  const app = GH_ORGS.get('__tmp_org_placeholder__');
 
   const issueInfo = {
     labels: [],

--- a/src/webhooks/pubsub/stalebot.ts
+++ b/src/webhooks/pubsub/stalebot.ts
@@ -7,7 +7,7 @@ import {
   STALE_LABEL,
   WAITING_FOR_COMMUNITY_LABEL,
 } from '@/config';
-import { GitHubApp } from '@/config/loadGitHubAppsFromEnvironment';
+import { GitHubOrg } from '@/config/loadGitHubOrgsFromEnvironment';
 
 const GH_API_PER_PAGE = 100;
 const DAYS_BEFORE_STALE = 21;
@@ -75,7 +75,7 @@ But! If you comment or otherwise update it, I will reset the clock, and if you r
 };
 
 export const triggerStaleBot = async (
-  app: GitHubApp,
+  app: GitHubOrg,
   octokit: Octokit,
   now: moment.Moment
 ) => {


### PR DESCRIPTION
Part of #482, coming here from https://github.com/getsentry/eng-pipes/pull/524#issuecomment-1640753889, before #530.

I want to improve our object model so that `GitHubOrg` is the top-level thing we instantiate at startup, and `app` (i.e., an `octokit` client) is a property of the org. This should hopefully make it harder to cross wires between events incoming from a given org and subsequent API calls, which should be against the same org.