### PR TITLE
Switch getClient(App) cases to use org.api instead

### DIFF
--- a/src/api/github/getChangedStack.ts
+++ b/src/api/github/getChangedStack.ts
@@ -1,8 +1,6 @@
 import * as Sentry from '@sentry/node';
 
-import { ClientType } from '@/api/github/clientType';
 import { GETSENTRY_ORG } from '@/config';
-import { getClient } from '@api/github/getClient';
 
 const FRONTEND_CHANGE_CHECK_NAME = 'only frontend changes';
 const BACKEND_CHANGE_CHECK_NAME = 'only backend changes';
@@ -13,14 +11,15 @@ const BACKEND_CHANGE_CHECK_NAME = 'only backend changes';
  */
 export async function getChangedStack(ref: string, repo: string) {
   try {
-    const octokit = await getClient(ClientType.App, GETSENTRY_ORG.slug);
-
-    const check_runs = await octokit.paginate(octokit.checks.listForRef, {
-      owner: GETSENTRY_ORG.slug,
-      repo,
-      ref,
-      per_page: 100,
-    });
+    const check_runs = await GETSENTRY_ORG.api.paginate(
+      GETSENTRY_ORG.api.checks.listForRef,
+      {
+        owner: GETSENTRY_ORG.slug,
+        repo,
+        ref,
+        per_page: 100,
+      }
+    );
 
     const checkRuns = check_runs.filter(
       ({ name, conclusion }) =>

--- a/src/api/github/getRelevantCommit.ts
+++ b/src/api/github/getRelevantCommit.ts
@@ -1,8 +1,6 @@
 import * as Sentry from '@sentry/node';
 
-import { ClientType } from '@/api/github/clientType';
 import { GETSENTRY_ORG, GETSENTRY_REPO_SLUG, SENTRY_REPO_SLUG } from '@/config';
-import { getClient } from '@api/github/getClient';
 
 /**
  * Attempts to find the relevant commit for a SHA
@@ -13,10 +11,8 @@ import { getClient } from '@api/github/getClient';
  */
 export async function getRelevantCommit(ref: string) {
   try {
-    const octokit = await getClient(ClientType.App, GETSENTRY_ORG.slug);
-
     // Attempt to get the getsentry commit first
-    const { data: commit } = await octokit.repos.getCommit({
+    const { data: commit } = await GETSENTRY_ORG.api.repos.getCommit({
       owner: GETSENTRY_ORG.slug,
       repo: GETSENTRY_REPO_SLUG,
       ref,
@@ -38,7 +34,7 @@ export async function getRelevantCommit(ref: string) {
     // a merge in the sentry repo
     //
     // In this case, fetch the sentry commit to display
-    const { data } = await octokit.repos.getCommit({
+    const { data } = await GETSENTRY_ORG.api.repos.getCommit({
       owner: GETSENTRY_ORG.slug,
       repo: SENTRY_REPO_SLUG,
       ref: sentryCommitSha,

--- a/src/api/github/org.ts
+++ b/src/api/github/org.ts
@@ -22,7 +22,8 @@ export class GitHubOrg {
     this.project = config.project;
 
     // Call bindAPI ASAP. We can't call it here because constructors can't be
-    // async.
+    // async. Note that in testing this ends up being mocked as if it were
+    // bound, even though (afaict) we generally don't call bindAPI in test.
     this.api = new OctokitWithRetries({
       authStrategy: createAppAuth,
       auth: this.appAuth, // unbound, good enough for now

--- a/src/brain/githubMetrics/index.test.ts
+++ b/src/brain/githubMetrics/index.test.ts
@@ -22,9 +22,7 @@ import { Fastify } from '@types';
 import { createGitHubEvent } from '@test/utils/github';
 
 import { buildServer } from '@/buildServer';
-import { DRY_RUN } from '@/config';
-import { ClientType } from '@api/github/clientType';
-import { getClient } from '@api/github/getClient';
+import { DRY_RUN, GETSENTRY_ORG } from '@/config';
 import { db } from '@utils/db';
 import * as dbFunctions from '@utils/metrics';
 
@@ -48,7 +46,7 @@ const SCHEMA = Object.entries(dbFunctions.TARGETS.oss.schema).map(
 
 describe('github webhook', function () {
   let fastify: Fastify;
-  let octokit;
+  const org = GETSENTRY_ORG;
 
   beforeAll(async () => {
     await db.migrate.latest();
@@ -66,7 +64,6 @@ describe('github webhook', function () {
 
   beforeEach(async function () {
     fastify = await buildServer(false);
-    octokit = await getClient(ClientType.App, 'getsentry');
     metrics();
   });
 
@@ -74,7 +71,7 @@ describe('github webhook', function () {
     fastify.close();
     (dbFunctions.insertOss as jest.Mock).mockClear();
     (dbFunctions.insert as jest.Mock).mockClear();
-    octokit.orgs.checkMembershipForUser.mockClear();
+    org.api.orgs.checkMembershipForUser.mockClear();
     mockDataset.mockClear();
     mockTable.mockClear();
     mockInsert.mockClear();

--- a/src/brain/gocdSlackFeeds/deployFeed.test.ts
+++ b/src/brain/gocdSlackFeeds/deployFeed.test.ts
@@ -6,8 +6,6 @@ import * as slackblocks from '@/blocks/slackBlocks';
 import { Color, GETSENTRY_ORG } from '@/config';
 import { SlackMessage } from '@/config/slackMessage';
 import { GoCDPipeline } from '@/types';
-import { ClientType } from '@api/github/clientType';
-import { getClient } from '@api/github/getClient';
 import { bolt } from '@api/slack';
 import { db } from '@utils/db';
 
@@ -16,6 +14,8 @@ import { DeployFeed } from './deployFeed';
 jest.mock('@api/getUser');
 
 describe('DeployFeed', () => {
+  const org = GETSENTRY_ORG;
+
   beforeAll(async function () {
     await db.migrate.latest();
   });
@@ -516,8 +516,7 @@ describe('DeployFeed', () => {
   });
 
   it('post message with commits in deploy link for getsentry', async () => {
-    const octokit = await getClient(ClientType.App, GETSENTRY_ORG.slug);
-    octokit.repos.getContent.mockImplementation((args) => {
+    org.api.repos.getContent.mockImplementation((args) => {
       if (args.owner != 'getsentry') {
         throw new Error(`Unexpected getContent() owner: ${args.owner}`);
       }
@@ -643,12 +642,11 @@ describe('DeployFeed', () => {
     const slackMessages = await db('slack_messages').select('*');
     expect(slackMessages).toHaveLength(1);
 
-    expect(octokit.repos.getContent).toBeCalledTimes(2);
+    expect(org.api.repos.getContent).toBeCalledTimes(2);
   });
 
   it('handle error if get content fails', async () => {
-    const octokit = await getClient(ClientType.App, GETSENTRY_ORG.slug);
-    octokit.repos.getContent.mockImplementation((args) => {
+    org.api.repos.getContent.mockImplementation((args) => {
       throw new Error('Injected error');
     });
 

--- a/src/brain/gocdSlackFeeds/deployFeed.ts
+++ b/src/brain/gocdSlackFeeds/deployFeed.ts
@@ -2,12 +2,11 @@ import * as Sentry from '@sentry/node';
 import { KnownBlock, MessageAttachment, MrkdwnElement } from '@slack/types';
 
 import { getUser } from '@/api/getUser';
-import { ClientType } from '@/api/github/clientType';
 import { bolt } from '@/api/slack';
 import * as slackblocks from '@/blocks/slackBlocks';
 import {
-  GETSENTRY_ORG,
   GETSENTRY_REPO_SLUG,
+  GH_ORGS,
   GOCD_ORIGIN,
   SENTRY_REPO_SLUG,
 } from '@/config';
@@ -17,7 +16,6 @@ import { getLastGetSentryGoCDDeploy } from '@/utils/db/getLatestDeploy';
 import { getSlackMessage } from '@/utils/db/getSlackMessage';
 import { saveSlackMessage } from '@/utils/db/saveSlackMessage';
 import { firstMaterialSHA, getProgressColor } from '@/utils/gocdHelpers';
-import { getClient } from '@api/github/getClient';
 
 export class DeployFeed {
   private feedName: string;
@@ -61,8 +59,8 @@ export class DeployFeed {
     const result = url.match(reg);
     if (result) {
       return {
-        org: result[1],
-        repo: result[2],
+        orgSlug: result[1],
+        repoSlug: result[2],
       };
     }
     return null;
@@ -73,22 +71,22 @@ export class DeployFeed {
   }
 
   async getSentryRevisions(
-    owner: string,
-    repo: string,
+    orgSlug: string,
+    repoSlug: string,
     prevDeploySHA: string,
     currentDeploySHA
   ) {
-    const octokit = await getClient(ClientType.App, GETSENTRY_ORG.slug);
+    const org = GH_ORGS.get(orgSlug);
     const responses = await Promise.all([
-      octokit.repos.getContent({
-        owner,
-        repo,
+      org.api.repos.getContent({
+        owner: org.slug,
+        repo: repoSlug,
         path: 'sentry-version',
         ref: prevDeploySHA,
       }),
-      octokit.repos.getContent({
-        owner,
-        repo,
+      org.api.repos.getContent({
+        owner: org.slug,
+        repo: repoSlug,
         path: 'sentry-version',
         ref: currentDeploySHA,
       }),
@@ -108,15 +106,15 @@ export class DeployFeed {
     });
   }
 
-  compareURL(org: string, repo: string, prevRef: string, ref: string) {
-    return `https://github.com/${org}/${repo}/compare/${prevRef}...${ref}`;
+  compareURL(orgSlug: string, repoSlug: string, prevRef: string, ref: string) {
+    return `https://github.com/${orgSlug}/${repoSlug}/compare/${prevRef}...${ref}`;
   }
 
   async getCommitsInDeployBlock(
     pipeline: GoCDPipeline,
     modification: GoCDModification,
-    org: string,
-    repo: string
+    orgSlug: string,
+    repoSlug: string
   ): Promise<MrkdwnElement | undefined> {
     const latestDeploy = await getLastGetSentryGoCDDeploy(
       pipeline.group,
@@ -132,28 +130,28 @@ export class DeployFeed {
     }
 
     const compareURL = this.compareURL(
-      org,
-      repo,
+      orgSlug,
+      repoSlug,
       latestSHA,
       modification.revision
     );
-    if (repo !== GETSENTRY_REPO_SLUG) {
+    if (repoSlug !== GETSENTRY_REPO_SLUG) {
       return this.basicCommitsInDeployBlock(compareURL);
     }
 
     try {
-      // Getsentry comparisons are that useful since the majority of
-      // development is on the sentry repo
+      // Getsentry comparisons aren't that useful since the majority of
+      // development is on the sentry repo.
       const shas = await this.getSentryRevisions(
-        org,
-        repo,
+        orgSlug,
+        repoSlug,
         latestSHA,
         modification.revision
       );
 
       if (shas[0] && shas[1] && shas[0] != shas[1]) {
         const sentryCompareURL = this.compareURL(
-          org,
+          orgSlug,
           SENTRY_REPO_SLUG,
           shas[0],
           shas[1]
@@ -203,15 +201,15 @@ export class DeployFeed {
       block.elements.push(
         slackblocks.markdown('Deploying'),
         slackblocks.markdown(
-          `<https://github.com/${match.org}/${match.repo}/commits/${modification.revision}|${match.repo}@${sha}>`
+          `<https://github.com/${match.orgSlug}/${match.repoSlug}/commits/${modification.revision}|${match.repoSlug}@${sha}>`
         )
       );
 
       const commitsBlock = await this.getCommitsInDeployBlock(
         pipeline,
         modification,
-        match.org,
-        match.repo
+        match.orgSlug,
+        match.repoSlug
       );
       if (commitsBlock) {
         block.elements.push(commitsBlock);

--- a/src/brain/issueLabelHandler/followups.ts
+++ b/src/brain/issueLabelHandler/followups.ts
@@ -10,8 +10,6 @@ import {
   WAITING_FOR_PRODUCT_OWNER_LABEL,
   WAITING_FOR_SUPPORT_LABEL,
 } from '@/config';
-import { ClientType } from '@api/github/clientType';
-import { getClient } from '@api/github/getClient';
 import {
   calculateSLOViolationRoute,
   calculateSLOViolationTriage,
@@ -63,8 +61,6 @@ export async function updateCommunityFollowups({
     return;
   }
 
-  const owner = payload.repository.owner.login;
-  const octokit = await getClient(ClientType.App, owner);
   const repo = payload.repository.name;
   const issueNumber = payload.issue.number;
 
@@ -73,16 +69,16 @@ export async function updateCommunityFollowups({
   )?.name;
 
   if (isWaitingForCommunityLabelOnIssue) {
-    await octokit.issues.removeLabel({
-      owner,
+    await org.api.issues.removeLabel({
+      owner: org.slug,
       repo: repo,
       issue_number: issueNumber,
       name: WAITING_FOR_COMMUNITY_LABEL,
     });
   }
 
-  await octokit.issues.addLabels({
-    owner,
+  await org.api.issues.addLabels({
+    owner: org.slug,
     repo: repo,
     issue_number: issueNumber,
     labels: [WAITING_FOR_PRODUCT_OWNER_LABEL],
@@ -124,8 +120,6 @@ export async function ensureOneWaitingForLabel({
   }
 
   const { issue, label } = payload;
-  const owner = payload.repository.owner.login;
-  const octokit = await getClient(ClientType.App, owner);
   const repo = payload.repository.name;
   const issueNumber = payload.issue.number;
   // Here label will never be undefined, ts is erroring here but is handled in the shouldSkip above
@@ -137,8 +131,8 @@ export async function ensureOneWaitingForLabel({
   )?.name;
 
   if (labelToRemove != null) {
-    await octokit.issues.removeLabel({
-      owner: owner,
+    await org.api.issues.removeLabel({
+      owner: org.slug,
       repo: repo,
       issue_number: issueNumber,
       name: labelToRemove,

--- a/src/brain/issueLabelHandler/triage.ts
+++ b/src/brain/issueLabelHandler/triage.ts
@@ -6,8 +6,6 @@ import {
   SENTRY_REPOS_WITHOUT_ROUTING,
   WAITING_FOR_PRODUCT_OWNER_LABEL,
 } from '@/config';
-import { ClientType } from '@api/github/clientType';
-import { getClient } from '@api/github/getClient';
 import { isFromABot } from '@utils/isFromABot';
 import { isNotFromAnExternalOrGTMUser } from '@utils/isNotFromAnExternalOrGTMUser';
 import { shouldSkip } from '@utils/shouldSkip';
@@ -54,13 +52,11 @@ export async function markWaitingForProductOwner({
   }
 
   // New issues get an Untriaged label.
-  const owner = payload.repository.owner.login;
-  const octokit = await getClient(ClientType.App, owner);
   const repo = payload.repository.name;
   const issueNumber = payload.issue.number;
 
-  await octokit.issues.addLabels({
-    owner,
+  await org.api.issues.addLabels({
+    owner: org.slug,
     repo: repo,
     issue_number: issueNumber,
     labels: [WAITING_FOR_PRODUCT_OWNER_LABEL],
@@ -104,11 +100,9 @@ export async function markNotWaitingForProductOwner({
   }
 
   // Remove Untriaged label when triaged.
-  const owner = payload.repository.owner.login;
-  const octokit = await getClient(ClientType.App, owner);
   try {
-    await octokit.issues.removeLabel({
-      owner: owner,
+    await org.api.issues.removeLabel({
+      owner: org.slug,
       repo: payload.repository.name,
       issue_number: payload.issue.number,
       name: WAITING_FOR_PRODUCT_OWNER_LABEL,

--- a/src/brain/notifyOnGoCDStageEvent/index.ts
+++ b/src/brain/notifyOnGoCDStageEvent/index.ts
@@ -1,4 +1,3 @@
-import { Octokit } from '@octokit/rest';
 import * as Sentry from '@sentry/node';
 
 import {
@@ -9,7 +8,6 @@ import {
 } from '@types';
 import { GoCDStageData } from '@types';
 
-import { ClientType } from '@/api/github/clientType';
 import { getChangedStack } from '@/api/github/getChangedStack';
 import { getRelevantCommit } from '@/api/github/getRelevantCommit';
 import { gocdevents } from '@/api/gocdevents';
@@ -33,7 +31,7 @@ import {
   getProgressSuffix,
 } from '@/utils/gocdHelpers';
 import { getUser } from '@api/getUser';
-import { getClient } from '@api/github/getClient';
+import { GitHubOrg } from '@api/github/org';
 import { bolt } from '@api/slack';
 import { getSlackMessage } from '@utils/db/getSlackMessage';
 
@@ -206,12 +204,12 @@ async function filterCommits(pipeline, commits) {
 }
 
 async function getCommitsInDeployment(
-  octokit: Octokit,
+  org: GitHubOrg,
   sha: string,
   prevsha: string | null
 ): Promise<CompareCommits['commits']> {
   if (prevsha && prevsha !== sha) {
-    const { data } = await octokit.repos.compareCommits({
+    const { data } = await org.api.repos.compareCommits({
       owner: GETSENTRY_ORG.slug,
       repo: GETSENTRY_REPO_SLUG,
       head: sha,
@@ -219,7 +217,7 @@ async function getCommitsInDeployment(
     });
     return data.commits;
   }
-  const resp = await octokit.repos.getCommit({
+  const resp = await org.api.repos.getCommit({
     owner: GETSENTRY_ORG.slug,
     repo: GETSENTRY_REPO_SLUG,
     ref: sha,
@@ -273,15 +271,13 @@ export async function handler(resBody: GoCDResponse) {
   Sentry.configureScope((scope) => scope.setSpan(tx));
 
   // Get the range of commits for this payload
-  const octokit = await getClient(ClientType.App, GETSENTRY_ORG.slug);
-
   try {
     const latestDeploy = await getLastGetSentryGoCDDeploy(
       pipeline.group,
       pipeline.name
     );
     const commits = await getCommitsInDeployment(
-      octokit,
+      GETSENTRY_ORG,
       sha,
       firstMaterialSHA(latestDeploy)
     );

--- a/src/brain/pleaseDeployNotifier/actionViewUndeployedCommits.ts
+++ b/src/brain/pleaseDeployNotifier/actionViewUndeployedCommits.ts
@@ -1,6 +1,5 @@
 import * as Sentry from '@sentry/node';
 
-import { ClientType } from '@/api/github/clientType';
 import {
   GETSENTRY_ORG,
   GETSENTRY_REPO_SLUG,
@@ -9,7 +8,6 @@ import {
 } from '@/config';
 import { firstMaterialSHA } from '@/utils/gocdHelpers';
 import { getBlocksForCommit } from '@api/getBlocksForCommit';
-import { getClient } from '@api/github/getClient';
 import { getRelevantCommit } from '@api/github/getRelevantCommit';
 import { getLastGetSentryGoCDDeploy } from '@utils/db/getLatestDeploy';
 
@@ -68,7 +66,6 @@ export async function actionViewUndeployedCommits({
     return;
   }
 
-  const octokit = await getClient(ClientType.App, GETSENTRY_ORG.slug);
   const base = firstMaterialSHA(lastDeploy);
   if (!base) {
     // Failed to get base sha
@@ -77,7 +74,7 @@ export async function actionViewUndeployedCommits({
   const head = payload.value;
 
   // Get all getsentry commits between `base` and `head`
-  const { data } = await octokit.repos.compareCommits({
+  const { data } = await GETSENTRY_ORG.api.repos.compareCommits({
     owner: GETSENTRY_ORG.slug,
     repo: GETSENTRY_REPO_SLUG,
     base,

--- a/src/brain/projectsHandler/project.ts
+++ b/src/brain/projectsHandler/project.ts
@@ -2,8 +2,6 @@ import { EmitterWebhookEvent } from '@octokit/webhooks';
 import * as Sentry from '@sentry/node';
 
 import { GH_ORGS, PRODUCT_AREA_LABEL_PREFIX } from '@/config';
-import { ClientType } from '@api/github/clientType';
-import { getClient } from '@api/github/getClient';
 import { shouldSkip } from '@utils/shouldSkip';
 
 function isNotInAProjectWeCareAbout(payload, org) {
@@ -60,8 +58,6 @@ export async function syncLabelsWithProjectField({
     return;
   }
 
-  const owner = payload?.organization?.login || '';
-  const octokit = await getClient(ClientType.App, owner);
   const fieldName = getFieldName(payload, org);
   const fieldValue = await org.getKeyValueFromProjectField(
     payload.projects_v2_item.node_id,
@@ -77,8 +73,8 @@ export async function syncLabelsWithProjectField({
     payload.projects_v2_item.content_node_id
   );
 
-  await octokit.issues.addLabels({
-    owner,
+  await org.api.issues.addLabels({
+    owner: org.slug,
     repo: issueInfo.repo,
     issue_number: issueInfo.number,
     labels: [

--- a/src/brain/requiredChecks/getAnnotations.test.ts
+++ b/src/brain/requiredChecks/getAnnotations.test.ts
@@ -1,17 +1,12 @@
-import { ClientType } from '@api/github/clientType';
-import { getClient } from '@api/github/getClient';
+import { GETSENTRY_ORG } from '@/config';
 
 import { getAnnotations } from './getAnnotations';
 
 describe('getAnnotations', function () {
-  let octokit;
-
-  beforeAll(async function () {
-    octokit = await getClient(ClientType.App, 'getsentry');
-  });
+  const org = GETSENTRY_ORG;
 
   beforeEach(function () {
-    octokit.checks.listAnnotations.mockClear();
+    org.api.checks.listAnnotations.mockClear();
   });
 
   it('returns annotations without "Process completed with exit code..."', async function () {
@@ -45,7 +40,7 @@ describe('getAnnotations', function () {
   });
 
   it('returns annotation with only "Process completed with exit code..."', async function () {
-    octokit.checks.listAnnotations.mockImplementation(() => ({
+    org.api.checks.listAnnotations.mockImplementation(() => ({
       data: [
         {
           path: '.github',
@@ -90,7 +85,7 @@ describe('getAnnotations', function () {
   });
 
   it('returns annotation with "Process completed with exit code...", when there are only warning annotations', async function () {
-    octokit.checks.listAnnotations.mockImplementation(() => ({
+    org.api.checks.listAnnotations.mockImplementation(() => ({
       data: [
         {
           path: '.github',
@@ -161,7 +156,7 @@ describe('getAnnotations', function () {
   });
 
   it('does not ignore annotations from a manually canceled job', async function () {
-    octokit.checks.listAnnotations.mockImplementation(() => ({
+    org.api.checks.listAnnotations.mockImplementation(() => ({
       data: [
         {
           path: '.github',
@@ -207,7 +202,7 @@ describe('getAnnotations', function () {
   });
 
   it('ignores annotations from canceled jobs due to another failing job', async function () {
-    octokit.checks.listAnnotations.mockImplementation(() => ({
+    org.api.checks.listAnnotations.mockImplementation(() => ({
       data: [
         {
           path: '.github',

--- a/src/brain/typescript/getProgress.ts
+++ b/src/brain/typescript/getProgress.ts
@@ -1,6 +1,4 @@
-import { ClientType } from '@/api/github/clientType';
 import { GETSENTRY_ORG, SENTRY_REPO_SLUG } from '@/config';
-import { getClient } from '@api/github/getClient';
 
 /**
  * Paths that we do not intend to convert to ts
@@ -18,8 +16,6 @@ export default async function getProgress({
   appDir?: string;
   date?: string;
 }) {
-  const octokit = await getClient(ClientType.App, GETSENTRY_ORG.slug);
-
   const getContentsParams: {
     owner: string;
     repo: string;
@@ -32,7 +28,7 @@ export default async function getProgress({
   };
 
   if (date) {
-    const commits = await octokit.repos.listCommits({
+    const commits = await GETSENTRY_ORG.api.repos.listCommits({
       owner: GETSENTRY_ORG.slug,
       repo,
       until: date,
@@ -44,7 +40,7 @@ export default async function getProgress({
     }
   }
 
-  const contents = await octokit.repos.getContent(getContentsParams);
+  const contents = await GETSENTRY_ORG.api.repos.getContent(getContentsParams);
 
   if (!Array.isArray(contents.data)) {
     throw new Error('Invalid directory');
@@ -56,7 +52,7 @@ export default async function getProgress({
     throw new Error('Invalid directory');
   }
 
-  const tree = await octokit.git.getTree({
+  const tree = await GETSENTRY_ORG.api.git.getTree({
     owner: GETSENTRY_ORG.slug,
     repo,
     tree_sha: app.sha,

--- a/src/utils/db/getFailureMessages.test.ts
+++ b/src/utils/db/getFailureMessages.test.ts
@@ -1,19 +1,19 @@
+import { GETSENTRY_ORG } from '@/config';
 import { SlackMessage } from '@/config/slackMessage';
-import { ClientType } from '@api/github/clientType';
-import { getClient } from '@api/github/getClient';
 import { db } from '@utils/db';
 import { saveSlackMessage } from '@utils/db/saveSlackMessage';
 
 import { getFailureMessages } from './getFailureMessages';
 
 describe('getFailureMessages', function () {
-  let octokit;
+  const org = GETSENTRY_ORG;
+
   beforeAll(async function () {
     await db.migrate.latest();
   });
 
   beforeEach(async function () {
-    octokit = await getClient(ClientType.App, 'getsentry');
+    org.api.mockClear();
   });
 
   afterAll(async function () {
@@ -22,7 +22,7 @@ describe('getFailureMessages', function () {
 
   afterEach(async function () {
     await db('slack_messages').delete();
-    octokit.repos.compareCommits.mockClear();
+    org.api.repos.compareCommits.mockClear();
   });
 
   it('initially is not failing', async function () {

--- a/src/utils/db/getFailureMessages.ts
+++ b/src/utils/db/getFailureMessages.ts
@@ -1,8 +1,6 @@
-import { ClientType } from '@/api/github/clientType';
 import { GETSENTRY_ORG, GETSENTRY_REPO_SLUG } from '@/config';
 import { BuildStatus } from '@/config';
 import { SlackMessage } from '@/config/slackMessage';
-import { getClient } from '@api/github/getClient';
 import { db } from '@utils/db';
 import { getTimestamp } from '@utils/db/getTimestamp';
 
@@ -40,14 +38,13 @@ export async function getFailureMessages(
 
   const onlyOlderFailedMessages = await Promise.all(
     messages.map(async (message) => {
-      const octokit = await getClient(ClientType.App, GETSENTRY_ORG.slug);
       // We *ONLY* want failed builds before `headSha` - when calling GH's
       // `compareCommits`, we use `headSha` as the head commit, so we only want
       // the messages for failed builds that came before `headSha`.
 
       // This happens when say build A starts, and then after build B starts
       // and fails before A completes. In this case, build A should not mark B as being fixed
-      const { data } = await octokit.repos.compareCommits({
+      const { data } = await GETSENTRY_ORG.api.repos.compareCommits({
         owner: GETSENTRY_ORG.slug,
         repo: GETSENTRY_REPO_SLUG,
         base: message.refId,

--- a/src/webhooks/pubsub/index.test.ts
+++ b/src/webhooks/pubsub/index.test.ts
@@ -1,0 +1,62 @@
+import * as slackNotifications from './slackNotifications';
+import * as staleBot from './stalebot';
+import { pubSubHandler } from '.';
+
+const mockNotifier = jest.fn();
+const mockStaleBot = jest.fn();
+
+slackNotifications.notifyProductOwnersForUntriagedIssues = mockNotifier;
+staleBot.triggerStaleBot = mockStaleBot;
+
+class MockReply {
+  statusCode: number;
+  code(c) {
+    this.statusCode = c;
+  }
+  send() {}
+}
+
+describe('slack app', function () {
+  let reply;
+
+  async function pubSub(operationSlug: string) {
+    const request = {
+      body: {
+        message: {
+          data: new Buffer.from(
+            JSON.stringify({ name: operationSlug })
+          ).toString('base64'),
+        },
+      },
+    };
+    const reply = new MockReply();
+    await pubSubHandler(request, reply);
+    return reply;
+  }
+
+  beforeEach(async function () {
+    mockNotifier.mockClear();
+    mockStaleBot.mockClear();
+  });
+
+  it('basically works', async function () {
+    const reply = await pubSub('stale-bot');
+    expect(reply.statusCode).toBe(204);
+    expect(mockNotifier).not.toHaveBeenCalled();
+    expect(mockStaleBot).toHaveBeenCalled();
+  });
+
+  it('keeps working', async function () {
+    const reply = await pubSub('stale-triage-notifier');
+    expect(reply.statusCode).toBe(204);
+    expect(mockNotifier).toHaveBeenCalled();
+    expect(mockStaleBot).not.toHaveBeenCalled();
+  });
+
+  it('replies with 400 for unknown operations', async function () {
+    const reply = await pubSub('cheez-whiz');
+    expect(reply.statusCode).toBe(400);
+    expect(mockNotifier).not.toHaveBeenCalled();
+    expect(mockStaleBot).not.toHaveBeenCalled();
+  });
+});

--- a/src/webhooks/pubsub/slackNotifications.test.ts
+++ b/src/webhooks/pubsub/slackNotifications.test.ts
@@ -61,24 +61,24 @@ describe('Triage Notification Tests', function () {
     });
 
     it('should return date populated in project field', async function () {
-      const octokit = {
+      org.api = {
         paginate: (a, b) => a(b),
         issues: { listComments: () => [] },
       };
       getIssueDueDateFromProjectSpy.mockReturnValue('2023-01-05T16:00:00.000Z');
       expect(
-        await getTriageSLOTimestamp(org, octokit, 'test', 1234, 'issueNodeId')
+        await getTriageSLOTimestamp(org, 'test', 1234, 'issueNodeId')
       ).toEqual('2023-01-05T16:00:00.000Z');
     });
     it('should return current time if unable to parse random string in project field', async function () {
-      const octokit = {
+      org.api = {
         paginate: (a, b) => a(b),
         issues: { listComments: () => [] },
       };
       const sentryCaptureExceptionSpy = jest.spyOn(Sentry, 'captureException');
       getIssueDueDateFromProjectSpy.mockReturnValue('randomstring');
       expect(
-        await getTriageSLOTimestamp(org, octokit, 'test', 1234, 'issueNodeId')
+        await getTriageSLOTimestamp(org, 'test', 1234, 'issueNodeId')
       ).not.toEqual('2023-01-05T16:00:00.000Z');
       expect(sentryCaptureExceptionSpy).toHaveBeenCalledWith(
         new Error(
@@ -87,14 +87,14 @@ describe('Triage Notification Tests', function () {
       );
     });
     it('should return current time if unable to parse empty string in project field', async function () {
-      const octokit = {
+      org.api = {
         paginate: (a, b) => a(b),
         issues: { listComments: () => [] },
       };
       const sentryCaptureExceptionSpy = jest.spyOn(Sentry, 'captureException');
       getIssueDueDateFromProjectSpy.mockReturnValue('');
       expect(
-        await getTriageSLOTimestamp(org, octokit, 'test', 1234, 'issueNodeId')
+        await getTriageSLOTimestamp(org, 'test', 1234, 'issueNodeId')
       ).not.toEqual('2023-01-05T16:00:00.000Z');
       expect(sentryCaptureExceptionSpy).toHaveBeenCalledWith(
         new Error(

--- a/src/webhooks/pubsub/stalebot.test.ts
+++ b/src/webhooks/pubsub/stalebot.test.ts
@@ -1,8 +1,6 @@
 import moment from 'moment-timezone';
 
 import { GETSENTRY_ORG, STALE_LABEL } from '@/config';
-import { ClientType } from '@api/github/clientType';
-import { getClient } from '@api/github/getClient';
 
 import { triggerStaleBot } from './stalebot';
 
@@ -21,30 +19,26 @@ describe('Stalebot Tests', function () {
     labels: [],
     updated_at: '2023-04-05T15:51:22Z',
   };
-  let octokit;
 
   beforeEach(async function () {
-    octokit = {
-      ...(await getClient(ClientType.App, 'Enterprise')),
-      paginate: (a, b) => a(b),
-    };
+    org.api.paginate = (a, b) => a(b);
   });
 
   afterEach(async function () {
-    octokit.issues._labels = new Set([]);
-    octokit.issues.addLabels.mockClear();
-    octokit.issues.removeLabel.mockClear();
-    octokit.issues._comments = [];
-    octokit.issues.createComment.mockClear();
-    octokit.teams.getByName.mockClear();
+    org.api.issues._labels = new Set([]);
+    org.api.issues.addLabels.mockClear();
+    org.api.issues.removeLabel.mockClear();
+    org.api.issues._comments = [];
+    org.api.issues.createComment.mockClear();
+    org.api.teams.getByName.mockClear();
     jest.clearAllMocks();
   });
 
   it('should mark issue as stale if it has been over 3 weeks', async function () {
-    octokit.issues.listForRepo = () => [issueInfo];
-    await triggerStaleBot(org, octokit, moment('2023-04-27T14:28:13Z').utc());
-    expect(octokit.issues._labels).toContain(STALE_LABEL);
-    expect(octokit.issues._comments).toEqual([
+    org.api.issues.listForRepo = () => [issueInfo];
+    await triggerStaleBot(org, moment('2023-04-27T14:28:13Z').utc());
+    expect(org.api.issues._labels).toContain(STALE_LABEL);
+    expect(org.api.issues._comments).toEqual([
       `This issue has gone three weeks without activity. In another week, I will close it.
 
 But! If you comment or otherwise update it, I will reset the clock, and if you remove the label \`Waiting for: Community\`, I will leave it alone ... forever!
@@ -56,24 +50,24 @@ But! If you comment or otherwise update it, I will reset the clock, and if you r
   });
 
   it('should not mark issue as stale if it has been under 3 weeks', async function () {
-    octokit.issues.listForRepo = () => [issueInfo];
-    await triggerStaleBot(org, octokit, moment('2023-04-10T14:28:13Z').utc());
-    expect(octokit.issues._labels).not.toContain(STALE_LABEL);
-    expect(octokit.issues._comments).toEqual([]);
+    org.api.issues.listForRepo = () => [issueInfo];
+    await triggerStaleBot(org, moment('2023-04-10T14:28:13Z').utc());
+    expect(org.api.issues._labels).not.toContain(STALE_LABEL);
+    expect(org.api.issues._comments).toEqual([]);
   });
 
   it('should not mark PR as stale if it has been under 3 weeks', async function () {
-    octokit.issues.listForRepo = () => [{ ...issueInfo, pull_request: {} }];
-    await triggerStaleBot(org, octokit, moment('2023-04-10T14:28:13Z').utc());
-    expect(octokit.issues._labels).not.toContain(STALE_LABEL);
-    expect(octokit.issues._comments).toEqual([]);
+    org.api.issues.listForRepo = () => [{ ...issueInfo, pull_request: {} }];
+    await triggerStaleBot(org, moment('2023-04-10T14:28:13Z').utc());
+    expect(org.api.issues._labels).not.toContain(STALE_LABEL);
+    expect(org.api.issues._comments).toEqual([]);
   });
 
   it('should mark PR as stale if it has been over 3 weeks', async function () {
-    octokit.issues.listForRepo = () => [{ ...issueInfo, pull_request: {} }];
-    await triggerStaleBot(org, octokit, moment('2023-04-27T14:28:13Z').utc());
-    expect(octokit.issues._labels).toContain(STALE_LABEL);
-    expect(octokit.issues._comments).toEqual([
+    org.api.issues.listForRepo = () => [{ ...issueInfo, pull_request: {} }];
+    await triggerStaleBot(org, moment('2023-04-27T14:28:13Z').utc());
+    expect(org.api.issues._labels).toContain(STALE_LABEL);
+    expect(org.api.issues._comments).toEqual([
       `This pull request has gone three weeks without activity. In another week, I will close it.
 
 But! If you comment or otherwise update it, I will reset the clock, and if you remove the label \`Waiting for: Community\`, I will leave it alone ... forever!
@@ -85,11 +79,11 @@ But! If you comment or otherwise update it, I will reset the clock, and if you r
   });
 
   it('should close issue if there is no activity after a week and an issue is stale', async function () {
-    const issueUpdateSpy = jest.spyOn(octokit.issues, 'update');
-    octokit.issues.listForRepo = () => [
+    const issueUpdateSpy = jest.spyOn(org.api.issues, 'update');
+    org.api.issues.listForRepo = () => [
       { ...issueInfo, labels: [STALE_LABEL] },
     ];
-    await triggerStaleBot(org, octokit, moment('2023-04-13T14:28:13Z').utc());
+    await triggerStaleBot(org, moment('2023-04-13T14:28:13Z').utc());
     expect(issueUpdateSpy).toHaveBeenCalledWith({
       issue_number: undefined,
       owner: 'getsentry',
@@ -99,24 +93,24 @@ But! If you comment or otherwise update it, I will reset the clock, and if you r
   });
 
   it('should not close issue if there is no activity under a week and an issue is stale', async function () {
-    const issueUpdateSpy = jest.spyOn(octokit.issues, 'update');
-    octokit.issues.listForRepo = () => [
+    const issueUpdateSpy = jest.spyOn(org.api.issues, 'update');
+    org.api.issues.listForRepo = () => [
       { ...issueInfo, labels: [STALE_LABEL] },
     ];
-    await triggerStaleBot(org, octokit, moment('2023-04-06T14:28:13Z').utc());
+    await triggerStaleBot(org, moment('2023-04-06T14:28:13Z').utc());
     expect(issueUpdateSpy).toBeCalledTimes(0);
   });
 
   it('should remove stale label if there is activity but stale label exists on issue', async function () {
-    const issueUpdateSpy = jest.spyOn(octokit.issues, 'update');
-    octokit.issues.listForRepo = () => [
+    const issueUpdateSpy = jest.spyOn(org.api.issues, 'update');
+    org.api.issues.listForRepo = () => [
       {
         ...issueInfo,
         updated_at: '2023-04-06T10:28:13Z',
         labels: [STALE_LABEL],
       },
     ];
-    await triggerStaleBot(org, octokit, moment('2023-04-06T14:28:13Z').utc());
-    expect(octokit.issues._labels).not.toContain(STALE_LABEL);
+    await triggerStaleBot(org, moment('2023-04-06T14:28:13Z').utc());
+    expect(org.api.issues._labels).not.toContain(STALE_LABEL);
   });
 });


### PR DESCRIPTION
Part of #482, after #539.

Now that the helper functions are nicely encapsulated in `GitHubOrg`, we're ready to switch everything over to using `org.api` rather than `octokit`!