### PR TITLE
Move githhubEventHelpers to api/github/helpers

### DIFF
--- a/src/api/github/helpers.test.ts
+++ b/src/api/github/helpers.test.ts
@@ -1,8 +1,8 @@
 import { GH_ORGS } from '@/config';
 
-import * as githubEventHelpers from './githubEventHelpers';
+import * as helpers from './helpers';
 
-describe('githubEventHelpers', function () {
+describe('helpers', function () {
   const org = GH_ORGS.get('__tmp_org_placeholder__');
 
   it('addIssueToGlobalIssuesProject should return project item id from project', async function () {
@@ -12,7 +12,7 @@ describe('githubEventHelpers', function () {
         .mockReturnValue({ addProjectV2ItemById: { item: { id: '12345' } } }),
     };
     expect(
-      await githubEventHelpers.addIssueToGlobalIssuesProject(
+      await helpers.addIssueToGlobalIssuesProject(
         org,
         'issueNodeId',
         'test-repo',
@@ -35,10 +35,7 @@ describe('githubEventHelpers', function () {
       }),
     };
     expect(
-      await githubEventHelpers.getAllProjectFieldNodeIds(
-        'projectFieldId',
-        octokit
-      )
+      await helpers.getAllProjectFieldNodeIds('projectFieldId', octokit)
     ).toEqual({
       'Waiting for: Product Owner': 1,
       'Waiting for: Support': 2,
@@ -53,7 +50,7 @@ describe('githubEventHelpers', function () {
       }),
     };
     expect(
-      await githubEventHelpers.getKeyValueFromProjectField(
+      await helpers.getKeyValueFromProjectField(
         'issueNodeId',
         'fieldName',
         octokit
@@ -79,11 +76,7 @@ describe('githubEventHelpers', function () {
       }),
     };
     expect(
-      await githubEventHelpers.getIssueDueDateFromProject(
-        org,
-        'issueNodeId',
-        octokit
-      )
+      await helpers.getIssueDueDateFromProject(org, 'issueNodeId', octokit)
     ).toEqual('2023-06-23T18:00:00.000Z');
   });
 
@@ -94,7 +87,7 @@ describe('githubEventHelpers', function () {
       }),
     };
     expect(
-      await githubEventHelpers.getIssueDetailsFromNodeId('issueNodeId', octokit)
+      await helpers.getIssueDetailsFromNodeId('issueNodeId', octokit)
     ).toEqual({ number: 1, repo: 'test-repo' });
   });
 });

--- a/src/api/github/helpers.ts
+++ b/src/api/github/helpers.ts
@@ -3,22 +3,6 @@ import * as Sentry from '@sentry/node';
 
 import { GitHubOrg } from '@api/github/org';
 
-// Validation Helpers
-
-export async function shouldSkip(payload, org: GitHubOrg, reasonsToSkip) {
-  // Could do Promise-based async here, but that was getting complicated[1] and
-  // there's not really a performance concern (famous last words).
-  //
-  // [1] https://github.com/getsentry/eng-pipes/pull/212#discussion_r657365585
-
-  for (const skipIf of reasonsToSkip) {
-    if (await skipIf(payload, org)) {
-      return true;
-    }
-  }
-  return false;
-}
-
 async function sendQuery(query: string, data: object, octokit: Octokit) {
   let response: any;
   try {

--- a/src/brain/issueLabelHandler/followups.ts
+++ b/src/brain/issueLabelHandler/followups.ts
@@ -13,17 +13,17 @@ import {
 import { ClientType } from '@api/github/clientType';
 import { getClient } from '@api/github/getClient';
 import {
-  calculateSLOViolationRoute,
-  calculateSLOViolationTriage,
-} from '@utils/businessHours';
-import {
   addIssueToGlobalIssuesProject,
   modifyDueByDate,
   modifyProjectIssueField,
-  shouldSkip,
-} from '@utils/githubEventHelpers';
+} from '@api/github/helpers';
+import {
+  calculateSLOViolationRoute,
+  calculateSLOViolationTriage,
+} from '@utils/businessHours';
 import { isFromABot } from '@utils/isFromABot';
 import { isNotFromAnExternalOrGTMUser } from '@utils/isNotFromAnExternalOrGTMUser';
+import { shouldSkip } from '@utils/shouldSkip';
 
 function isNotInARepoWeCareAboutForFollowups(payload) {
   return !SENTRY_REPOS.has(payload.repository.name);

--- a/src/brain/issueLabelHandler/index.test.ts
+++ b/src/brain/issueLabelHandler/index.test.ts
@@ -15,9 +15,9 @@ import { defaultErrorHandler, githubEvents } from '@api/github';
 import { MockOctokitError } from '@api/github/__mocks__/mockError';
 import { ClientType } from '@api/github/clientType';
 import { getClient } from '@api/github/getClient';
+import * as helpers from '@api/github/helpers';
 import * as businessHourFunctions from '@utils/businessHours';
 import { db } from '@utils/db';
-import * as helpers from '@utils/githubEventHelpers';
 
 import { issueLabelHandler } from '.';
 

--- a/src/brain/issueLabelHandler/route.ts
+++ b/src/brain/issueLabelHandler/route.ts
@@ -17,9 +17,9 @@ import { getClient } from '@api/github/getClient';
 import {
   addIssueToGlobalIssuesProject,
   modifyProjectIssueField,
-  shouldSkip,
-} from '@utils/githubEventHelpers';
+} from '@api/github/helpers';
 import { isNotFromAnExternalOrGTMUser } from '@utils/isNotFromAnExternalOrGTMUser';
+import { shouldSkip } from '@utils/shouldSkip';
 import { slugizeProductArea } from '@utils/slugizeProductArea';
 
 function isAlreadyWaitingForSupport(payload) {

--- a/src/brain/issueLabelHandler/triage.ts
+++ b/src/brain/issueLabelHandler/triage.ts
@@ -11,10 +11,10 @@ import { getClient } from '@api/github/getClient';
 import {
   addIssueToGlobalIssuesProject,
   modifyProjectIssueField,
-  shouldSkip,
-} from '@utils/githubEventHelpers';
+} from '@api/github/helpers';
 import { isFromABot } from '@utils/isFromABot';
 import { isNotFromAnExternalOrGTMUser } from '@utils/isNotFromAnExternalOrGTMUser';
+import { shouldSkip } from '@utils/shouldSkip';
 
 function isAlreadyUntriaged(payload) {
   return !isAlreadyTriaged(payload);

--- a/src/brain/projectsHandler/index.test.ts
+++ b/src/brain/projectsHandler/index.test.ts
@@ -6,8 +6,8 @@ import { Fastify } from '@/types';
 import { defaultErrorHandler, githubEvents } from '@api/github';
 import { ClientType } from '@api/github/clientType';
 import { getClient } from '@api/github/getClient';
+import * as helpers from '@api/github/helpers';
 import { db } from '@utils/db';
-import * as helpers from '@utils/githubEventHelpers';
 
 import { projectsHandler } from '.';
 

--- a/src/brain/projectsHandler/project.ts
+++ b/src/brain/projectsHandler/project.ts
@@ -4,11 +4,11 @@ import * as Sentry from '@sentry/node';
 import { GH_ORGS, PRODUCT_AREA_LABEL_PREFIX } from '@/config';
 import { ClientType } from '@api/github/clientType';
 import { getClient } from '@api/github/getClient';
-import { shouldSkip } from '@utils/githubEventHelpers';
 import {
   getIssueDetailsFromNodeId,
   getKeyValueFromProjectField,
-} from '@utils/githubEventHelpers';
+} from '@api/github/helpers';
+import { shouldSkip } from '@utils/shouldSkip';
 
 function isNotInAProjectWeCareAbout(payload, org) {
   return payload?.projects_v2_item?.project_node_id !== org.project.node_id;

--- a/src/utils/shouldSkip.ts
+++ b/src/utils/shouldSkip.ts
@@ -1,0 +1,10 @@
+import { GitHubOrg } from '@api/github/org';
+
+export async function shouldSkip(payload, org: GitHubOrg, reasonsToSkip) {
+  for (const skipIf of reasonsToSkip) {
+    if (await skipIf(payload, org)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/webhooks/pubsub/slackNotifications.test.ts
+++ b/src/webhooks/pubsub/slackNotifications.test.ts
@@ -3,7 +3,7 @@ import moment from 'moment-timezone';
 
 import { getLabelsTable } from '@/brain/issueNotifier';
 import { GH_ORGS } from '@/config';
-import * as githubEventHelpers from '@/utils/githubEventHelpers';
+import * as helpers from '@api/github/helpers';
 import { bolt } from '@api/slack';
 import { db } from '@utils/db';
 
@@ -50,10 +50,10 @@ describe('Triage Notification Tests', function () {
     };
     beforeAll(function () {
       jest
-        .spyOn(githubEventHelpers, 'addIssueToGlobalIssuesProject')
+        .spyOn(helpers, 'addIssueToGlobalIssuesProject')
         .mockReturnValue('issueNodeIdInProject');
       getIssueDueDateFromProjectSpy = jest.spyOn(
-        githubEventHelpers,
+        helpers,
         'getIssueDueDateFromProject'
       );
     });

--- a/src/webhooks/pubsub/slackNotifications.ts
+++ b/src/webhooks/pubsub/slackNotifications.ts
@@ -15,7 +15,7 @@ import { isChannelInBusinessHours } from '@/utils/businessHours';
 import {
   addIssueToGlobalIssuesProject,
   getIssueDueDateFromProject,
-} from '@/utils/githubEventHelpers';
+} from '@api/github/helpers';
 import { GitHubOrg } from '@api/github/org';
 import { bolt } from '@api/slack';
 import { db } from '@utils/db';


### PR DESCRIPTION
Part of #482, after #533.

Next step would be to move helpers onto the `GitHubOrg` class.