### PR TITLE
Use git material for sha lookup

### DIFF
--- a/src/brain/gocdSlackFeeds/deployFeed.ts
+++ b/src/brain/gocdSlackFeeds/deployFeed.ts
@@ -15,7 +15,7 @@ import { GoCDModification, GoCDPipeline, GoCDResponse } from '@/types';
 import { getLastGetSentryGoCDDeploy } from '@/utils/db/getLatestDeploy';
 import { getSlackMessage } from '@/utils/db/getSlackMessage';
 import { saveSlackMessage } from '@/utils/db/saveSlackMessage';
-import { firstMaterialSHA, getProgressColor } from '@/utils/gocdHelpers';
+import { firstGitMaterialSHA, getProgressColor } from '@/utils/gocdHelpers';
 
 export class DeployFeed {
   private feedName: string;
@@ -124,7 +124,7 @@ export class DeployFeed {
       return;
     }
 
-    const latestSHA = firstMaterialSHA(latestDeploy);
+    const latestSHA = firstGitMaterialSHA(latestDeploy);
     if (!latestSHA) {
       return;
     }

--- a/src/brain/notifyOnGoCDStageEvent/index.ts
+++ b/src/brain/notifyOnGoCDStageEvent/index.ts
@@ -26,7 +26,7 @@ import { queueCommitsForDeploy } from '@/utils/db/queueCommitsForDeploy';
 import {
   ALL_MESSAGE_SUFFIX,
   FINAL_STAGE_NAMES,
-  firstMaterialSHA,
+  firstGitMaterialSHA,
   getProgressColor,
   getProgressSuffix,
 } from '@/utils/gocdHelpers';
@@ -279,7 +279,7 @@ export async function handler(resBody: GoCDResponse) {
     const commits = await getCommitsInDeployment(
       GETSENTRY_ORG,
       sha,
-      firstMaterialSHA(latestDeploy)
+      firstGitMaterialSHA(latestDeploy)
     );
     const relevantCommitShas: string[] = await filterCommits(pipeline, commits);
 

--- a/src/brain/pleaseDeployNotifier/actionViewUndeployedCommits.ts
+++ b/src/brain/pleaseDeployNotifier/actionViewUndeployedCommits.ts
@@ -6,7 +6,7 @@ import {
   GOCD_SENTRYIO_BE_PIPELINE_GROUP,
   GOCD_SENTRYIO_BE_PIPELINE_NAME,
 } from '@/config';
-import { firstMaterialSHA } from '@/utils/gocdHelpers';
+import { firstGitMaterialSHA } from '@/utils/gocdHelpers';
 import { getBlocksForCommit } from '@api/getBlocksForCommit';
 import { getRelevantCommit } from '@api/github/getRelevantCommit';
 import { getLastGetSentryGoCDDeploy } from '@utils/db/getLatestDeploy';
@@ -66,7 +66,7 @@ export async function actionViewUndeployedCommits({
     return;
   }
 
-  const base = firstMaterialSHA(lastDeploy);
+  const base = firstGitMaterialSHA(lastDeploy);
   if (!base) {
     // Failed to get base sha
     return;

--- a/src/utils/gocdHelpers.test.ts
+++ b/src/utils/gocdHelpers.test.ts
@@ -1,22 +1,25 @@
-import { firstMaterialSHA } from '@/utils/gocdHelpers';
+import { firstGitMaterialSHA } from '@/utils/gocdHelpers';
 
-describe('firstMaterialSHA', () => {
+describe('firstGitMaterialSHA', () => {
   it('return nothing for no deploy', async function () {
-    const got = firstMaterialSHA(null);
+    const got = firstGitMaterialSHA(null);
     expect(got).toEqual(null);
   });
 
   it('return nothing no build materials', async function () {
-    const got = firstMaterialSHA({
+    const got = firstGitMaterialSHA({
       pipeline_build_cause: [],
     });
     expect(got).toEqual(null);
   });
 
-  it('return nothing no modifications', async function () {
-    const got = firstMaterialSHA({
+  it('return nothing for no modifications', async function () {
+    const got = firstGitMaterialSHA({
       pipeline_build_cause: [
         {
+          material: {
+            type: 'git',
+          },
           modifications: [],
         },
       ],
@@ -24,10 +27,31 @@ describe('firstMaterialSHA', () => {
     expect(got).toEqual(null);
   });
 
-  it('return first material sha', async function () {
-    const got = firstMaterialSHA({
+  it('return null for non-git material sha', async function () {
+    const got = firstGitMaterialSHA({
       pipeline_build_cause: [
         {
+          material: {
+            type: 'other',
+          },
+          modifications: [
+            {
+              revision: 'example-pipeline/1/example-stage',
+            },
+          ],
+        },
+      ],
+    });
+    expect(got).toEqual(null);
+  });
+
+  it('return first material sha', async function () {
+    const got = firstGitMaterialSHA({
+      pipeline_build_cause: [
+        {
+          material: {
+            type: 'git',
+          },
           modifications: [
             {
               revision: 'abc123',

--- a/src/utils/gocdHelpers.ts
+++ b/src/utils/gocdHelpers.ts
@@ -78,7 +78,7 @@ export function getProgressColor(pipeline: GoCDPipeline) {
   }
 }
 
-export function firstMaterialSHA(
+export function firstGitMaterialSHA(
   deploy: DBGoCDDeployment | undefined
 ): string | null {
   if (!deploy) {
@@ -87,9 +87,14 @@ export function firstMaterialSHA(
   if (deploy.pipeline_build_cause.length == 0) {
     return null;
   }
-  const bc = deploy.pipeline_build_cause[0];
-  if (bc.modifications.length == 0) {
-    return null;
+  for (const bc of deploy.pipeline_build_cause) {
+    if (!bc.material || bc.material.type != 'git') {
+      continue;
+    }
+    if (bc.modifications.length == 0) {
+      continue;
+    }
+    return bc.modifications[0].revision;
   }
-  return bc.modifications[0].revision;
+  return null;
 }


### PR DESCRIPTION
This is a quick fix but should be improved to look for a specific repo.

With pipedream, the first material for getsentry deployments is no longer a git repo, it's the upstream pipeline followed by the getsentry repo material.

This change brings back the old behavior and fixes these errors: https://sentry.sentry.io/issues/4264068988/?query=start%3D2023-07-25T06%3A41%3A00%26end%3D2023-07-26T20%3A50%3A50%26groupStatsPeriod%3Dauto&referrer=alerts-related-issues-issue-stream