### PR TITLE
Adding logic to properly handle gocd events without a group defined

### DIFF
--- a/src/api/gocdevents/index.test.ts
+++ b/src/api/gocdevents/index.test.ts
@@ -20,11 +20,36 @@ describe('gocdevents', function () {
     gocdevents.on('stage', stageSpy);
     gocdevents.on('agent', agentSpy);
 
-    gocdevents.emit('stage', {});
-    gocdevents.emit('agent', {});
+    gocdevents.emit('stage', {
+      data: {
+        pipeline: { name: 'test-name', group: 'test-group' },
+      },
+    });
+    gocdevents.emit('agent', {
+      data: {
+        pipeline: { name: 'test-name', group: 'test-group' },
+      },
+    });
 
     expect(starSpy).toHaveBeenCalledTimes(2);
     expect(stageSpy).toHaveBeenCalledTimes(1);
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('do not emit stage when no group is provided', () => {
+    const starSpy = jest.fn();
+    const stageSpy = jest.fn();
+    const agentSpy = jest.fn();
+
+    gocdevents.on('*', starSpy);
+    gocdevents.on('stage', stageSpy);
+    gocdevents.on('agent', agentSpy);
+
+    gocdevents.emit('stage', { data: { pipeline: { name: 'test-name' } } });
+    gocdevents.emit('agent', { data: { pipeline: { name: 'test-name' } } });
+
+    expect(starSpy).toHaveBeenCalledTimes(1);
+    expect(stageSpy).toHaveBeenCalledTimes(0);
     expect(agentSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/api/gocdevents/index.test.ts
+++ b/src/api/gocdevents/index.test.ts
@@ -25,11 +25,7 @@ describe('gocdevents', function () {
         pipeline: { name: 'test-name', group: 'test-group' },
       },
     });
-    gocdevents.emit('agent', {
-      data: {
-        pipeline: { name: 'test-name', group: 'test-group' },
-      },
-    });
+    gocdevents.emit('agent', {});
 
     expect(starSpy).toHaveBeenCalledTimes(2);
     expect(stageSpy).toHaveBeenCalledTimes(1);
@@ -39,17 +35,13 @@ describe('gocdevents', function () {
   it('do not emit stage when no group is provided', () => {
     const starSpy = jest.fn();
     const stageSpy = jest.fn();
-    const agentSpy = jest.fn();
 
     gocdevents.on('*', starSpy);
     gocdevents.on('stage', stageSpy);
-    gocdevents.on('agent', agentSpy);
 
     gocdevents.emit('stage', { data: { pipeline: { name: 'test-name' } } });
-    gocdevents.emit('agent', { data: { pipeline: { name: 'test-name' } } });
 
-    expect(starSpy).toHaveBeenCalledTimes(1);
+    expect(starSpy).toHaveBeenCalledTimes(0);
     expect(stageSpy).toHaveBeenCalledTimes(0);
-    expect(agentSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/api/gocdevents/index.ts
+++ b/src/api/gocdevents/index.ts
@@ -13,6 +13,8 @@ interface GoCDEventEmitter {
  */
 class GoCDEventEmitter extends EventEmitter {
   emit(event: GoCDEvents, reqBody: GoCDResponse) {
+    // During GoCD deployments, group name is initially missing
+    if (event === 'stage' && !reqBody.data.pipeline.group) return;
     super.emit('*', reqBody);
     return super.emit(event, reqBody);
   }

--- a/src/api/gocdevents/index.ts
+++ b/src/api/gocdevents/index.ts
@@ -14,7 +14,7 @@ interface GoCDEventEmitter {
 class GoCDEventEmitter extends EventEmitter {
   emit(event: GoCDEvents, reqBody: GoCDResponse) {
     // During GoCD deployments, group name is initially missing
-    if (event === 'stage' && !reqBody.data.pipeline.group) return;
+    if (event === 'stage' && !reqBody.data.pipeline.group) return false;
     super.emit('*', reqBody);
     return super.emit(event, reqBody);
   }


### PR DESCRIPTION
We were getting undefined group names and other errors due to undefined groups in slack messages.