### PR TITLE
Nevermind about the webhook secret alt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,6 @@ jobs:
           GH_APP_PRIVATE_KEY_FOR_GETSENTRY: ${{ secrets.GH_APP_PRIVATE_KEY_FOR_GETSENTRY}}
           GH_APP_IDENTIFIER: ${{ secrets.GH_APP_IDENTIFIER }}
           GH_WEBHOOK_SECRET: ${{ secrets.GH_WEBHOOK_SECRET }}
-          GH_WEBHOOK_SECRET_ALT: ${{ secrets.GH_WEBHOOK_SECRET_ALT }}
           SENTRY_WEBPACK_WEBHOOK_SECRET: ${{ secrets.SENTRY_WEBPACK_WEBHOOK_SECRET }}
           DB_USER: ${{ secrets.DB_USER }}
           DB_NAME: ${{ secrets.DB_NAME }}

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -6,7 +6,6 @@ IMAGE=gcr.io/${PROJECT}/product-eng-webhooks
 env_vars="ENV=production,"
 env_vars="${env_vars}GH_APP_PRIVATE_KEY_FOR_GETSENTRY=${GH_APP_PRIVATE_KEY_FOR_GETSENTRY},"
 env_vars="${env_vars}GH_WEBHOOK_SECRET=${GH_WEBHOOK_SECRET},"
-env_vars="${env_vars}GH_WEBHOOK_SECRET_ALT=${GH_WEBHOOK_SECRET_ALT},"
 env_vars="${env_vars}SLACK_SIGNING_SECRET=${SLACK_SIGNING_SECRET},"
 env_vars="${env_vars}SLACK_BOT_USER_ACCESS_TOKEN=${SLACK_BOT_USER_ACCESS_TOKEN},"
 env_vars="${env_vars}VERSION=${VERSION},"

--- a/src/api/github/index.ts
+++ b/src/api/github/index.ts
@@ -6,8 +6,7 @@ import { GH_USER_TOKEN } from '../../config';
 import { OctokitWithRetries } from './octokitWithRetries';
 
 const githubEvents = new Webhooks({
-  secret:
-    process.env.GH_WEBHOOK_SECRET || process.env.GH_WEBHOOK_SECRET_ALT || '',
+  secret: process.env.GH_WEBHOOK_SECRET || '',
 });
 
 // Set up default error handling in such a way that tests can override it.


### PR DESCRIPTION
Part of #482, reverts #550.

I was thinking about it wrong, the "or" is at startup config time, not at runtime. We still only get one secret at runtime (I did a little poking and didn't find differently). Gonna just have to run the race condition I think. :-/

## Rollout plan

- [x] Set `GH_WEBHOOK_SECRET` to the new value [in the GitHub production environment](https://github.com/getsentry/eng-pipes/settings/environments/164955041/edit).
- [ ] Merge this PR.
- [ ] Watch [the deploy log](https://github.com/getsentry/eng-pipes/actions/workflows/ci.yml?query=branch%3Amain).
- [ ] As close as possible to when this goes live, set the new secret [in GitHub app config](https://github.com/organizations/getsentry/settings/apps/getsantry).