### PR TITLE
Factor isNotFromAnExternalOrGTMUser out of githubEventHelpers

### DIFF
--- a/src/brain/issueLabelHandler/followups.ts
+++ b/src/brain/issueLabelHandler/followups.ts
@@ -18,12 +18,12 @@ import {
 } from '@utils/businessHours';
 import {
   addIssueToGlobalIssuesProject,
-  isNotFromAnExternalOrGTMUser,
   modifyDueByDate,
   modifyProjectIssueField,
   shouldSkip,
 } from '@utils/githubEventHelpers';
 import { isFromABot } from '@utils/isFromABot';
+import { isNotFromAnExternalOrGTMUser } from '@utils/isNotFromAnExternalOrGTMUser';
 
 function isNotInARepoWeCareAboutForFollowups(payload) {
   return !SENTRY_REPOS.has(payload.repository.name);

--- a/src/brain/issueLabelHandler/route.ts
+++ b/src/brain/issueLabelHandler/route.ts
@@ -16,10 +16,10 @@ import { ClientType } from '@api/github/clientType';
 import { getClient } from '@api/github/getClient';
 import {
   addIssueToGlobalIssuesProject,
-  isNotFromAnExternalOrGTMUser,
   modifyProjectIssueField,
   shouldSkip,
 } from '@utils/githubEventHelpers';
+import { isNotFromAnExternalOrGTMUser } from '@utils/isNotFromAnExternalOrGTMUser';
 import { slugizeProductArea } from '@utils/slugizeProductArea';
 
 function isAlreadyWaitingForSupport(payload) {

--- a/src/brain/issueLabelHandler/triage.ts
+++ b/src/brain/issueLabelHandler/triage.ts
@@ -9,12 +9,12 @@ import {
 import { ClientType } from '@api/github/clientType';
 import { getClient } from '@api/github/getClient';
 import {
-  isNotFromAnExternalOrGTMUser,
+  addIssueToGlobalIssuesProject,
   modifyProjectIssueField,
   shouldSkip,
 } from '@utils/githubEventHelpers';
-import { addIssueToGlobalIssuesProject } from '@utils/githubEventHelpers';
 import { isFromABot } from '@utils/isFromABot';
+import { isNotFromAnExternalOrGTMUser } from '@utils/isNotFromAnExternalOrGTMUser';
 
 function isAlreadyUntriaged(payload) {
   return !isAlreadyTriaged(payload);

--- a/src/utils/githubEventHelpers.ts
+++ b/src/utils/githubEventHelpers.ts
@@ -2,7 +2,6 @@ import { Octokit } from '@octokit/rest';
 import * as Sentry from '@sentry/node';
 
 import { GitHubOrg } from '@api/github/org';
-import { getOssUserType } from '@utils/getOssUserType';
 
 // Validation Helpers
 
@@ -18,11 +17,6 @@ export async function shouldSkip(payload, org: GitHubOrg, reasonsToSkip) {
     }
   }
   return false;
-}
-
-export async function isNotFromAnExternalOrGTMUser(payload: object) {
-  const type = await getOssUserType(payload);
-  return !(type === 'external' || type === 'gtm');
 }
 
 async function sendQuery(query: string, data: object, octokit: Octokit) {

--- a/src/utils/isNotFromAnExternalOrGTMUser.ts
+++ b/src/utils/isNotFromAnExternalOrGTMUser.ts
@@ -1,0 +1,6 @@
+import { getOssUserType } from '@utils/getOssUserType';
+
+export async function isNotFromAnExternalOrGTMUser(payload: object) {
+  const type = await getOssUserType(payload);
+  return !(type === 'external' || type === 'gtm');
+}


### PR DESCRIPTION
Part of #482, after #532.

I want to see if I can put the GraphQL wrappers on GitHubOrg. Gotta get this helper out of the way first.