### PR TITLE
Move sendQuery to GitHubOrg.sendGraphQuery

### DIFF
--- a/src/api/github/helpers.test.ts
+++ b/src/api/github/helpers.test.ts
@@ -6,7 +6,7 @@ describe('helpers', function () {
   const org = GETSENTRY_ORG;
 
   it('addIssueToGlobalIssuesProject should return project item id from project', async function () {
-    const octokit = {
+    org.api = {
       graphql: jest
         .fn()
         .mockReturnValue({ addProjectV2ItemById: { item: { id: '12345' } } }),
@@ -16,14 +16,13 @@ describe('helpers', function () {
         org,
         'issueNodeId',
         'test-repo',
-        1,
-        octokit
+        1
       )
     ).toEqual('12345');
   });
 
   it('getAllProjectFieldNodeIds should return timestamp from project', async function () {
-    const octokit = {
+    org.api = {
       graphql: jest.fn().mockReturnValue({
         node: {
           options: [
@@ -35,7 +34,7 @@ describe('helpers', function () {
       }),
     };
     expect(
-      await helpers.getAllProjectFieldNodeIds('projectFieldId', octokit)
+      await helpers.getAllProjectFieldNodeIds(org, 'projectFieldId')
     ).toEqual({
       'Waiting for: Product Owner': 1,
       'Waiting for: Support': 2,
@@ -44,22 +43,18 @@ describe('helpers', function () {
   });
 
   it('getKeyValueFromProjectField should return timestamp from project', async function () {
-    const octokit = {
+    org.api = {
       graphql: jest.fn().mockReturnValue({
         node: { fieldValueByName: { name: 'Product Area: Test' } },
       }),
     };
     expect(
-      await helpers.getKeyValueFromProjectField(
-        'issueNodeId',
-        'fieldName',
-        octokit
-      )
+      await helpers.getKeyValueFromProjectField(org, 'issueNodeId', 'fieldName')
     ).toEqual('Product Area: Test');
   });
 
   it('getIssueDueDateFromProject should return timestamp from project', async function () {
-    const octokit = {
+    org.api = {
       graphql: jest.fn().mockReturnValue({
         node: {
           fieldValues: {
@@ -76,18 +71,18 @@ describe('helpers', function () {
       }),
     };
     expect(
-      await helpers.getIssueDueDateFromProject(org, 'issueNodeId', octokit)
+      await helpers.getIssueDueDateFromProject(org, 'issueNodeId')
     ).toEqual('2023-06-23T18:00:00.000Z');
   });
 
-  it('getIssueDetailsFromNodeId should return timestamp from project', async function () {
-    const octokit = {
+  it('getIssueDetailsFromNodeId should return issue details', async function () {
+    org.api = {
       graphql: jest.fn().mockReturnValue({
         node: { number: 1, repository: { name: 'test-repo' } },
       }),
     };
-    expect(
-      await helpers.getIssueDetailsFromNodeId('issueNodeId', octokit)
-    ).toEqual({ number: 1, repo: 'test-repo' });
+    expect(await helpers.getIssueDetailsFromNodeId(org, 'issueNodeId')).toEqual(
+      { number: 1, repo: 'test-repo' }
+    );
   });
 });

--- a/src/api/github/org.ts
+++ b/src/api/github/org.ts
@@ -1,5 +1,6 @@
 import { createAppAuth } from '@octokit/auth-app';
 import { Octokit } from '@octokit/rest';
+import * as Sentry from '@sentry/node';
 
 import {
   AppAuthStrategyOptions,
@@ -47,5 +48,16 @@ export class GitHubOrg {
         auth: this.appAuth,
       });
     }
+  }
+
+  async sendGraphQuery(query: string, data: object) {
+    let response: any;
+    try {
+      response = await this.api.graphql(query);
+    } catch (err) {
+      Sentry.setContext('data', data);
+      Sentry.captureException(err);
+    }
+    return response;
   }
 }

--- a/src/brain/issueLabelHandler/followups.ts
+++ b/src/brain/issueLabelHandler/followups.ts
@@ -97,16 +97,14 @@ export async function updateCommunityFollowups({
     org,
     payload.issue.node_id,
     repo,
-    issueNumber,
-    octokit
+    issueNumber
   );
 
   await modifyProjectIssueField(
     org,
     itemId,
     WAITING_FOR_PRODUCT_OWNER_LABEL,
-    org.project.status_field_id,
-    octokit
+    org.project.status_field_id
   );
 
   tx.finish();
@@ -158,16 +156,14 @@ export async function ensureOneWaitingForLabel({
     org,
     payload.issue.node_id,
     repo,
-    issueNumber,
-    octokit
+    issueNumber
   );
 
   await modifyProjectIssueField(
     org,
     itemId,
     labelName,
-    org.project.status_field_id,
-    octokit
+    org.project.status_field_id
   );
 
   let timeToRespondBy;
@@ -189,8 +185,7 @@ export async function ensureOneWaitingForLabel({
     org,
     itemId,
     timeToRespondBy,
-    org.project.response_due_date_field_id,
-    octokit
+    org.project.response_due_date_field_id
   );
 
   tx.finish();

--- a/src/brain/issueLabelHandler/index.test.ts
+++ b/src/brain/issueLabelHandler/index.test.ts
@@ -551,15 +551,13 @@ describe('issueLabelHandler', function () {
         org,
         'itemId',
         WAITING_FOR_SUPPORT_LABEL,
-        org.project.status_field_id,
-        octokit
+        org.project.status_field_id
       );
       expect(modifyDueByDateSpy).toHaveBeenLastCalledWith(
         org,
         'itemId',
         '2022-12-20T00:00:00.000Z',
-        org.project.response_due_date_field_id,
-        octokit
+        org.project.response_due_date_field_id
       );
     });
 
@@ -574,15 +572,13 @@ describe('issueLabelHandler', function () {
         org,
         'itemId',
         WAITING_FOR_COMMUNITY_LABEL,
-        org.project.status_field_id,
-        octokit
+        org.project.status_field_id
       );
       expect(modifyDueByDateSpy).toHaveBeenLastCalledWith(
         org,
         'itemId',
         '',
-        org.project.response_due_date_field_id,
-        octokit
+        org.project.response_due_date_field_id
       );
     });
 
@@ -597,15 +593,13 @@ describe('issueLabelHandler', function () {
         org,
         'itemId',
         WAITING_FOR_COMMUNITY_LABEL,
-        org.project.status_field_id,
-        octokit
+        org.project.status_field_id
       );
       expect(modifyDueByDateSpy).toHaveBeenLastCalledWith(
         org,
         'itemId',
         '',
-        org.project.response_due_date_field_id,
-        octokit
+        org.project.response_due_date_field_id
       );
     });
 
@@ -627,15 +621,13 @@ describe('issueLabelHandler', function () {
         org,
         'itemId',
         WAITING_FOR_PRODUCT_OWNER_LABEL,
-        org.project.status_field_id,
-        octokit
+        org.project.status_field_id
       );
       expect(modifyDueByDateSpy).toHaveBeenLastCalledWith(
         org,
         'itemId',
         '2022-12-21T00:00:00.000Z',
-        org.project.response_due_date_field_id,
-        octokit
+        org.project.response_due_date_field_id
       );
     });
 
@@ -652,15 +644,13 @@ describe('issueLabelHandler', function () {
         org,
         'itemId',
         WAITING_FOR_PRODUCT_OWNER_LABEL,
-        org.project.status_field_id,
-        octokit
+        org.project.status_field_id
       );
       expect(modifyDueByDateSpy).toHaveBeenLastCalledWith(
         org,
         'itemId',
         '2022-12-21T00:00:00.000Z',
-        org.project.response_due_date_field_id,
-        octokit
+        org.project.response_due_date_field_id
       );
     });
 
@@ -674,15 +664,13 @@ describe('issueLabelHandler', function () {
         org,
         'itemId',
         WAITING_FOR_PRODUCT_OWNER_LABEL,
-        org.project.status_field_id,
-        octokit
+        org.project.status_field_id
       );
       expect(modifyDueByDateSpy).toHaveBeenLastCalledWith(
         org,
         'itemId',
         '2023-06-20T00:00:00.000Z',
-        org.project.response_due_date_field_id,
-        octokit
+        org.project.response_due_date_field_id
       );
       // Restore old mock return value used throughout the file
       calculateSLOViolationTriageSpy.mockReturnValue(
@@ -700,15 +688,13 @@ describe('issueLabelHandler', function () {
         org,
         'itemId',
         WAITING_FOR_SUPPORT_LABEL,
-        org.project.status_field_id,
-        octokit
+        org.project.status_field_id
       );
       expect(modifyDueByDateSpy).toHaveBeenLastCalledWith(
         org,
         'itemId',
         '2023-06-20T00:00:00.000Z',
-        org.project.response_due_date_field_id,
-        octokit
+        org.project.response_due_date_field_id
       );
       // Restore old mock return value used throughout the file
       calculateSLOViolationTriageSpy.mockReturnValue(
@@ -727,15 +713,13 @@ describe('issueLabelHandler', function () {
         org,
         'itemId',
         WAITING_FOR_PRODUCT_OWNER_LABEL,
-        org.project.status_field_id,
-        octokit
+        org.project.status_field_id
       );
       expect(modifyDueByDateSpy).toHaveBeenLastCalledWith(
         org,
         'itemId',
         '2022-12-21T00:00:00.000Z',
-        org.project.response_due_date_field_id,
-        octokit
+        org.project.response_due_date_field_id
       );
     });
   });

--- a/src/brain/issueLabelHandler/route.ts
+++ b/src/brain/issueLabelHandler/route.ts
@@ -196,8 +196,7 @@ export async function markNotWaitingForSupport({
     org,
     payload.issue.node_id,
     payload.repository.name,
-    payload.issue.number,
-    octokit
+    payload.issue.number
   );
   const productArea = productAreaLabelName?.substr(
     PRODUCT_AREA_LABEL_PREFIX.length
@@ -206,8 +205,7 @@ export async function markNotWaitingForSupport({
     org,
     itemId,
     productArea,
-    org.project.product_area_field_id,
-    octokit
+    org.project.product_area_field_id
   );
 
   tx.finish();

--- a/src/brain/issueLabelHandler/triage.ts
+++ b/src/brain/issueLabelHandler/triage.ts
@@ -74,16 +74,14 @@ export async function markWaitingForProductOwner({
     org,
     payload.issue.node_id,
     repo,
-    issueNumber,
-    octokit
+    issueNumber
   );
 
   await modifyProjectIssueField(
     org,
     itemId,
     WAITING_FOR_PRODUCT_OWNER_LABEL,
-    org.project.status_field_id,
-    octokit
+    org.project.status_field_id
   );
 
   tx.finish();

--- a/src/brain/projectsHandler/project.ts
+++ b/src/brain/projectsHandler/project.ts
@@ -68,9 +68,9 @@ export async function syncLabelsWithProjectField({
   const octokit = await getClient(ClientType.App, owner);
   const fieldName = getFieldName(payload, org);
   const fieldValue = await getKeyValueFromProjectField(
+    org,
     payload.projects_v2_item.node_id,
-    fieldName,
-    octokit
+    fieldName
   );
 
   // Single select field value has been unset, so don't do anything
@@ -79,8 +79,8 @@ export async function syncLabelsWithProjectField({
   }
 
   const issueInfo = await getIssueDetailsFromNodeId(
-    payload.projects_v2_item.content_node_id,
-    octokit
+    org,
+    payload.projects_v2_item.content_node_id
   );
 
   await octokit.issues.addLabels({

--- a/src/webhooks/pubsub/slackNotifications.ts
+++ b/src/webhooks/pubsub/slackNotifications.ts
@@ -136,14 +136,9 @@ export const getTriageSLOTimestamp = async (
     org,
     issueNodeId,
     repo,
-    issueNumber,
-    octokit
+    issueNumber
   );
-  const dueByDate = await getIssueDueDateFromProject(
-    org,
-    issueNodeIdInProject,
-    octokit
-  );
+  const dueByDate = await getIssueDueDateFromProject(org, issueNodeIdInProject);
   if (dueByDate == null || !moment(dueByDate).isValid()) {
     // Throw an exception if we have trouble parsing the timestamp
     Sentry.captureException(


### PR DESCRIPTION
Part of #482, after #537.

I want to encapsulate the helpers under the GitHubOrg class for cleanliness and assurance that we're not crossing org wires. This is the root helper function and so is a good candidate to go first.