### PR TITLE
Make GETSENTRY_ORG an org instead of a string

### DIFF
--- a/src/api/github/getChangedStack.ts
+++ b/src/api/github/getChangedStack.ts
@@ -13,10 +13,10 @@ const BACKEND_CHANGE_CHECK_NAME = 'only backend changes';
  */
 export async function getChangedStack(ref: string, repo: string) {
   try {
-    const octokit = await getClient(ClientType.App, GETSENTRY_ORG);
+    const octokit = await getClient(ClientType.App, GETSENTRY_ORG.slug);
 
     const check_runs = await octokit.paginate(octokit.checks.listForRef, {
-      owner: GETSENTRY_ORG,
+      owner: GETSENTRY_ORG.slug,
       repo,
       ref,
       per_page: 100,
@@ -36,7 +36,7 @@ export async function getChangedStack(ref: string, repo: string) {
       // Track this event in case the check status name changes in the future.
       Sentry.captureMessage(`Failed to identify the type of commit`, {
         extra: {
-          Commit: `https://github.com/${GETSENTRY_ORG}/${repo}/commit/${ref}`,
+          Commit: `https://github.com/${GETSENTRY_ORG.slug}/${repo}/commit/${ref}`,
           'GH Check Runs': check_runs.map((c) => c.name),
         },
       });

--- a/src/api/github/getClient.ts
+++ b/src/api/github/getClient.ts
@@ -1,6 +1,6 @@
 import { createAppAuth } from '@octokit/auth-app';
 
-import { GH_ORGS } from '@/config/index';
+import { GETSENTRY_ORG } from '@/config/index';
 import { GH_USER_TOKEN } from '@/config/index';
 import { AppAuthStrategyOptions } from '@/types';
 
@@ -44,7 +44,7 @@ export async function getClient(type: ClientType, orgSlug?: string | null) {
       );
     }
 
-    const org = GH_ORGS.get('__tmp_org_placeholder__');
+    const org = GETSENTRY_ORG;
 
     let client = _CLIENTS_BY_ORG.get(orgSlug);
     if (client === undefined) {

--- a/src/api/github/getRelevantCommit.ts
+++ b/src/api/github/getRelevantCommit.ts
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/node';
 
 import { ClientType } from '@/api/github/clientType';
-import { GETSENTRY_ORG, GETSENTRY_REPO, SENTRY_REPO } from '@/config';
+import { GETSENTRY_ORG, GETSENTRY_REPO_SLUG, SENTRY_REPO_SLUG } from '@/config';
 import { getClient } from '@api/github/getClient';
 
 /**
@@ -13,12 +13,12 @@ import { getClient } from '@api/github/getClient';
  */
 export async function getRelevantCommit(ref: string) {
   try {
-    const octokit = await getClient(ClientType.App, GETSENTRY_ORG);
+    const octokit = await getClient(ClientType.App, GETSENTRY_ORG.slug);
 
     // Attempt to get the getsentry commit first
     const { data: commit } = await octokit.repos.getCommit({
-      owner: GETSENTRY_ORG,
-      repo: GETSENTRY_REPO,
+      owner: GETSENTRY_ORG.slug,
+      repo: GETSENTRY_REPO_SLUG,
       ref,
     });
 
@@ -39,8 +39,8 @@ export async function getRelevantCommit(ref: string) {
     //
     // In this case, fetch the sentry commit to display
     const { data } = await octokit.repos.getCommit({
-      owner: GETSENTRY_ORG,
-      repo: SENTRY_REPO,
+      owner: GETSENTRY_ORG.slug,
+      repo: SENTRY_REPO_SLUG,
       ref: sentryCommitSha,
     });
 

--- a/src/api/github/helpers.test.ts
+++ b/src/api/github/helpers.test.ts
@@ -1,9 +1,9 @@
-import { GH_ORGS } from '@/config';
+import { GETSENTRY_ORG } from '@/config';
 
 import * as helpers from './helpers';
 
 describe('helpers', function () {
-  const org = GH_ORGS.get('__tmp_org_placeholder__');
+  const org = GETSENTRY_ORG;
 
   it('addIssueToGlobalIssuesProject should return project item id from project', async function () {
     const octokit = {

--- a/src/api/github/isGetsentryRequiredCheck/index.ts
+++ b/src/api/github/isGetsentryRequiredCheck/index.ts
@@ -1,6 +1,10 @@
 import { EmitterWebhookEvent } from '@octokit/webhooks';
 
-import { GETSENTRY_ORG, GETSENTRY_REPO, REQUIRED_CHECK_NAME } from '@/config';
+import {
+  GETSENTRY_ORG,
+  GETSENTRY_REPO_SLUG,
+  REQUIRED_CHECK_NAME,
+} from '@/config';
 
 /**
  * Checks payload to see if:
@@ -12,7 +16,10 @@ export function isGetsentryRequiredCheck({
   payload,
 }: EmitterWebhookEvent<'check_run'>) {
   // Only on `getsentry` repo
-  if (payload.repository?.full_name !== `${GETSENTRY_ORG}/${GETSENTRY_REPO}`) {
+  if (
+    payload.repository?.full_name !==
+    `${GETSENTRY_ORG.slug}/${GETSENTRY_REPO_SLUG}`
+  ) {
     return false;
   }
 

--- a/src/brain/gocdSlackFeeds/deployFeed.test.ts
+++ b/src/brain/gocdSlackFeeds/deployFeed.test.ts
@@ -516,7 +516,7 @@ describe('DeployFeed', () => {
   });
 
   it('post message with commits in deploy link for getsentry', async () => {
-    const octokit = await getClient(ClientType.App, GETSENTRY_ORG);
+    const octokit = await getClient(ClientType.App, GETSENTRY_ORG.slug);
     octokit.repos.getContent.mockImplementation((args) => {
       if (args.owner != 'getsentry') {
         throw new Error(`Unexpected getContent() owner: ${args.owner}`);
@@ -647,7 +647,7 @@ describe('DeployFeed', () => {
   });
 
   it('handle error if get content fails', async () => {
-    const octokit = await getClient(ClientType.App, GETSENTRY_ORG);
+    const octokit = await getClient(ClientType.App, GETSENTRY_ORG.slug);
     octokit.repos.getContent.mockImplementation((args) => {
       throw new Error('Injected error');
     });

--- a/src/brain/gocdSlackFeeds/deployFeed.ts
+++ b/src/brain/gocdSlackFeeds/deployFeed.ts
@@ -7,9 +7,9 @@ import { bolt } from '@/api/slack';
 import * as slackblocks from '@/blocks/slackBlocks';
 import {
   GETSENTRY_ORG,
-  GETSENTRY_REPO,
+  GETSENTRY_REPO_SLUG,
   GOCD_ORIGIN,
-  SENTRY_REPO,
+  SENTRY_REPO_SLUG,
 } from '@/config';
 import { SlackMessage } from '@/config/slackMessage';
 import { GoCDModification, GoCDPipeline, GoCDResponse } from '@/types';
@@ -78,7 +78,7 @@ export class DeployFeed {
     prevDeploySHA: string,
     currentDeploySHA
   ) {
-    const octokit = await getClient(ClientType.App, GETSENTRY_ORG);
+    const octokit = await getClient(ClientType.App, GETSENTRY_ORG.slug);
     const responses = await Promise.all([
       octokit.repos.getContent({
         owner,
@@ -137,7 +137,7 @@ export class DeployFeed {
       latestSHA,
       modification.revision
     );
-    if (repo !== GETSENTRY_REPO) {
+    if (repo !== GETSENTRY_REPO_SLUG) {
       return this.basicCommitsInDeployBlock(compareURL);
     }
 
@@ -154,7 +154,7 @@ export class DeployFeed {
       if (shas[0] && shas[1] && shas[0] != shas[1]) {
         const sentryCompareURL = this.compareURL(
           org,
-          SENTRY_REPO,
+          SENTRY_REPO_SLUG,
           shas[0],
           shas[1]
         );

--- a/src/brain/issueLabelHandler/index.test.ts
+++ b/src/brain/issueLabelHandler/index.test.ts
@@ -5,7 +5,7 @@ import { createGitHubEvent } from '@test/utils/github';
 import { getLabelsTable, slackHandler } from '@/brain/issueNotifier';
 import { buildServer } from '@/buildServer';
 import {
-  GH_ORGS,
+  GETSENTRY_ORG,
   WAITING_FOR_COMMUNITY_LABEL,
   WAITING_FOR_PRODUCT_OWNER_LABEL,
   WAITING_FOR_SUPPORT_LABEL,
@@ -24,7 +24,7 @@ import { issueLabelHandler } from '.';
 describe('issueLabelHandler', function () {
   let fastify: Fastify;
   let octokit;
-  const org = GH_ORGS.get('__tmp_org_placeholder__');
+  const org = GETSENTRY_ORG;
   const errors = jest.fn();
   let say, respond, client, ack;
   let calculateSLOViolationRouteSpy, calculateSLOViolationTriageSpy;

--- a/src/brain/issueLabelHandler/route.ts
+++ b/src/brain/issueLabelHandler/route.ts
@@ -91,7 +91,7 @@ export async function markWaitingForSupport({
     owner,
     repo: repo,
     issue_number: issueNumber,
-    body: `Assigning to @${GETSENTRY_ORG}/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️`,
+    body: `Assigning to @${GETSENTRY_ORG.slug}/support for [routing](https://open.sentry.io/triage/#2-route) ⏲️`,
   });
 
   tx.finish();
@@ -104,13 +104,13 @@ async function routeIssue(octokit, productAreaLabelName) {
     );
     const ghTeamSlug = 'product-owners-' + slugizeProductArea(productArea);
     await octokit.teams.getByName({
-      org: GETSENTRY_ORG,
+      org: GETSENTRY_ORG.slug,
       team_slug: ghTeamSlug,
     }); // expected to throw if team doesn't exist
-    return `Routing to @${GETSENTRY_ORG}/${ghTeamSlug} for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️`;
+    return `Routing to @${GETSENTRY_ORG.slug}/${ghTeamSlug} for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️`;
   } catch (error) {
     Sentry.captureException(error);
-    return `Failed to route for ${productAreaLabelName}. Defaulting to @${GETSENTRY_ORG}/open-source for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️`;
+    return `Failed to route for ${productAreaLabelName}. Defaulting to @${GETSENTRY_ORG.slug}/open-source for [triage](https://develop.sentry.dev/processing-tickets/#3-triage) ⏲️`;
   }
 }
 

--- a/src/brain/pleaseDeployNotifier/actionViewUndeployedCommits.ts
+++ b/src/brain/pleaseDeployNotifier/actionViewUndeployedCommits.ts
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/node';
 import { ClientType } from '@/api/github/clientType';
 import {
   GETSENTRY_ORG,
-  GETSENTRY_REPO,
+  GETSENTRY_REPO_SLUG,
   GOCD_SENTRYIO_BE_PIPELINE_GROUP,
   GOCD_SENTRYIO_BE_PIPELINE_NAME,
 } from '@/config';
@@ -68,7 +68,7 @@ export async function actionViewUndeployedCommits({
     return;
   }
 
-  const octokit = await getClient(ClientType.App, GETSENTRY_ORG);
+  const octokit = await getClient(ClientType.App, GETSENTRY_ORG.slug);
   const base = firstMaterialSHA(lastDeploy);
   if (!base) {
     // Failed to get base sha
@@ -78,8 +78,8 @@ export async function actionViewUndeployedCommits({
 
   // Get all getsentry commits between `base` and `head`
   const { data } = await octokit.repos.compareCommits({
-    owner: GETSENTRY_ORG,
-    repo: GETSENTRY_REPO,
+    owner: GETSENTRY_ORG.slug,
+    repo: GETSENTRY_REPO_SLUG,
     base,
     head,
   });

--- a/src/brain/pleaseDeployNotifier/index.ts
+++ b/src/brain/pleaseDeployNotifier/index.ts
@@ -11,10 +11,10 @@ import { viewUndeployedCommits } from '@/blocks/viewUndeployedCommits';
 import {
   Color,
   GETSENTRY_ORG,
-  GETSENTRY_REPO,
+  GETSENTRY_REPO_SLUG,
   GOCD_SENTRYIO_BE_PIPELINE_NAME,
   GOCD_SENTRYIO_FE_PIPELINE_NAME,
-  SENTRY_REPO,
+  SENTRY_REPO_SLUG,
 } from '@/config';
 import { SlackMessage } from '@/config/slackMessage';
 import { getGoCDDeployForQueuedCommit } from '@/utils/db/getDeployForQueuedCommit';
@@ -130,13 +130,15 @@ async function handler({
 
   // Author of commit found
   const commit = checkRun.head_sha;
-  const commitLink = `https://github.com/${GETSENTRY_ORG}/${GETSENTRY_REPO}/commits/${commit}`;
+  const commitLink = `https://github.com/${GETSENTRY_ORG.slug}/${GETSENTRY_REPO_SLUG}/commits/${commit}`;
   const commitLinkText = `${commit.slice(0, 7)}`;
 
   // checkRun.head_sha will always be from getsentry, so if relevantCommit's
   // sha differs, it means that the relevantCommit is on the sentry repo
   const relevantCommitRepo =
-    relevantCommit.sha === checkRun.head_sha ? GETSENTRY_REPO : SENTRY_REPO;
+    relevantCommit.sha === checkRun.head_sha
+      ? GETSENTRY_REPO_SLUG
+      : SENTRY_REPO_SLUG;
   const { isFrontendOnly, isFullstack } = await getChangedStack(
     relevantCommit.sha,
     relevantCommitRepo

--- a/src/brain/projectsHandler/index.test.ts
+++ b/src/brain/projectsHandler/index.test.ts
@@ -1,7 +1,7 @@
 import { createGitHubEvent } from '@test/utils/github';
 
 import { buildServer } from '@/buildServer';
-import { GH_ORGS } from '@/config';
+import { GETSENTRY_ORG } from '@/config';
 import { Fastify } from '@/types';
 import { defaultErrorHandler, githubEvents } from '@api/github';
 import { ClientType } from '@api/github/clientType';
@@ -14,7 +14,7 @@ import { projectsHandler } from '.';
 describe('projectsHandler', function () {
   let fastify: Fastify;
   let octokit;
-  const org = GH_ORGS.get('__tmp_org_placeholder__');
+  const org = GETSENTRY_ORG;
   const errors = jest.fn();
 
   beforeAll(async function () {

--- a/src/brain/requiredChecks/getAnnotations.ts
+++ b/src/brain/requiredChecks/getAnnotations.ts
@@ -1,5 +1,5 @@
 import { ClientType } from '@/api/github/clientType';
-import { GETSENTRY_ORG, GETSENTRY_REPO } from '@/config';
+import { GETSENTRY_ORG, GETSENTRY_REPO_SLUG } from '@/config';
 import { Annotation } from '@/types';
 import { getClient } from '@api/github/getClient';
 
@@ -82,7 +82,7 @@ function filterAnnotations(annotations: Annotation[]) {
 export async function getAnnotations(
   jobs: string[][]
 ): Promise<Record<string, Annotation[]>> {
-  const octokit = await getClient(ClientType.App, GETSENTRY_ORG);
+  const octokit = await getClient(ClientType.App, GETSENTRY_ORG.slug);
 
   const annotations = await Promise.all(
     jobs
@@ -92,8 +92,8 @@ export async function getAnnotations(
       .filter(([, runId]) => runId)
       .map(async ([jobLink, checkRunId]) => {
         const { data: annotations } = await octokit.checks.listAnnotations({
-          owner: GETSENTRY_ORG,
-          repo: GETSENTRY_REPO,
+          owner: GETSENTRY_ORG.slug,
+          repo: GETSENTRY_REPO_SLUG,
           check_run_id: parseInt(checkRunId ?? '0', 10),
         });
 

--- a/src/brain/requiredChecks/getTextParts.ts
+++ b/src/brain/requiredChecks/getTextParts.ts
@@ -1,4 +1,4 @@
-import { GETSENTRY_ORG, GETSENTRY_REPO } from '@/config';
+import { GETSENTRY_ORG, GETSENTRY_REPO_SLUG } from '@/config';
 import { CheckRunForRequiredChecksText } from '@/types';
 
 /**
@@ -7,12 +7,12 @@ import { CheckRunForRequiredChecksText } from '@/types';
  * @param checkRun CheckRun from GitHub
  */
 export function getTextParts(checkRun: CheckRunForRequiredChecksText) {
-  const commitLink = `https://github.com/${GETSENTRY_ORG}/${GETSENTRY_REPO}/commits/${checkRun.head_sha}`;
+  const commitLink = `https://github.com/${GETSENTRY_ORG.slug}/${GETSENTRY_REPO_SLUG}/commits/${checkRun.head_sha}`;
   const commitLinkText = `${checkRun.head_sha.slice(0, 7)}`;
   const buildLink = `<${checkRun.html_url}|View Build>`;
 
   return [
-    `${GETSENTRY_REPO}@master`,
+    `${GETSENTRY_REPO_SLUG}@master`,
     `<${commitLink}|${commitLinkText}>`,
     `is failing`,
     `(${buildLink})`,

--- a/src/brain/typescript/getProgress.ts
+++ b/src/brain/typescript/getProgress.ts
@@ -1,5 +1,5 @@
 import { ClientType } from '@/api/github/clientType';
-import { GETSENTRY_ORG, SENTRY_REPO } from '@/config';
+import { GETSENTRY_ORG, SENTRY_REPO_SLUG } from '@/config';
 import { getClient } from '@api/github/getClient';
 
 /**
@@ -8,7 +8,7 @@ import { getClient } from '@api/github/getClient';
 const IGNORED_PATHS = [/views\/events.*/, /views\/dashboards.*/];
 
 export default async function getProgress({
-  repo = SENTRY_REPO,
+  repo = SENTRY_REPO_SLUG,
   basePath = 'static',
   appDir = 'app',
   date,
@@ -18,7 +18,7 @@ export default async function getProgress({
   appDir?: string;
   date?: string;
 }) {
-  const octokit = await getClient(ClientType.App, GETSENTRY_ORG);
+  const octokit = await getClient(ClientType.App, GETSENTRY_ORG.slug);
 
   const getContentsParams: {
     owner: string;
@@ -26,14 +26,14 @@ export default async function getProgress({
     path: string;
     ref?: string;
   } = {
-    owner: GETSENTRY_ORG,
+    owner: GETSENTRY_ORG.slug,
     repo,
     path: basePath,
   };
 
   if (date) {
     const commits = await octokit.repos.listCommits({
-      owner: GETSENTRY_ORG,
+      owner: GETSENTRY_ORG.slug,
       repo,
       until: date,
       per_page: 1,
@@ -57,7 +57,7 @@ export default async function getProgress({
   }
 
   const tree = await octokit.git.getTree({
-    owner: GETSENTRY_ORG,
+    owner: GETSENTRY_ORG.slug,
     repo,
     tree_sha: app.sha,
     recursive: '1',

--- a/src/brain/typescript/index.ts
+++ b/src/brain/typescript/index.ts
@@ -1,4 +1,4 @@
-import { GETSENTRY_REPO } from '@/config';
+import { GETSENTRY_REPO_SLUG } from '@/config';
 import { bolt } from '@api/slack';
 import { wrapHandler } from '@utils/wrapHandler';
 
@@ -37,12 +37,12 @@ export function typescript() {
         }),
         getProgress({}),
         getProgress({
-          repo: GETSENTRY_REPO,
+          repo: GETSENTRY_REPO_SLUG,
           basePath: 'static/getsentry',
           appDir: 'gsApp',
         }),
         getProgress({
-          repo: GETSENTRY_REPO,
+          repo: GETSENTRY_REPO_SLUG,
           basePath: 'static/getsentry',
           appDir: 'gsAdmin',
         }),

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -171,6 +171,19 @@ export const GH_USER_TOKEN = process.env.GH_USER_TOKEN || '';
 /**
  * Load GitHubOrgs. We [want to] support processing events coming at us from
  * multiple GitHub orgs and this is how we [plan to] encapsulate it all.
+ *
+ * Some of the logic in eng-pipes is meant *only* for the `getsentry` org
+ * (things related to CI/CD, mostly), so we want to have a global reference to
+ * its GitHubOrg that we can import and use around the codebase. We're fine
+ * with failing somewhat opaquely at runtime if it's not configured (at least,
+ * that's the status quo). The default org below is intended to accomplish
+ * that. We're also fine with trusting that there are no webhook routes
+ * pointing at these parts of the codebase by which events from other GitHub
+ * orgs could leak into `getsentry`. Eep.
+ *
+ * Other logic (mostly related to automations for issues and discussions)
+ * operates on whatever org--possibly `getsentry`--we find in the payloads from
+ * GitHub. For those we use the GH_ORGS registry.
  */
 export const GH_ORGS: GitHubOrgs = loadGitHubOrgsFromEnvironment(process.env);
 export const GETSENTRY_ORG =

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,3 +1,5 @@
+import { GitHubOrg } from '../api/github/org';
+
 import {
   GitHubOrgs,
   loadGitHubOrgsFromEnvironment,
@@ -12,9 +14,8 @@ export const DEFAULT_PORT = 3000;
 
 export const DAY_IN_MS = 1000 * 60 * 60 * 24;
 
-export const GETSENTRY_ORG = process.env.GETSENTRY_ORG || 'getsentry';
-export const SENTRY_REPO = process.env.SENTRY_REPO || 'sentry';
-export const GETSENTRY_REPO = process.env.GETSENTRY_REPO || 'getsentry';
+export const SENTRY_REPO_SLUG = process.env.SENTRY_REPO || 'sentry';
+export const GETSENTRY_REPO_SLUG = process.env.GETSENTRY_REPO || 'getsentry';
 export const GETSENTRY_BOT_ID = 10587625;
 export const GOCD_SENTRYIO_FE_PIPELINE_NAME =
   process.env.GOCD_SENTRYIO_FE_PIPELINE_NAME || 'getsentry-frontend';
@@ -168,10 +169,27 @@ export const SENTRY_REPOS: Set<string> = new Set([
 export const GH_USER_TOKEN = process.env.GH_USER_TOKEN || '';
 
 /**
- * Load GitHubOrgs. We support processing events coming at us from multiple
- * GitHub orgs and this is how we encapsulate it all.
+ * Load GitHubOrgs. We [want to] support processing events coming at us from
+ * multiple GitHub orgs and this is how we [plan to] encapsulate it all.
  */
 export const GH_ORGS: GitHubOrgs = loadGitHubOrgsFromEnvironment(process.env);
+export const GETSENTRY_ORG =
+  process.env.GH_APP_IDENTIFIER && process.env.GH_APP_SECRET_KEY
+    ? GH_ORGS.get(process.env.GETSENTRY_ORG || 'getsentry')
+    : new GitHubOrg({
+        num: -1,
+        slug: '☢️  no getsentry org configured ☢️',
+        appAuth: {
+          appId: -1,
+          privateKey: '',
+        },
+        project: {
+          node_id: '',
+          product_area_field_id: '',
+          status_field_id: '',
+          response_due_date_field_id: '',
+        },
+      });
 
 /**
  * Business Hours by Office

--- a/src/config/loadGitHubOrgsFromEnvironment.test.ts
+++ b/src/config/loadGitHubOrgsFromEnvironment.test.ts
@@ -5,9 +5,9 @@ describe('loadGitHubOrgsFromEnvironment ', function () {
     const expected = {
       orgs: new Map([
         [
-          '__tmp_org_placeholder__',
+          'getsentry',
           {
-            slug: '__tmp_org_placeholder__',
+            slug: 'getsentry',
             appAuth: {
               appId: 42,
               privateKey: 'cheese',
@@ -41,7 +41,7 @@ describe('loadGitHubOrgsFromEnvironment ', function () {
 
       GH_APP_IDENTIFIER: '42',
       GH_APP_SECRET_KEY: 'cheese',
-    }).get('__tmp_org_placeholder__').appAuth.appId;
+    }).get('getsentry').appAuth.appId;
     expect(actual).toEqual(42);
   });
 
@@ -57,9 +57,9 @@ describe('loadGitHubOrgsFromEnvironment ', function () {
     const expected = {
       orgs: new Map([
         [
-          '__tmp_org_placeholder__',
+          'getsentry',
           {
-            slug: '__tmp_org_placeholder__',
+            slug: 'getsentry',
             appAuth: {
               appId: 42,
               privateKey: 'cheese',

--- a/src/config/loadGitHubOrgsFromEnvironment.ts
+++ b/src/config/loadGitHubOrgsFromEnvironment.ts
@@ -48,7 +48,7 @@ export class GitHubOrgs {
 
   getForPayload(gitHubEventPayload) {
     // Soon we aim to support multiple orgs!
-    const orgSlug = '__tmp_org_placeholder__'; // payload?.organization?.login;
+    const orgSlug = process.env.GETSENTRY_ORG || 'getsentry'; // ☢️
     if (!orgSlug) {
       throw new Error(
         `Could not find an org slug in ${JSON.stringify(gitHubEventPayload)}.`
@@ -71,7 +71,7 @@ export function loadGitHubOrgsFromEnvironment(env) {
     // (once we've made a full pass through process.env).
 
     config = configs.getOrCreate(1);
-    config.slug = '__tmp_org_placeholder__';
+    config.slug = process.env.GETSENTRY_ORG || 'getsentry'; // ☢️
     config.appAuth = {
       appId: Number(env.GH_APP_IDENTIFIER),
       privateKey: env.GH_APP_SECRET_KEY.replace(/\\n/g, '\n'),

--- a/src/utils/db/getFailureMessages.ts
+++ b/src/utils/db/getFailureMessages.ts
@@ -1,5 +1,5 @@
 import { ClientType } from '@/api/github/clientType';
-import { GETSENTRY_ORG, GETSENTRY_REPO } from '@/config';
+import { GETSENTRY_ORG, GETSENTRY_REPO_SLUG } from '@/config';
 import { BuildStatus } from '@/config';
 import { SlackMessage } from '@/config/slackMessage';
 import { getClient } from '@api/github/getClient';
@@ -40,7 +40,7 @@ export async function getFailureMessages(
 
   const onlyOlderFailedMessages = await Promise.all(
     messages.map(async (message) => {
-      const octokit = await getClient(ClientType.App, GETSENTRY_ORG);
+      const octokit = await getClient(ClientType.App, GETSENTRY_ORG.slug);
       // We *ONLY* want failed builds before `headSha` - when calling GH's
       // `compareCommits`, we use `headSha` as the head commit, so we only want
       // the messages for failed builds that came before `headSha`.
@@ -48,8 +48,8 @@ export async function getFailureMessages(
       // This happens when say build A starts, and then after build B starts
       // and fails before A completes. In this case, build A should not mark B as being fixed
       const { data } = await octokit.repos.compareCommits({
-        owner: GETSENTRY_ORG,
-        repo: GETSENTRY_REPO,
+        owner: GETSENTRY_ORG.slug,
+        repo: GETSENTRY_REPO_SLUG,
         base: message.refId,
         head: headSha,
       });

--- a/src/webhooks/pubsub/index.ts
+++ b/src/webhooks/pubsub/index.ts
@@ -3,7 +3,7 @@ import { FastifyReply, FastifyRequest } from 'fastify';
 import moment from 'moment-timezone';
 
 import { ClientType } from '@/api/github/clientType';
-import { GETSENTRY_ORG, GH_ORGS } from '@/config';
+import { GETSENTRY_ORG } from '@/config';
 import { notifyProductOwnersForUntriagedIssues } from '@/webhooks/pubsub/slackNotifications';
 import { getClient } from '@api/github/getClient';
 
@@ -58,8 +58,8 @@ export const pubSubHandler = async (
   // call security warning.
   // https://codeql.github.com/codeql-query-help/javascript/js-unvalidated-dynamic-method-call/
   if (typeof func === 'function') {
-    org = GH_ORGS.get('__tmp_org_placeholder__');
-    octokit = await getClient(ClientType.App, GETSENTRY_ORG);
+    org = GETSENTRY_ORG;
+    octokit = await getClient(ClientType.App, GETSENTRY_ORG.slug);
     now = moment().utc();
   } else {
     func = async () => {}; // no-op

--- a/src/webhooks/pubsub/slackNotifications.test.ts
+++ b/src/webhooks/pubsub/slackNotifications.test.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/node';
 import moment from 'moment-timezone';
 
 import { getLabelsTable } from '@/brain/issueNotifier';
-import { GH_ORGS } from '@/config';
+import { GETSENTRY_ORG } from '@/config';
 import * as helpers from '@api/github/helpers';
 import { bolt } from '@api/slack';
 import { db } from '@utils/db';
@@ -13,7 +13,7 @@ import {
 } from './slackNotifications';
 
 describe('Triage Notification Tests', function () {
-  const org = GH_ORGS.get('__tmp_org_placeholder__');
+  const org = GETSENTRY_ORG;
 
   beforeAll(async function () {
     await db.migrate.latest();

--- a/src/webhooks/pubsub/slackNotifications.ts
+++ b/src/webhooks/pubsub/slackNotifications.ts
@@ -407,7 +407,7 @@ export const notifyProductOwnersForUntriagedIssues = async (
     repo: string
   ): Promise<IssueSLOInfo[]> => {
     const untriagedIssues = await octokit.paginate(octokit.issues.listForRepo, {
-      owner: GETSENTRY_ORG,
+      owner: GETSENTRY_ORG.slug,
       repo,
       state: 'open',
       labels: WAITING_FOR_PRODUCT_OWNER_LABEL,

--- a/src/webhooks/pubsub/stalebot.test.ts
+++ b/src/webhooks/pubsub/stalebot.test.ts
@@ -1,7 +1,6 @@
 import moment from 'moment-timezone';
 
-import { STALE_LABEL } from '@/config';
-import { GH_ORGS } from '@/config';
+import { GETSENTRY_ORG, STALE_LABEL } from '@/config';
 import { ClientType } from '@api/github/clientType';
 import { getClient } from '@api/github/getClient';
 
@@ -16,7 +15,7 @@ jest.mock('@/config', () => {
 });
 
 describe('Stalebot Tests', function () {
-  const org = GH_ORGS.get('__tmp_org_placeholder__');
+  const org = GETSENTRY_ORG;
 
   const issueInfo = {
     labels: [],

--- a/src/webhooks/pubsub/stalebot.ts
+++ b/src/webhooks/pubsub/stalebot.ts
@@ -29,14 +29,14 @@ const staleStatusUpdater = async (
         if (now.diff(issue.updated_at, 'days') >= DAYS_BEFORE_CLOSE) {
           // Interestingly enough, this api works for both issues and pull requests
           return octokit.issues.update({
-            owner: GETSENTRY_ORG,
+            owner: GETSENTRY_ORG.slug,
             repo: repo,
             issue_number: issue.number,
             state: 'closed',
           });
         } else if (now.diff(issue.updated_at, 'days') < DAYS_BEFORE_CLOSE) {
           return octokit.issues.removeLabel({
-            owner: GETSENTRY_ORG,
+            owner: GETSENTRY_ORG.slug,
             repo: repo,
             issue_number: issue.number,
             name: STALE_LABEL,
@@ -47,13 +47,13 @@ const staleStatusUpdater = async (
         if (now.diff(issue.updated_at, 'days') >= DAYS_BEFORE_STALE) {
           return Promise.all([
             octokit.issues.addLabels({
-              owner: GETSENTRY_ORG,
+              owner: GETSENTRY_ORG.slug,
               repo: repo,
               issue_number: issue.number,
               labels: [STALE_LABEL],
             }),
             octokit.issues.createComment({
-              owner: GETSENTRY_ORG,
+              owner: GETSENTRY_ORG.slug,
               repo: repo,
               issue_number: issue.number,
               body: `This ${
@@ -82,7 +82,7 @@ export const triggerStaleBot = async (
   // Get all open issues and pull requests that are Waiting for Community
   SENTRY_REPOS.forEach(async (repo: string) => {
     const issues = await octokit.paginate(octokit.issues.listForRepo, {
-      owner: GETSENTRY_ORG,
+      owner: GETSENTRY_ORG.slug,
       repo,
       state: 'open',
       labels: WAITING_FOR_COMMUNITY_LABEL,


### PR DESCRIPTION
Part of #482, after #534.

Where I'm going with this is to have both `slug` and `octokit` live on a single `GitHubOrg` object, so that when we make calls we can use both together in calls that look like this:

```ts
await org.api.issues.addLabels({                                                                          
  owner: org.slug,
  repo: repo,
  issue_number: issueNumber,
  labels: [WAITING_FOR_PRODUCT_OWNER_LABEL],
});
```

Or this:

```ts
const { data } = await GETSENTRY_ORG.api.repos.compareCommits({
  owner: GETSENTRY_ORG.slug,
  repo: GETSENTRY_REPO_SLUG,
  base: message.refId,
  head: headSha,
});
```

That won't make crossed wires impossible, but I think it reduces the risk to an acceptable level.