### PR TITLE
Move GitHubOrg (and GitHubConfig) out of @/config

### DIFF
--- a/src/api/github/org.ts
+++ b/src/api/github/org.ts
@@ -1,0 +1,17 @@
+import {
+  AppAuthStrategyOptions,
+  GitHubIssuesSomeoneElseCaresAbout,
+  GitHubOrgConfig,
+} from '@/types';
+
+export class GitHubOrg {
+  slug: string;
+  appAuth: AppAuthStrategyOptions;
+  project: GitHubIssuesSomeoneElseCaresAbout;
+
+  constructor(config: GitHubOrgConfig) {
+    this.slug = config.slug;
+    this.appAuth = config.appAuth;
+    this.project = config.project;
+  }
+}

--- a/src/config/loadGitHubOrgsFromEnvironment.ts
+++ b/src/config/loadGitHubOrgsFromEnvironment.ts
@@ -1,19 +1,12 @@
-import {
-  AppAuthStrategyOptions,
-  GitHubIssuesSomeoneElseCaresAbout,
-} from '@/types';
+import { GitHubOrgConfig } from '@/types';
 
-// Config - loosely typed and ephemeral, used for collecting values found in
+// Don't use '@api' here, because it's ... not loaded yet, or something?
+import { GitHubOrg } from '../api/github/org';
+
+// Configs - loosely typed and ephemeral, used for collecting values found in
 // the environment. We check for missing values using this but not for types,
 // that is what GitHubOrg is for (below). Configs are stored by number taken
 // from envvars. Roughly, `GH_APP_1_FOO=bar` becomes `{1: {FOO: "bar"}}`.
-
-class GitHubOrgConfig {
-  num: any;
-  slug: any;
-  appAuth: any;
-  project: any;
-}
 
 class GitHubOrgConfigs {
   configs: Map<number, any>;
@@ -22,31 +15,18 @@ class GitHubOrgConfigs {
     this.configs = new Map<number, object>();
   }
 
-  getOrCreate(num: number): object | undefined {
+  getOrCreate(num: number): GitHubOrgConfig | undefined {
     if (!this.configs.has(num)) {
-      const config = new GitHubOrgConfig();
-      config.num = num;
+      const config = { num: num };
       this.configs.set(num, config);
     }
     return this.configs.get(num);
   }
 }
 
-// Org - strongly typed and permanent, these are used throughout the codebase
-// via `{ import GH_ORGS } from '/@config'`. They are accessed by org slug,
+// Orgs - strongly typed and permanent, these are used throughout the codebase
+// via `{ import GH_ORGS } from '@/config'`. They are accessed by org slug,
 // usually taken from a GitHub event payload.
-
-export class GitHubOrg {
-  slug: string;
-  appAuth: AppAuthStrategyOptions;
-  project: GitHubIssuesSomeoneElseCaresAbout;
-
-  constructor(config) {
-    this.slug = config.slug;
-    this.appAuth = config.appAuth;
-    this.project = config.project;
-  }
-}
 
 export class GitHubOrgs {
   orgs: Map<string, GitHubOrg>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,6 +42,13 @@ export interface GitHubIssuesSomeoneElseCaresAbout {
   response_due_date_field_id: string;
 }
 
+export interface GitHubOrgConfig {
+  num: any;
+  slug: any;
+  appAuth: any;
+  project: any;
+}
+
 export type CheckRun = EmitterWebhookEvent<'check_run'>['payload']['check_run'];
 
 // Note we intentionally only pick the pieces of checkRun that is needed to

--- a/src/utils/githubEventHelpers.ts
+++ b/src/utils/githubEventHelpers.ts
@@ -1,7 +1,7 @@
 import { Octokit } from '@octokit/rest';
 import * as Sentry from '@sentry/node';
 
-import { GitHubOrg } from '@/config/loadGitHubOrgsFromEnvironment';
+import { GitHubOrg } from '@api/github/org';
 import { getOssUserType } from '@utils/getOssUserType';
 
 // Validation Helpers

--- a/src/webhooks/pubsub/slackNotifications.ts
+++ b/src/webhooks/pubsub/slackNotifications.ts
@@ -10,13 +10,13 @@ import {
   SENTRY_REPOS_WITH_ROUTING,
   WAITING_FOR_PRODUCT_OWNER_LABEL,
 } from '@/config';
-import { GitHubOrg } from '@/config/loadGitHubOrgsFromEnvironment';
 import { Issue } from '@/types';
 import { isChannelInBusinessHours } from '@/utils/businessHours';
 import {
   addIssueToGlobalIssuesProject,
   getIssueDueDateFromProject,
 } from '@/utils/githubEventHelpers';
+import { GitHubOrg } from '@api/github/org';
 import { bolt } from '@api/slack';
 import { db } from '@utils/db';
 

--- a/src/webhooks/pubsub/stalebot.ts
+++ b/src/webhooks/pubsub/stalebot.ts
@@ -7,7 +7,7 @@ import {
   STALE_LABEL,
   WAITING_FOR_COMMUNITY_LABEL,
 } from '@/config';
-import { GitHubOrg } from '@/config/loadGitHubOrgsFromEnvironment';
+import { GitHubOrg } from '@api/github/org';
 
 const GH_API_PER_PAGE = 100;
 const DAYS_BEFORE_STALE = 21;


### PR DESCRIPTION
Part of #482, after #531.

I want to see if I can move the functions from `githubEventHelpers` onto this class, to unfrobulate the call chains and how we pass org around.