### PR TITLE
Remove `Waiting for: Product Owner` on staff or collaborator comments

### DIFF
--- a/src/api/github/org.ts
+++ b/src/api/github/org.ts
@@ -157,11 +157,7 @@ export class GitHubOrg {
     await this.sendGraphQuery(modifyProjectIssueFieldMutation, data);
   }
 
-  async clearProjectIssueField(
-    itemId: string,
-    projectFieldOption: string,
-    fieldId: string
-  ) {
+  async clearProjectIssueField(itemId: string, fieldId: string) {
     const modifyProjectIssueFieldMutation = `mutation {
       clearProjectV2ItemFieldValue(
         input: {
@@ -177,7 +173,6 @@ export class GitHubOrg {
     }`;
     const data = {
       itemId,
-      projectFieldOption,
       fieldId,
     };
     await this.sendGraphQuery(modifyProjectIssueFieldMutation, data);

--- a/src/brain/issueLabelHandler/followups.ts
+++ b/src/brain/issueLabelHandler/followups.ts
@@ -86,15 +86,14 @@ export async function updateFollowupsOnComment({
         issue_number: issueNumber,
         name: WAITING_FOR_PRODUCT_OWNER_LABEL,
       });
+      const itemId: string = await org.addIssueToGlobalIssuesProject(
+        payload.issue.node_id,
+        repo,
+        issueNumber
+      );
+
+      await org.clearProjectIssueField(itemId, org.project.fieldIds.status);
     }
-
-    const itemId: string = await org.addIssueToGlobalIssuesProject(
-      payload.issue.node_id,
-      repo,
-      issueNumber
-    );
-
-    await org.clearProjectIssueField(itemId, org.project.fieldIds.status);
   } else {
     const isWaitingForCommunityLabelOnIssue = isLabelOnIssue(
       WAITING_FOR_COMMUNITY_LABEL

--- a/src/brain/issueLabelHandler/followups.ts
+++ b/src/brain/issueLabelHandler/followups.ts
@@ -42,22 +42,20 @@ function isPullRequest(payload) {
 
 // Markers of State
 
-export async function updateCommunityFollowups({
+export async function updateFollowupsOnComment({
   id,
   payload,
   ...rest
 }: EmitterWebhookEvent<'issue_comment.created'>) {
   const tx = Sentry.startTransaction({
     op: 'brain',
-    name: 'issueLabelHandler.updateCommunityFollowups',
+    name: 'issueLabelHandler.updateFollowupsOnComment',
   });
 
   const org = GH_ORGS.getForPayload(payload);
 
   const reasonsToDoNothing = [
     isNotInARepoWeCareAboutForFollowups,
-    isNotFromAnExternalOrGTMUser,
-    isCommentFromCollaborator,
     isWaitingForSupport,
     isPullRequest,
     isFromABot,
@@ -70,37 +68,66 @@ export async function updateCommunityFollowups({
   const repo = payload.repository.name;
   const issueNumber = payload.issue.number;
 
-  const isWaitingForCommunityLabelOnIssue = payload.issue.labels?.find(
-    ({ name }) => name === WAITING_FOR_COMMUNITY_LABEL
-  )?.name;
+  const isLabelOnIssue = (labelName) =>
+    payload.issue.labels?.find(({ name }) => name === labelName)?.name;
 
-  if (isWaitingForCommunityLabelOnIssue) {
-    await org.api.issues.removeLabel({
+  if (
+    (await isNotFromAnExternalOrGTMUser(payload)) ||
+    isCommentFromCollaborator(payload)
+  ) {
+    const isWaitingForProductOwnerLabelOnIssue = isLabelOnIssue(
+      WAITING_FOR_PRODUCT_OWNER_LABEL
+    );
+
+    if (isWaitingForProductOwnerLabelOnIssue) {
+      await org.api.issues.removeLabel({
+        owner: org.slug,
+        repo: repo,
+        issue_number: issueNumber,
+        name: WAITING_FOR_PRODUCT_OWNER_LABEL,
+      });
+    }
+
+    const itemId: string = await org.addIssueToGlobalIssuesProject(
+      payload.issue.node_id,
+      repo,
+      issueNumber
+    );
+
+    await org.clearProjectIssueField(itemId, org.project.fieldIds.status);
+  } else {
+    const isWaitingForCommunityLabelOnIssue = isLabelOnIssue(
+      WAITING_FOR_COMMUNITY_LABEL
+    );
+
+    if (isWaitingForCommunityLabelOnIssue) {
+      await org.api.issues.removeLabel({
+        owner: org.slug,
+        repo: repo,
+        issue_number: issueNumber,
+        name: WAITING_FOR_COMMUNITY_LABEL,
+      });
+    }
+
+    await org.api.issues.addLabels({
       owner: org.slug,
       repo: repo,
       issue_number: issueNumber,
-      name: WAITING_FOR_COMMUNITY_LABEL,
+      labels: [WAITING_FOR_PRODUCT_OWNER_LABEL],
     });
+
+    const itemId: string = await org.addIssueToGlobalIssuesProject(
+      payload.issue.node_id,
+      repo,
+      issueNumber
+    );
+
+    await org.modifyProjectIssueField(
+      itemId,
+      WAITING_FOR_PRODUCT_OWNER_LABEL,
+      org.project.fieldIds.status
+    );
   }
-
-  await org.api.issues.addLabels({
-    owner: org.slug,
-    repo: repo,
-    issue_number: issueNumber,
-    labels: [WAITING_FOR_PRODUCT_OWNER_LABEL],
-  });
-
-  const itemId: string = await org.addIssueToGlobalIssuesProject(
-    payload.issue.node_id,
-    repo,
-    issueNumber
-  );
-
-  await org.modifyProjectIssueField(
-    itemId,
-    WAITING_FOR_PRODUCT_OWNER_LABEL,
-    org.project.fieldIds.status
-  );
 
   tx.finish();
 }
@@ -135,7 +162,6 @@ export async function clearWaitingForProductOwnerStatus({
     );
     return;
   }
-  const labelName = label.name;
 
   const itemId: string = await org.addIssueToGlobalIssuesProject(
     payload.issue.node_id,
@@ -143,11 +169,7 @@ export async function clearWaitingForProductOwnerStatus({
     issueNumber
   );
 
-  await org.clearProjectIssueField(
-    itemId,
-    labelName,
-    org.project.fieldIds.status
-  );
+  await org.clearProjectIssueField(itemId, org.project.fieldIds.status);
 
   tx.finish();
 }

--- a/src/brain/issueLabelHandler/index.test.ts
+++ b/src/brain/issueLabelHandler/index.test.ts
@@ -691,6 +691,28 @@ describe('issueLabelHandler', function () {
       );
     });
 
+    it('should remove `Waiting for: Product Owner` label when staff member comments and issue is waiting for community', async function () {
+      await setupIssue();
+      await addLabel(WAITING_FOR_PRODUCT_OWNER_LABEL, 'routing-repo');
+      await addComment('routing-repo', 'Picard');
+      expect(org.api.issues._labels).toEqual(new Set(['Product Area: Test']));
+      expect(clearProjectIssueFieldSpy).toHaveBeenLastCalledWith(
+        'itemId',
+        org.project.fieldIds.status
+      );
+    });
+
+    it('should remove `Waiting for: Product Owner` label when collaborator comments and issue is waiting for community', async function () {
+      await setupIssue();
+      await addLabel(WAITING_FOR_PRODUCT_OWNER_LABEL, 'routing-repo');
+      await addComment('routing-repo', 'Troi');
+      expect(org.api.issues._labels).toEqual(new Set(['Product Area: Test']));
+      expect(clearProjectIssueFieldSpy).toHaveBeenLastCalledWith(
+        'itemId',
+        org.project.fieldIds.status
+      );
+    });
+
     it('should modify time to respond by when adding `Waiting for: Product Owner` label when calculateSLOViolationTriage returns null', async function () {
       await setupIssue();
       calculateSLOViolationTriageSpy.mockReturnValue(null);
@@ -738,7 +760,7 @@ describe('issueLabelHandler', function () {
     it('should not modify labels when community member comments and issue is waiting for product owner', async function () {
       await setupIssue();
       await addLabel(WAITING_FOR_PRODUCT_OWNER_LABEL, 'routing-repo');
-      await addComment('routing-repo', 'Picard');
+      await addComment('routing-repo', 'Skywalker');
       expect(org.api.issues._labels).toEqual(
         new Set(['Product Area: Test', WAITING_FOR_PRODUCT_OWNER_LABEL])
       );
@@ -777,7 +799,6 @@ describe('issueLabelHandler', function () {
         org.api.issues.removeLabel(label);
         expect(clearProjectIssueFieldSpy).toHaveBeenLastCalledWith(
           'itemId',
-          label,
           org.project.fieldIds.status
         );
       }

--- a/src/brain/issueLabelHandler/index.test.ts
+++ b/src/brain/issueLabelHandler/index.test.ts
@@ -691,7 +691,7 @@ describe('issueLabelHandler', function () {
       );
     });
 
-    it('should remove `Waiting for: Product Owner` label when staff member comments and issue is waiting for community', async function () {
+    it('should remove `Waiting for: Product Owner` label when staff member comments and issue is waiting for product owner', async function () {
       await setupIssue();
       await addLabel(WAITING_FOR_PRODUCT_OWNER_LABEL, 'routing-repo');
       await addComment('routing-repo', 'Picard');
@@ -702,7 +702,20 @@ describe('issueLabelHandler', function () {
       );
     });
 
-    it('should remove `Waiting for: Product Owner` label when collaborator comments and issue is waiting for community', async function () {
+    it('should not remove `Waiting for: Community` label when staff member comments and issue is waiting for community', async function () {
+      await setupIssue();
+      await addLabel(WAITING_FOR_COMMUNITY_LABEL, 'routing-repo');
+      await addComment('routing-repo', 'Picard');
+      expect(org.api.issues._labels).toEqual(
+        new Set(['Product Area: Test', WAITING_FOR_COMMUNITY_LABEL])
+      );
+      expect(clearProjectIssueFieldSpy).not.toHaveBeenLastCalledWith(
+        'itemId',
+        org.project.fieldIds.status
+      );
+    });
+
+    it('should remove `Waiting for: Product Owner` label when collaborator comments and issue is waiting for product owner', async function () {
       await setupIssue();
       await addLabel(WAITING_FOR_PRODUCT_OWNER_LABEL, 'routing-repo');
       await addComment('routing-repo', 'Troi');

--- a/src/brain/issueLabelHandler/index.test.ts
+++ b/src/brain/issueLabelHandler/index.test.ts
@@ -691,7 +691,7 @@ describe('issueLabelHandler', function () {
       );
     });
 
-    it('should remove `Waiting for: Product Owner` label when staff member comments and issue is waiting for product owner', async function () {
+    it('should remove `Waiting for: Product Owner` label when staff member comments and issue already has `Waiting for: Product Owner` label', async function () {
       await setupIssue();
       await addLabel(WAITING_FOR_PRODUCT_OWNER_LABEL, 'routing-repo');
       await addComment('routing-repo', 'Picard');
@@ -702,7 +702,7 @@ describe('issueLabelHandler', function () {
       );
     });
 
-    it('should not remove `Waiting for: Community` label when staff member comments and issue is waiting for community', async function () {
+    it('should not remove `Waiting for: Community` label when staff member comments and issue has `Waiting for: Community` label', async function () {
       await setupIssue();
       await addLabel(WAITING_FOR_COMMUNITY_LABEL, 'routing-repo');
       await addComment('routing-repo', 'Picard');
@@ -715,7 +715,7 @@ describe('issueLabelHandler', function () {
       );
     });
 
-    it('should remove `Waiting for: Product Owner` label when collaborator comments and issue is waiting for product owner', async function () {
+    it('should remove `Waiting for: Product Owner` label when collaborator comments and issue already has `Waiting for: Product Owner` label', async function () {
       await setupIssue();
       await addLabel(WAITING_FOR_PRODUCT_OWNER_LABEL, 'routing-repo');
       await addComment('routing-repo', 'Troi');

--- a/src/brain/issueLabelHandler/index.ts
+++ b/src/brain/issueLabelHandler/index.ts
@@ -3,7 +3,7 @@ import { githubEvents } from '@api/github';
 import {
   clearWaitingForProductOwnerStatus,
   ensureOneWaitingForLabel,
-  updateCommunityFollowups,
+  updateFollowupsOnComment,
 } from './followups';
 import { markNotWaitingForSupport, markWaitingForSupport } from './route';
 import {
@@ -24,9 +24,9 @@ export async function issueLabelHandler() {
   githubEvents.on('issues.labeled', markNotWaitingForSupport);
   githubEvents.removeListener(
     'issue_comment.created',
-    updateCommunityFollowups
+    updateFollowupsOnComment
   );
-  githubEvents.on('issue_comment.created', updateCommunityFollowups);
+  githubEvents.on('issue_comment.created', updateFollowupsOnComment);
   githubEvents.removeListener('issues.labeled', ensureOneWaitingForLabel);
   githubEvents.on('issues.labeled', ensureOneWaitingForLabel);
   githubEvents.removeListener(


### PR DESCRIPTION
If a staff member or contractor comments on an issue that is `Waiting for: Product Owner`, remove the label.