### PR TITLE
Clear issue status on label removal from user

### DIFF
--- a/src/api/github/org.ts
+++ b/src/api/github/org.ts
@@ -157,6 +157,32 @@ export class GitHubOrg {
     await this.sendGraphQuery(modifyProjectIssueFieldMutation, data);
   }
 
+  async clearProjectIssueField(
+    itemId: string,
+    projectFieldOption: string,
+    fieldId: string
+  ) {
+    const modifyProjectIssueFieldMutation = `mutation {
+      clearProjectV2ItemFieldValue(
+        input: {
+          projectId: "${this.project.nodeId}"
+          itemId: "${itemId}"
+          fieldId: "${fieldId}"
+        }
+      ) {
+        projectV2Item {
+          id
+        }
+      }
+    }`;
+    const data = {
+      itemId,
+      projectFieldOption,
+      fieldId,
+    };
+    await this.sendGraphQuery(modifyProjectIssueFieldMutation, data);
+  }
+
   async modifyDueByDate(
     itemId: string,
     projectFieldOption: string,

--- a/src/brain/issueLabelHandler/followups.ts
+++ b/src/brain/issueLabelHandler/followups.ts
@@ -112,7 +112,7 @@ export async function clearWaitingForProductOwnerStatus({
 }: EmitterWebhookEvent<'issues.unlabeled'>) {
   const tx = Sentry.startTransaction({
     op: 'brain',
-    name: 'issueLabelHandler.isNotWaitingForProductOwnerLabel',
+    name: 'issueLabelHandler.clearWaitingForProductOwnerStatus',
   });
 
   const org = GH_ORGS.getForPayload(payload);
@@ -129,8 +129,12 @@ export async function clearWaitingForProductOwnerStatus({
   const { label } = payload;
   const repo = payload.repository.name;
   const issueNumber = payload.issue.number;
-  // Here label will never be undefined, ts is erroring here but is handled in the shouldSkip above
-  // @ts-ignore
+  if (label.name === undefined) {
+    Sentry.captureException(
+      `Webhook label name is undefined for ${repo}/${issueNumber}`
+    );
+    return;
+  }
   const labelName = label.name;
 
   const itemId: string = await org.addIssueToGlobalIssuesProject(
@@ -171,8 +175,12 @@ export async function ensureOneWaitingForLabel({
   const { issue, label } = payload;
   const repo = payload.repository.name;
   const issueNumber = payload.issue.number;
-  // Here label will never be undefined, ts is erroring here but is handled in the shouldSkip above
-  // @ts-ignore
+  if (label.name === undefined) {
+    Sentry.captureException(
+      `Webhook label name is undefined for ${repo}/${issueNumber}`
+    );
+    return;
+  }
   const labelName = label.name;
 
   const labelToRemove = issue.labels?.find(

--- a/src/brain/issueLabelHandler/followups.ts
+++ b/src/brain/issueLabelHandler/followups.ts
@@ -105,6 +105,49 @@ export async function updateCommunityFollowups({
   tx.finish();
 }
 
+export async function clearWaitingForProductOwnerStatus({
+  id,
+  payload,
+  ...rest
+}: EmitterWebhookEvent<'issues.unlabeled'>) {
+  const tx = Sentry.startTransaction({
+    op: 'brain',
+    name: 'issueLabelHandler.isNotWaitingForProductOwnerLabel',
+  });
+
+  const org = GH_ORGS.getForPayload(payload);
+
+  const reasonsToDoNothing = [
+    isNotInARepoWeCareAboutForFollowups,
+    isNotWaitingForLabel,
+    isFromABot,
+  ];
+  if (await shouldSkip(payload, org, reasonsToDoNothing)) {
+    return;
+  }
+
+  const { label } = payload;
+  const repo = payload.repository.name;
+  const issueNumber = payload.issue.number;
+  // Here label will never be undefined, ts is erroring here but is handled in the shouldSkip above
+  // @ts-ignore
+  const labelName = label.name;
+
+  const itemId: string = await org.addIssueToGlobalIssuesProject(
+    payload.issue.node_id,
+    repo,
+    issueNumber
+  );
+
+  await org.clearProjectIssueField(
+    itemId,
+    labelName,
+    org.project.fieldIds.status
+  );
+
+  tx.finish();
+}
+
 export async function ensureOneWaitingForLabel({
   id,
   payload,

--- a/src/brain/issueLabelHandler/followups.ts
+++ b/src/brain/issueLabelHandler/followups.ts
@@ -129,7 +129,7 @@ export async function clearWaitingForProductOwnerStatus({
   const { label } = payload;
   const repo = payload.repository.name;
   const issueNumber = payload.issue.number;
-  if (label.name === undefined) {
+  if (label?.name == null) {
     Sentry.captureException(
       `Webhook label name is undefined for ${repo}/${issueNumber}`
     );
@@ -175,7 +175,7 @@ export async function ensureOneWaitingForLabel({
   const { issue, label } = payload;
   const repo = payload.repository.name;
   const issueNumber = payload.issue.number;
-  if (label.name === undefined) {
+  if (label?.name == null) {
     Sentry.captureException(
       `Webhook label name is undefined for ${repo}/${issueNumber}`
     );

--- a/src/brain/issueLabelHandler/index.test.ts
+++ b/src/brain/issueLabelHandler/index.test.ts
@@ -153,21 +153,6 @@ describe('issueLabelHandler', function () {
     );
   }
 
-  async function removeLabel(label: string, repo?: string, sender?: string) {
-    await createGitHubEvent(
-      fastify,
-      'issues.unlabeled',
-      makePayload({
-        repo,
-        label,
-        sender,
-        state: undefined,
-        author_association: undefined,
-      })
-    );
-    org.api.issues.removeLabel(label);
-  }
-
   async function addLabel(label: string, repo?: string, state?: string) {
     await createGitHubEvent(
       fastify,
@@ -778,7 +763,18 @@ describe('issueLabelHandler', function () {
       async function (label) {
         await setupIssue();
         await addLabel(label, 'routing-repo');
-        await removeLabel(label);
+        await createGitHubEvent(
+          fastify,
+          'issues.unlabeled',
+          makePayload({
+            repo: 'routing-repo',
+            label,
+            sender: undefined,
+            state: undefined,
+            author_association: undefined,
+          })
+        );
+        org.api.issues.removeLabel(label);
         expect(clearProjectIssueFieldSpy).toHaveBeenLastCalledWith(
           'itemId',
           label,
@@ -796,7 +792,18 @@ describe('issueLabelHandler', function () {
       async function (label) {
         await setupIssue();
         await addLabel(label, 'routing-repo');
-        await removeLabel(label, undefined, 'getsentry-bot');
+        await createGitHubEvent(
+          fastify,
+          'issues.unlabeled',
+          makePayload({
+            repo: 'routing-repo',
+            label,
+            sender: 'getsentry-bot',
+            state: undefined,
+            author_association: undefined,
+          })
+        );
+        org.api.issues.removeLabel(label);
         expect(clearProjectIssueFieldSpy).not.toHaveBeenCalled();
       }
     );

--- a/src/brain/issueLabelHandler/index.ts
+++ b/src/brain/issueLabelHandler/index.ts
@@ -1,6 +1,7 @@
 import { githubEvents } from '@api/github';
 
 import {
+  clearWaitingForProductOwnerStatus,
   ensureOneWaitingForLabel,
   updateCommunityFollowups,
 } from './followups';
@@ -28,4 +29,9 @@ export async function issueLabelHandler() {
   githubEvents.on('issue_comment.created', updateCommunityFollowups);
   githubEvents.removeListener('issues.labeled', ensureOneWaitingForLabel);
   githubEvents.on('issues.labeled', ensureOneWaitingForLabel);
+  githubEvents.removeListener(
+    'issues.unlabeled',
+    clearWaitingForProductOwnerStatus
+  );
+  githubEvents.on('issues.unlabeled', clearWaitingForProductOwnerStatus);
 }

--- a/test/github-orgs.yml
+++ b/test/github-orgs.yml
@@ -4,11 +4,11 @@ getsentry:
     privateKey: 'STUB'
     installationId: -1
   project:
-    nodeId: ''
+    nodeId: 'projectNodeId'
     fieldIds:
-      productArea: ''
-      status: ''
-      responseDue: ''
+      productArea: 'productAreaFieldId'
+      status: 'statusFieldId'
+      responseDue: 'responseDueFieldId'
   repos:
     withRouting:
       - routing-repo


### PR DESCRIPTION
When a user removes a `Waiting for: *` label from an issue, clear status in `Issues Someone Else Cares About` board. If it's a bot, don't clear, since the bot will only unlabel issues when it is about to add another one.