### PR TITLE
Improve build cause filtering

### DIFF
--- a/src/brain/notifyOnGoCDStageEvent/index.ts
+++ b/src/brain/notifyOnGoCDStageEvent/index.ts
@@ -29,6 +29,7 @@ import {
   firstGitMaterialSHA,
   getProgressColor,
   getProgressSuffix,
+  filterBuildCauses,
 } from '@/utils/gocdHelpers';
 import { getUser } from '@api/getUser';
 import { GitHubOrg } from '@api/github/org';
@@ -259,7 +260,7 @@ export async function handler(resBody: GoCDResponse) {
   }
 
   // This is not a getsentry deploy.
-  const sha = getGetsentrySHA(pipeline['build-cause']);
+  const sha = getGetsentrySHA(filterBuildCauses(pipeline, 'git'));
   if (!sha) {
     return;
   }

--- a/src/brain/saveGoCDStageEvents/index.ts
+++ b/src/brain/saveGoCDStageEvents/index.ts
@@ -1,4 +1,5 @@
 import { DBGoCDBuildMaterial, GoCDPipeline, GoCDResponse } from '@/types';
+import {filterBuildCauses} from '@utils/gocdHelpers';
 import { gocdevents } from '@api/gocdevents';
 import { db } from '@utils/db';
 
@@ -50,15 +51,8 @@ export async function handler(resBody: GoCDResponse) {
 
 async function saveBuildMaterials(pipeline_id: string, pipeline: GoCDPipeline) {
   const gitMaterials: Array<DBGoCDBuildMaterial> = [];
-  for (const bc of pipeline['build-cause']) {
-    if (!bc.material || bc.material.type != 'git') {
-      // The material may be an upstream pipeline
-      continue;
-    }
-    if (bc.modifications.length == 0) {
-      continue;
-    }
-
+  const buildCauses = filterBuildCauses(pipeline, 'git');
+  for (const bc of buildCauses) {
     const gitConfig = bc.material['git-configuration'];
     const modification = bc.modifications[0];
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -117,7 +117,7 @@ interface GoCDJob {
 export interface GoCDBuildCause {
   material: {
     'git-configuration': GoCDGitConfiguration;
-    type: string;
+    type: GoCDBuildType;
   };
   changed: boolean;
   modifications: Array<GoCDModification>;
@@ -170,3 +170,5 @@ type GoCDApprovalType = 'success' | 'manual';
 type GoCDResultType = 'Passed' | 'Failed' | 'Cancelled' | 'Unknown';
 
 type GoCDStateType = 'Passed' | 'Failed' | 'Cancelled' | 'Building';
+
+type GoCDBuildType = 'git';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -171,4 +171,4 @@ type GoCDResultType = 'Passed' | 'Failed' | 'Cancelled' | 'Unknown';
 
 type GoCDStateType = 'Passed' | 'Failed' | 'Cancelled' | 'Building';
 
-type GoCDBuildType = 'git';
+export type GoCDBuildType = 'git' | 'pipeline';

--- a/src/utils/gocdHelpers.test.ts
+++ b/src/utils/gocdHelpers.test.ts
@@ -1,4 +1,4 @@
-import { firstGitMaterialSHA } from '@/utils/gocdHelpers';
+import { filterBuildCauses, firstGitMaterialSHA } from '@/utils/gocdHelpers';
 
 describe('firstGitMaterialSHA', () => {
   it('return nothing for no deploy', async function () {
@@ -61,5 +61,66 @@ describe('firstGitMaterialSHA', () => {
       ],
     });
     expect(got).toEqual('abc123');
+  });
+});
+
+describe('filterBuildCauses', () => {
+  it('filter build causes', function () {
+    const pipeline = {
+      'build-cause': [
+        {
+          id: 1,
+          material: {
+            type: 'git',
+          },
+          modifications: [{}],
+        },
+        {
+          id: 2,
+          material: {
+            type: 'git',
+          },
+          modifications: [],
+        },
+        {
+          id: 3,
+          material: {
+            type: 'pipeline',
+          },
+          modifications: [{}],
+        },
+        {
+          id: 4,
+          material: {
+            type: 'pipeline',
+          },
+          modifications: [],
+        },
+      ],
+    };
+
+    const gotGit = filterBuildCauses(pipeline, 'git');
+    expect(gotGit.length).toEqual(1);
+    expect(gotGit).toEqual([
+      {
+        id: 1,
+        material: {
+          type: 'git',
+        },
+        modifications: [{}],
+      },
+    ]);
+
+    const gotPipeline = filterBuildCauses(pipeline, 'pipeline');
+    expect(gotPipeline.length).toEqual(1);
+    expect(gotPipeline).toEqual([
+      {
+        id: 3,
+        material: {
+          type: 'pipeline',
+        },
+        modifications: [{}],
+      },
+    ]);
   });
 });

--- a/src/utils/gocdHelpers.ts
+++ b/src/utils/gocdHelpers.ts
@@ -1,4 +1,4 @@
-import { DBGoCDDeployment, GoCDPipeline } from '@types';
+import { DBGoCDDeployment, GoCDPipeline, GoCDBuildCause, GoCDBuildType } from '@types';
 
 import {
   Color,
@@ -102,3 +102,20 @@ export function firstGitMaterialSHA(
   }
   return null;
 }
+
+export function filterBuildCauses(pipeline: GoCDPipeline, type: GoCDBuildType): Array<GoCDBuildCause> {
+  const buildCauses = pipeline['build-cause'];
+  if (!buildCauses || buildCauses.length == 0) {
+    return [];
+  }
+
+  const blocks: Array<GoCDBuildCause> = [];
+  for (const bc of buildCauses) {
+    if (!bc.material || bc.material.type !== type || bc.modifications.length == 0) {
+      continue;
+    }
+    blocks.push(bc);
+  }
+  return [];
+}
+

--- a/src/utils/gocdHelpers.ts
+++ b/src/utils/gocdHelpers.ts
@@ -1,4 +1,9 @@
-import { DBGoCDDeployment, GoCDPipeline, GoCDBuildCause, GoCDBuildType } from '@types';
+import {
+  DBGoCDDeployment,
+  GoCDBuildCause,
+  GoCDBuildType,
+  GoCDPipeline,
+} from '@types';
 
 import {
   Color,
@@ -103,7 +108,10 @@ export function firstGitMaterialSHA(
   return null;
 }
 
-export function filterBuildCauses(pipeline: GoCDPipeline, type: GoCDBuildType): Array<GoCDBuildCause> {
+export function filterBuildCauses(
+  pipeline: GoCDPipeline,
+  type: GoCDBuildType
+): Array<GoCDBuildCause> {
   const buildCauses = pipeline['build-cause'];
   if (!buildCauses || buildCauses.length == 0) {
     return [];
@@ -111,11 +119,14 @@ export function filterBuildCauses(pipeline: GoCDPipeline, type: GoCDBuildType): 
 
   const blocks: Array<GoCDBuildCause> = [];
   for (const bc of buildCauses) {
-    if (!bc.material || bc.material.type !== type || bc.modifications.length == 0) {
+    if (
+      !bc.material ||
+      bc.material.type !== type ||
+      bc.modifications.length == 0
+    ) {
       continue;
     }
     blocks.push(bc);
   }
-  return [];
+  return blocks;
 }
-


### PR DESCRIPTION
Noticed that the slack feed was intermittently showing the `Deploying <repo>@<sha>` in messages, this is because I grabbed the first build-cause rather than look for the git repo I wanted.