### PR TITLE
Avoid adding waiting for product owner if issue is unrouted

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -7,6 +7,7 @@ GH_APP_SECRET_KEY="top \nsecret\n key"
 GH_ORGS_YML="test/github-orgs.yml"
 SENTRY_REPO_SLUG="sentry"
 GETSENTRY_REPO_SLUG="getsentry"
+GETSENTRY_ORG_SLUG="getsentry"
 
 # Slack
 SLACK_SIGNING_SECRET="slacksigningsecret"

--- a/github-orgs.example.yml
+++ b/github-orgs.example.yml
@@ -2,6 +2,7 @@ your-org-CHANGEME:
   appAuth:
     appId: ''
     privateKey: 'GH_APP_PRIVATE_KEY' # leave this, it names an env var to pull from
+    installationId: ''
   project:
     nodeId: ''
     fieldIds:

--- a/src/brain/issueLabelHandler/followups.ts
+++ b/src/brain/issueLabelHandler/followups.ts
@@ -25,6 +25,10 @@ function isNotWaitingForLabel(payload) {
   return !payload.label?.name.startsWith(WAITING_FOR_LABEL_PREFIX);
 }
 
+function isWaitingForSupport(payload) {
+  return payload.label?.name === WAITING_FOR_SUPPORT_LABEL;
+}
+
 function isContractor(payload) {
   // Contractors are outside collaborators on GitHub
   return payload.comment.author_association === 'COLLABORATOR';
@@ -51,6 +55,7 @@ export async function updateCommunityFollowups({
   const reasonsToDoNothing = [
     isNotInARepoWeCareAboutForFollowups,
     isNotFromAnExternalOrGTMUser,
+    isWaitingForSupport,
     isContractor,
     isPullRequest,
     isFromABot,

--- a/src/brain/issueLabelHandler/followups.ts
+++ b/src/brain/issueLabelHandler/followups.ts
@@ -26,7 +26,9 @@ function isNotWaitingForLabel(payload) {
 }
 
 function isWaitingForSupport(payload) {
-  return payload.label?.name === WAITING_FOR_SUPPORT_LABEL;
+  return payload.issue.labels.some(
+    ({ name }) => name === WAITING_FOR_SUPPORT_LABEL
+  );
 }
 
 function isContractor(payload) {

--- a/src/brain/issueLabelHandler/index.test.ts
+++ b/src/brain/issueLabelHandler/index.test.ts
@@ -598,6 +598,15 @@ describe('issueLabelHandler', function () {
       expect(org.api.issues._labels).toEqual(new Set([]));
     });
 
+    it('should not add `Waiting for: Product Owner` label when community member comments and issue is waiting for support', async function () {
+      await createPR('routing-repo');
+      await addLabel(WAITING_FOR_SUPPORT_LABEL);
+      await addComment('routing-repo', 'Skywalker', true);
+      expect(org.api.issues._labels).toEqual(
+        new Set([WAITING_FOR_SUPPORT_LABEL])
+      );
+    });
+
     it('should add `Waiting for: Product Owner` label when community member comments and issue is not waiting for community', async function () {
       await setupIssue();
       await addComment('routing-repo', 'Skywalker');


### PR DESCRIPTION
Bug seen here:
https://github.com/getsentry/self-hosted/issues/2305

User files issue, `Waiting for: Support` is added.
User comments on ticket. `Waiting for: Product Owner` is added without a product area.