### PR TITLE
Make pubsub handlers multi-org

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,6 @@ GH_USER_TOKEN=''
 GH_WEBHOOK_SECRET=''
 GH_APP_PRIVATE_KEY='-----BEGIN RSA PRIVATE KEY----------END RSA PRIVATE KEY-----'
 GH_ORGS_YML='github-orgs.local.yml'
-PERSONAL_TEST_REPO='testing-eng-pipes'
 
 # Slack
 SLACK_SIGNING_SECRET=''

--- a/github-orgs.example.yml
+++ b/github-orgs.example.yml
@@ -1,10 +1,15 @@
 your-org-CHANGEME:
   appAuth:
     appId: ''
-    privateKey: 'GH_APP_PRIVATE_KEY' # this is the name of an env var to pull from
+    privateKey: 'GH_APP_PRIVATE_KEY' # leave this, it names an env var to pull from
   project:
     nodeId: ''
     fieldIds:
       productArea: ''
       status: ''
       responseDue: ''
+  repos:
+    withRouting:
+      - 'foo'
+    withoutRouting:
+      - 'bar'

--- a/github-orgs.yml
+++ b/github-orgs.yml
@@ -8,3 +8,41 @@ getsentry:
       productArea: 'PVTSSF_lADOABVQ184AOGW8zgJEBno'
       status: 'PVTSSF_lADOABVQ184AOGW8zgI_7g0'
       responseDue: 'PVTF_lADOABVQ184AOGW8zgLLxGg'
+  repos:
+    withRouting:
+      - 'sentry'
+      - 'sentry-docs'
+
+    withoutRouting:
+      - 'arroyo'
+      - 'cdc'
+      - 'craft'
+      - 'relay'
+      - 'responses'
+      - 'self-hosted'
+      - 'sentry-native'
+      - 'snuba'
+      - 'snuba-sdk'
+      - 'symbolic'
+      - 'symbolicator'
+      - 'test-ttt-simple'
+      - 'wal2json'
+
+      # Web team T1
+      - 'sentry-javascript'
+      - 'sentry-python'
+      - 'sentry-php'
+      - 'sentry-laravel'
+      - 'sentry-symfony'
+      - 'sentry-ruby'
+
+      # Mobile team T1
+      # www.notion.so/346452f21e7947b4bf515d5f3a4d497d?v=cad7f04cf9064e7483ab426a26d3923a
+      - 'sentry-cocoa'
+      - 'sentry-java'
+      - 'sentry-react-native'
+      - 'sentry-unity'
+      - 'sentry-dart'
+      - 'sentry-android-gradle-plugin'
+      - 'sentry-dotnet'
+      - 'sentry-dart-plugin'

--- a/src/api/github/org.test.ts
+++ b/src/api/github/org.test.ts
@@ -33,6 +33,27 @@ describe('constructor', function () {
   it('does not try to get an org installation', async function () {
     expect(octokitClass.apps.getOrgInstallation).toHaveBeenCalledTimes(0);
   });
+
+  it('combines repos into .all', async function () {
+    const org = new GitHubOrg('barn', {
+      repos: {
+        withRouting: ['cheese'],
+        withoutRouting: ['bread'],
+      },
+    });
+    expect(org.repos.all).toEqual(['cheese', 'bread']);
+  });
+
+  it('is fine without one of them', async function () {
+    const org = new GitHubOrg('barn', {
+      repos: {
+        withRouting: ['cheese', 'wine'],
+      },
+    });
+    expect(org.repos.all).toEqual(['cheese', 'wine']);
+    expect(org.repos.withRouting).toEqual(['cheese', 'wine']);
+    expect(org.repos.withoutRouting).toEqual([]);
+  });
 });
 
 describe('bindAPI', function () {

--- a/src/api/github/org.ts
+++ b/src/api/github/org.ts
@@ -6,6 +6,7 @@ import {
   AppAuthStrategyOptions,
   GitHubIssuesSomeoneElseCaresAbout,
   GitHubOrgConfig,
+  GitHubOrgRepos,
 } from '@/types';
 
 // We can't use @ to import config here or we get an error from jest due to
@@ -19,6 +20,7 @@ export class GitHubOrg {
   slug: string;
   appAuth: AppAuthStrategyOptions;
   project: GitHubIssuesSomeoneElseCaresAbout;
+  repos: GitHubOrgRepos;
 
   // The docs say it's safe for Octokit instances to be long-lived:
   //
@@ -33,6 +35,14 @@ export class GitHubOrg {
     this.slug = orgSlug;
     this.appAuth = config.appAuth;
     this.project = config.project;
+    this.repos = config.repos || {};
+    if (!this.repos.withRouting) {
+      this.repos.withRouting = [];
+    }
+    if (!this.repos.withoutRouting) {
+      this.repos.withoutRouting = [];
+    }
+    this.repos.all = [...this.repos.withRouting, ...this.repos.withoutRouting];
 
     // Call bindAPI ASAP. We can't call it here because constructors can't be
     // async. Note that in testing this ends up being mocked as if it were

--- a/src/brain/issueLabelHandler/followups.ts
+++ b/src/brain/issueLabelHandler/followups.ts
@@ -4,7 +4,6 @@ import moment from 'moment-timezone';
 
 import {
   GH_ORGS,
-  SENTRY_REPOS,
   WAITING_FOR_COMMUNITY_LABEL,
   WAITING_FOR_LABEL_PREFIX,
   WAITING_FOR_PRODUCT_OWNER_LABEL,
@@ -18,8 +17,8 @@ import { isFromABot } from '@utils/isFromABot';
 import { isNotFromAnExternalOrGTMUser } from '@utils/isNotFromAnExternalOrGTMUser';
 import { shouldSkip } from '@utils/shouldSkip';
 
-function isNotInARepoWeCareAboutForFollowups(payload) {
-  return !SENTRY_REPOS.has(payload.repository.name);
+function isNotInARepoWeCareAboutForFollowups(payload, org) {
+  return !org.repos.all.includes(payload.repository.name);
 }
 
 function isNotWaitingForLabel(payload) {

--- a/src/brain/issueLabelHandler/index.test.ts
+++ b/src/brain/issueLabelHandler/index.test.ts
@@ -341,7 +341,7 @@ describe('issueLabelHandler', function () {
     });
 
     it('adds `Status: Unrouted` and `Waiting for: Support` to new issues', async function () {
-      await createIssue('sentry-docs');
+      await createIssue('routing-repo');
       expectWaitingForSupport();
       expect(org.api.issues._labels).toContain(WAITING_FOR_SUPPORT_LABEL);
       // Simulate GitHub adding Waiting for Support Label to send webhook
@@ -353,7 +353,7 @@ describe('issueLabelHandler', function () {
     });
 
     it('adds `Status: Unrouted` and `Waiting for: Support` for GTM users', async function () {
-      await createIssue('sentry-docs', 'Troi');
+      await createIssue('routing-repo', 'Troi');
       expectWaitingForSupport();
       expect(org.api.issues._labels).toContain(WAITING_FOR_SUPPORT_LABEL);
       // Simulate GitHub adding Waiting for Support Label to send webhook
@@ -365,7 +365,7 @@ describe('issueLabelHandler', function () {
     });
 
     it('skips adding `Waiting for: Support` for internal users', async function () {
-      await createIssue('sentry-docs', 'Picard');
+      await createIssue('routing-repo', 'Picard');
       expectNotWaitingForSupport();
       expect(org.api.issues._labels).not.toContain(WAITING_FOR_SUPPORT_LABEL);
       expect(org.api.issues._comments).toEqual([]);
@@ -381,8 +381,8 @@ describe('issueLabelHandler', function () {
     });
 
     it('removes waiting for support label when product area label is added', async function () {
-      await createIssue('sentry-docs');
-      await addLabel('Product Area: Test', 'sentry-docs');
+      await createIssue('routing-repo');
+      await addLabel('Product Area: Test', 'routing-repo');
       expectWaitingforProductOwner();
       expectNotWaitingForSupport();
       expect(org.api.issues._labels).not.toContain(WAITING_FOR_SUPPORT_LABEL);
@@ -395,8 +395,8 @@ describe('issueLabelHandler', function () {
     });
 
     it('does not remove waiting for support label when label is added that is not a product area label', async function () {
-      await createIssue('sentry-docs');
-      await addLabel('Status: Needs More Information', 'sentry-docs');
+      await createIssue('routing-repo');
+      await addLabel('Status: Needs More Information', 'routing-repo');
       expectWaitingForSupport();
       expect(org.api.issues._labels).toContain(WAITING_FOR_SUPPORT_LABEL);
       // Simulate GitHub adding Waiting for Support Label to send webhook
@@ -408,8 +408,8 @@ describe('issueLabelHandler', function () {
     });
 
     it('should default to route to open source team if product area does not exist', async function () {
-      await createIssue('sentry-docs');
-      await addLabel('Product Area: Does Not Exist', 'sentry-docs');
+      await createIssue('routing-repo');
+      await addLabel('Product Area: Does Not Exist', 'routing-repo');
       expectWaitingforProductOwner();
       expectNotWaitingForSupport();
       expect(org.api.issues._labels).not.toContain(WAITING_FOR_SUPPORT_LABEL);
@@ -422,11 +422,11 @@ describe('issueLabelHandler', function () {
     });
 
     it('removes previous Product Area labels when re[routing](https://open.sentry.io/triage/#2-route)', async function () {
-      await createIssue('sentry-docs');
-      await addLabel('Product Area: Test', 'sentry-docs');
+      await createIssue('routing-repo');
+      await addLabel('Product Area: Test', 'routing-repo');
       expectWaitingforProductOwner();
       expectNotWaitingForSupport();
-      await addLabel('Product Area: Rerouted', 'sentry-docs');
+      await addLabel('Product Area: Rerouted', 'routing-repo');
       expect(org.api.issues._labels).toContain('Product Area: Rerouted');
       expect(org.api.issues._labels).not.toContain('Product Area: Test');
       expect(org.api.issues._comments).toEqual([
@@ -438,12 +438,12 @@ describe('issueLabelHandler', function () {
     });
 
     it('should not reapply label `Waiting for: Product Owner` if issue changes product areas and is not waiting for support', async function () {
-      await createIssue('sentry-docs');
-      await addLabel('Product Area: Test', 'sentry-docs');
+      await createIssue('routing-repo');
+      await addLabel('Product Area: Test', 'routing-repo');
       expectWaitingforProductOwner();
       expectNotWaitingForSupport();
-      await addLabel('Waiting for: Community', 'sentry-docs');
-      await addLabel('Product Area: Rerouted', 'sentry-docs');
+      await addLabel('Waiting for: Community', 'routing-repo');
+      await addLabel('Product Area: Rerouted', 'routing-repo');
       expect(org.api.issues._labels).toContain('Product Area: Rerouted');
       expect(org.api.issues._labels).toContain('Waiting for: Community');
       expect(org.api.issues._labels).not.toContain(
@@ -458,12 +458,12 @@ describe('issueLabelHandler', function () {
     });
 
     it('should not reroute if Status: Backlog is exists on issue', async function () {
-      await createIssue('sentry-docs');
-      await addLabel('Product Area: Test', 'sentry-docs');
+      await createIssue('routing-repo');
+      await addLabel('Product Area: Test', 'routing-repo');
       expectWaitingforProductOwner();
       expectNotWaitingForSupport();
-      await addLabel('Status: Backlog', 'sentry-docs');
-      await addLabel('Product Area: Rerouted', 'sentry-docs');
+      await addLabel('Status: Backlog', 'routing-repo');
+      await addLabel('Product Area: Rerouted', 'routing-repo');
       expect(org.api.issues._labels).toContain('Product Area: Rerouted');
       expect(org.api.issues._labels).toContain('Product Area: Test');
       expect(org.api.issues._comments).toEqual([
@@ -474,12 +474,12 @@ describe('issueLabelHandler', function () {
     });
 
     it('should not reroute if Status: In Progress exists on issue', async function () {
-      await createIssue('sentry-docs');
-      await addLabel('Product Area: Test', 'sentry-docs');
+      await createIssue('routing-repo');
+      await addLabel('Product Area: Test', 'routing-repo');
       expectWaitingforProductOwner();
       expectNotWaitingForSupport();
-      await addLabel('Status: In Progress', 'sentry-docs');
-      await addLabel('Product Area: Rerouted', 'sentry-docs');
+      await addLabel('Status: In Progress', 'routing-repo');
+      await addLabel('Product Area: Rerouted', 'routing-repo');
       expect(org.api.issues._labels).toContain('Product Area: Rerouted');
       expect(org.api.issues._labels).toContain('Product Area: Test');
       expect(org.api.issues._comments).toEqual([
@@ -490,11 +490,11 @@ describe('issueLabelHandler', function () {
     });
 
     it('should not reroute if issue is closed', async function () {
-      await createIssue('sentry-docs');
-      await addLabel('Product Area: Test', 'sentry-docs');
+      await createIssue('routing-repo');
+      await addLabel('Product Area: Test', 'routing-repo');
       expectWaitingforProductOwner();
       expectNotWaitingForSupport();
-      await addLabel('Product Area: Rerouted', 'sentry-docs', 'closed');
+      await addLabel('Product Area: Rerouted', 'routing-repo', 'closed');
       expect(org.api.issues._labels).toContain('Product Area: Rerouted');
       expect(org.api.issues._labels).toContain('Product Area: Test');
       expect(org.api.issues._comments).toEqual([
@@ -524,8 +524,8 @@ describe('issueLabelHandler', function () {
       jest.clearAllMocks();
     });
     const setupIssue = async () => {
-      await createIssue('sentry-docs');
-      await addLabel('Product Area: Test', 'sentry-docs');
+      await createIssue('routing-repo');
+      await addLabel('Product Area: Test', 'routing-repo');
     };
 
     it('should remove `Waiting for: Product Owner` label when another `Waiting for: *` label is added', async function () {
@@ -534,11 +534,11 @@ describe('issueLabelHandler', function () {
       expect(org.api.issues._labels).toEqual(
         new Set([WAITING_FOR_PRODUCT_OWNER_LABEL, 'Product Area: Test'])
       );
-      await addLabel('Waiting for: Community', 'sentry-docs');
+      await addLabel('Waiting for: Community', 'routing-repo');
       expect(org.api.issues._labels).toEqual(
         new Set(['Product Area: Test', WAITING_FOR_COMMUNITY_LABEL])
       );
-      await addLabel('Waiting for: Support', 'sentry-docs');
+      await addLabel('Waiting for: Support', 'routing-repo');
       expect(org.api.issues._labels).toEqual(
         new Set(['Product Area: Test', WAITING_FOR_SUPPORT_LABEL])
       );
@@ -556,8 +556,8 @@ describe('issueLabelHandler', function () {
 
     it('should not add `Waiting for: Product Owner` label when product owner/GTM member comments and issue is waiting for community', async function () {
       await setupIssue();
-      await addLabel(WAITING_FOR_COMMUNITY_LABEL, 'sentry-docs');
-      await addComment('sentry-docs', 'Picard');
+      await addLabel(WAITING_FOR_COMMUNITY_LABEL, 'routing-repo');
+      await addComment('routing-repo', 'Picard');
       expect(org.api.issues._labels).toEqual(
         new Set(['Product Area: Test', WAITING_FOR_COMMUNITY_LABEL])
       );
@@ -575,8 +575,8 @@ describe('issueLabelHandler', function () {
 
     it('should not add `Waiting for: Product Owner` label when contractor comments and issue is waiting for community', async function () {
       await setupIssue();
-      await addLabel(WAITING_FOR_COMMUNITY_LABEL, 'sentry-docs');
-      await addComment('sentry-docs', 'Troi');
+      await addLabel(WAITING_FOR_COMMUNITY_LABEL, 'routing-repo');
+      await addComment('routing-repo', 'Troi');
       expect(org.api.issues._labels).toEqual(
         new Set(['Product Area: Test', WAITING_FOR_COMMUNITY_LABEL])
       );
@@ -593,14 +593,14 @@ describe('issueLabelHandler', function () {
     });
 
     it('should not add `Waiting for: Product Owner` label when community member comments and issue is a PR', async function () {
-      await createPR('sentry-docs');
-      await addComment('sentry-docs', 'Skywalker', true);
+      await createPR('routing-repo');
+      await addComment('routing-repo', 'Skywalker', true);
       expect(org.api.issues._labels).toEqual(new Set([]));
     });
 
     it('should add `Waiting for: Product Owner` label when community member comments and issue is not waiting for community', async function () {
       await setupIssue();
-      await addComment('sentry-docs', 'Skywalker');
+      await addComment('routing-repo', 'Skywalker');
       expect(org.api.issues._labels).toEqual(
         new Set(['Product Area: Test', WAITING_FOR_PRODUCT_OWNER_LABEL])
       );
@@ -620,8 +620,8 @@ describe('issueLabelHandler', function () {
 
     it('should add `Waiting for: Product Owner` label when community member comments and issue is waiting for community', async function () {
       await setupIssue();
-      await addLabel(WAITING_FOR_COMMUNITY_LABEL, 'sentry-docs');
-      await addComment('sentry-docs', 'Skywalker');
+      await addLabel(WAITING_FOR_COMMUNITY_LABEL, 'routing-repo');
+      await addComment('routing-repo', 'Skywalker');
       expect(org.api.issues._labels).toEqual(
         new Set(['Product Area: Test', WAITING_FOR_PRODUCT_OWNER_LABEL])
       );
@@ -662,7 +662,7 @@ describe('issueLabelHandler', function () {
     });
 
     it('should modify time to respond by when adding `Waiting for: Support` label when calculateSLOViolationTriage returns null', async function () {
-      await createIssue('sentry-docs');
+      await createIssue('routing-repo');
       calculateSLOViolationRouteSpy.mockReturnValue(null);
       jest.spyOn(Date, 'now').mockReturnValue('2023-06-20T00:00:00.000Z');
       // Simulate GH webhook being thrown when Waiting for: Product Owner label is added
@@ -685,8 +685,8 @@ describe('issueLabelHandler', function () {
 
     it('should not modify labels when community member comments and issue is waiting for product owner', async function () {
       await setupIssue();
-      await addLabel(WAITING_FOR_PRODUCT_OWNER_LABEL, 'sentry-docs');
-      await addComment('sentry-docs', 'Picard');
+      await addLabel(WAITING_FOR_PRODUCT_OWNER_LABEL, 'routing-repo');
+      await addComment('routing-repo', 'Picard');
       expect(org.api.issues._labels).toEqual(
         new Set(['Product Area: Test', WAITING_FOR_PRODUCT_OWNER_LABEL])
       );

--- a/src/brain/issueLabelHandler/route.ts
+++ b/src/brain/issueLabelHandler/route.ts
@@ -7,7 +7,6 @@ import {
   IN_PROGRESS_LABEL,
   PRODUCT_AREA_LABEL_PREFIX,
   PRODUCT_AREA_UNKNOWN,
-  SENTRY_REPOS_WITH_ROUTING,
   WAITING_FOR_PRODUCT_OWNER_LABEL,
   WAITING_FOR_SUPPORT_LABEL,
 } from '@/config';
@@ -21,8 +20,8 @@ function isAlreadyWaitingForSupport(payload) {
   );
 }
 
-function isNotInARepoWeCareAboutForRouting(payload) {
-  return !SENTRY_REPOS_WITH_ROUTING.has(payload.repository.name);
+function isNotInARepoWeCareAboutForRouting(payload, org) {
+  return !org.repos.withRouting.includes(payload.repository.name);
 }
 
 function isValidLabel(payload) {

--- a/src/brain/issueLabelHandler/triage.ts
+++ b/src/brain/issueLabelHandler/triage.ts
@@ -1,11 +1,7 @@
 import { EmitterWebhookEvent } from '@octokit/webhooks';
 import * as Sentry from '@sentry/node';
 
-import {
-  GH_ORGS,
-  SENTRY_REPOS_WITHOUT_ROUTING,
-  WAITING_FOR_PRODUCT_OWNER_LABEL,
-} from '@/config';
+import { GH_ORGS, WAITING_FOR_PRODUCT_OWNER_LABEL } from '@/config';
 import { isFromABot } from '@utils/isFromABot';
 import { isNotFromAnExternalOrGTMUser } from '@utils/isNotFromAnExternalOrGTMUser';
 import { shouldSkip } from '@utils/shouldSkip';
@@ -20,8 +16,8 @@ function isAlreadyTriaged(payload) {
   );
 }
 
-function isNotInARepoWeCareAboutForTriage(payload) {
-  return !SENTRY_REPOS_WITHOUT_ROUTING.has(payload.repository.name);
+function isNotInARepoWeCareAboutForTriage(payload, org) {
+  return !org.repos.withoutRouting.includes(payload.repository.name);
 }
 
 function isWaitingForProductOwnerLabel(payload) {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -106,58 +106,6 @@ export const WAITING_FOR_PRODUCT_OWNER_LABEL = 'Waiting for: Product Owner';
 export const MAX_TRIAGE_DAYS = 2;
 export const MAX_ROUTE_DAYS = 1;
 
-// Only add the `PERSONAL_TEST_REPO` to the array of `SENTRY_REPOS_WITH_ROUTING` if it has actually been set
-// in the instantiating environment.
-export const PERSONAL_TEST_REPO = process.env.PERSONAL_TEST_REPO;
-export const PERSONAL_TEST_REPOS = PERSONAL_TEST_REPO
-  ? [PERSONAL_TEST_REPO]
-  : [];
-
-export const SENTRY_REPOS_WITH_ROUTING: Set<string> = new Set([
-  'sentry',
-  'sentry-docs',
-  ...PERSONAL_TEST_REPOS,
-]);
-export const SENTRY_REPOS_WITHOUT_ROUTING: Set<string> = new Set([
-  'arroyo',
-  'cdc',
-  'craft',
-  'relay',
-  'responses',
-  'self-hosted',
-  'sentry-native',
-  'snuba',
-  'snuba-sdk',
-  'symbolic',
-  'symbolicator',
-  'test-ttt-simple',
-  'wal2json',
-
-  // Web team, T1
-  'sentry-javascript',
-  'sentry-python',
-  'sentry-php',
-  'sentry-laravel',
-  'sentry-symfony',
-  'sentry-ruby',
-
-  // Mobile team, T1
-  // https://www.notion.so/sentry/346452f21e7947b4bf515d5f3a4d497d?v=cad7f04cf9064e7483ab426a26d3923a
-  'sentry-cocoa',
-  'sentry-java',
-  'sentry-react-native',
-  'sentry-unity',
-  'sentry-dart',
-  'sentry-android-gradle-plugin',
-  'sentry-dotnet',
-  'sentry-dart-plugin',
-]);
-
-export const SENTRY_REPOS: Set<string> = new Set([
-  ...SENTRY_REPOS_WITH_ROUTING,
-  ...SENTRY_REPOS_WITHOUT_ROUTING,
-]);
-
 /**
  * As far as we can tell, it's not possible to check private org membership
  * from an app installation. Therefore, we use a Personal Access Token for a

--- a/src/config/loadGitHubOrgs.test.ts
+++ b/src/config/loadGitHubOrgs.test.ts
@@ -22,6 +22,7 @@ describe('loadGitHubOrgs', function () {
     }).get('getsentry');
     expect(org.appAuth.privateKey).toEqual('cheese');
     expect(org.appAuth.appId).toEqual(66573);
+    expect(org.repos.withRouting).toEqual(['sentry', 'sentry-docs']);
   });
 
   it('chokes on non-numeric appId', async function () {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -45,10 +45,16 @@ export interface GitHubIssuesSomeoneElseCaresAbout {
 }
 
 export interface GitHubOrgConfig {
-  num: any;
   slug: any;
   appAuth: any;
   project: any;
+  repos: any;
+}
+
+export interface GitHubOrgRepos {
+  all: string[];
+  withRouting: string[];
+  withoutRouting: string[];
 }
 
 export type CheckRun = EmitterWebhookEvent<'check_run'>['payload']['check_run'];

--- a/src/webhooks/pubsub/slackNotifications.ts
+++ b/src/webhooks/pubsub/slackNotifications.ts
@@ -4,9 +4,7 @@ import moment from 'moment-timezone';
 import { getLabelsTable } from '@/brain/issueNotifier';
 import {
   BACKLOG_LABEL,
-  GETSENTRY_ORG,
   PRODUCT_AREA_LABEL_PREFIX,
-  SENTRY_REPOS_WITH_ROUTING,
   WAITING_FOR_PRODUCT_OWNER_LABEL,
 } from '@/config';
 import { Issue } from '@/types';
@@ -393,16 +391,13 @@ export const notifyProductOwnersForUntriagedIssues = async (
   const getIssueSLOInfoForRepo = async (
     repo: string
   ): Promise<IssueSLOInfo[]> => {
-    const untriagedIssues = await GETSENTRY_ORG.api.paginate(
-      GETSENTRY_ORG.api.issues.listForRepo,
-      {
-        owner: GETSENTRY_ORG.slug,
-        repo,
-        state: 'open',
-        labels: WAITING_FOR_PRODUCT_OWNER_LABEL,
-        per_page: GH_API_PER_PAGE,
-      }
-    );
+    const untriagedIssues = await org.api.paginate(org.api.issues.listForRepo, {
+      owner: org.slug,
+      repo,
+      state: 'open',
+      labels: WAITING_FOR_PRODUCT_OWNER_LABEL,
+      per_page: GH_API_PER_PAGE,
+    });
 
     const issuesWithSLOInfo = untriagedIssues
       .filter(filterIssuesOnBacklog)
@@ -424,9 +419,7 @@ export const notifyProductOwnersForUntriagedIssues = async (
   };
 
   const issuesToNotifyAbout = (
-    await Promise.all(
-      [...SENTRY_REPOS_WITH_ROUTING].map(getIssueSLOInfoForRepo)
-    )
+    await Promise.all([...org.repos.withRouting].map(getIssueSLOInfoForRepo))
   ).flat();
 
   // Get an N-to-N mapping of "Product Area: *" labels to issues

--- a/src/webhooks/pubsub/stalebot.test.ts
+++ b/src/webhooks/pubsub/stalebot.test.ts
@@ -4,16 +4,9 @@ import { GETSENTRY_ORG, STALE_LABEL } from '@/config';
 
 import { triggerStaleBot } from './stalebot';
 
-jest.mock('@/config', () => {
-  const actualEnvVariables = jest.requireActual('@/config');
-  return {
-    ...actualEnvVariables,
-    SENTRY_REPOS: ['test-sentry-repo'],
-  };
-});
-
 describe('Stalebot Tests', function () {
   const org = GETSENTRY_ORG;
+  let origRepos;
 
   const issueInfo = {
     labels: [],
@@ -21,10 +14,13 @@ describe('Stalebot Tests', function () {
   };
 
   beforeEach(async function () {
+    origRepos = org.repos.all;
+    org.repos.all = ['test-sentry-repo'];
     org.api.paginate = (a, b) => a(b);
   });
 
   afterEach(async function () {
+    org.repos.all = origRepos;
     org.api.issues._labels = new Set([]);
     org.api.issues.addLabels.mockClear();
     org.api.issues.removeLabel.mockClear();

--- a/test/github-orgs.yml
+++ b/test/github-orgs.yml
@@ -8,3 +8,8 @@ getsentry:
       productArea: ''
       status: ''
       responseDue: ''
+  repos:
+    withRouting:
+      - routing-repo
+    withoutRouting:
+      - test-ttt-simple


### PR DESCRIPTION
Part of #482, after #543.

This makes the pubsub handlers multi-org by taking repos from the new `github-orgs.yml`.