### PR TITLE
Adding url_prefix to Sentry Release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,3 +145,4 @@ jobs:
         with:
           environment: 'production'
           sourcemaps: './lib'
+          url_prefix: 'app:///lib/'


### PR DESCRIPTION
After doing some investigating into what is causing the source maps to not work correctly, I realized we may need to include a `url_prefix`.