### PR TITLE
Update traffic after deploy

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -27,5 +27,6 @@ gcloud run deploy product-eng-webhooks \
   --allow-unauthenticated \
   --add-cloudsql-instances ${DB_INSTANCE_CONNECTION_NAME} \
   --region=us-west1
+gcloud run services update-traffic product-eng-webhooks --to-latest
 
 


### PR DESCRIPTION
From [docs](https://cloud.google.com/sdk/gcloud/reference/run/deploy):
```
To restore sending traffic to the LATEST revision by default, run the [gcloud run services update-traffic](https://cloud.google.com/sdk/gcloud/reference/run/services/update-traffic) command with --to-latest.
```

Not sure when it started happening, but traffic is not being rerouted to the latest version after deploys. This happens even in a successful deploy job. [Example](https://github.com/getsentry/eng-pipes/actions/runs/5697087690/job/15489754357)

Hopefully this fixes it