### PR TITLE
Allow for flexible webhook secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
           GH_APP_PRIVATE_KEY_FOR_GETSENTRY: ${{ secrets.GH_APP_PRIVATE_KEY_FOR_GETSENTRY}}
           GH_APP_IDENTIFIER: ${{ secrets.GH_APP_IDENTIFIER }}
           GH_WEBHOOK_SECRET: ${{ secrets.GH_WEBHOOK_SECRET }}
+          GH_WEBHOOK_SECRET_ALT: ${{ secrets.GH_WEBHOOK_SECRET_ALT }}
           SENTRY_WEBPACK_WEBHOOK_SECRET: ${{ secrets.SENTRY_WEBPACK_WEBHOOK_SECRET }}
           DB_USER: ${{ secrets.DB_USER }}
           DB_NAME: ${{ secrets.DB_NAME }}

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -6,6 +6,7 @@ IMAGE=gcr.io/${PROJECT}/product-eng-webhooks
 env_vars="ENV=production,"
 env_vars="${env_vars}GH_APP_PRIVATE_KEY_FOR_GETSENTRY=${GH_APP_PRIVATE_KEY_FOR_GETSENTRY},"
 env_vars="${env_vars}GH_WEBHOOK_SECRET=${GH_WEBHOOK_SECRET},"
+env_vars="${env_vars}GH_WEBHOOK_SECRET_ALT=${GH_WEBHOOK_SECRET_ALT},"
 env_vars="${env_vars}SLACK_SIGNING_SECRET=${SLACK_SIGNING_SECRET},"
 env_vars="${env_vars}SLACK_BOT_USER_ACCESS_TOKEN=${SLACK_BOT_USER_ACCESS_TOKEN},"
 env_vars="${env_vars}VERSION=${VERSION},"

--- a/src/api/github/index.ts
+++ b/src/api/github/index.ts
@@ -6,7 +6,8 @@ import { GH_USER_TOKEN } from '../../config';
 import { OctokitWithRetries } from './octokitWithRetries';
 
 const githubEvents = new Webhooks({
-  secret: process.env.GH_WEBHOOK_SECRET || '',
+  secret:
+    process.env.GH_WEBHOOK_SECRET || process.env.GH_WEBHOOK_SECRET_ALT || '',
 });
 
 // Set up default error handling in such a way that tests can override it.


### PR DESCRIPTION
Part of #482, see also #548.

We want to use the same webhook for both getsantry and covecod, but the original one is lost to us now. Having an alternative envvar will allow for seamless transition to a new webhook, which we can store in 1password for future org expansion.