### PR TITLE
Add a quick fix for sentryio deployments

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -22,7 +22,7 @@ export const GOCD_SENTRYIO_FE_PIPELINE_NAME =
 export const GOCD_SENTRYIO_BE_PIPELINE_GROUP =
   process.env.GOCD_SENTRYIO_BE_PIPELINE_GROUP || 'getsentry-backend';
 export const GOCD_SENTRYIO_BE_PIPELINE_NAME =
-  process.env.GOCD_SENTRYIO_BE_PIPELINE_NAME || 'getsentry-backend';
+  process.env.GOCD_SENTRYIO_BE_PIPELINE_NAME || 'deploy-getsentry-backend-us';
 export const GOCD_ORIGIN =
   process.env.GOCD_ORIGIN || 'https://deploy.getsentry.net';
 export const FEED_DEPLOY_CHANNEL_ID =


### PR DESCRIPTION
This will get alerts back to what they were for sentryio deployments