### PR TITLE
Sync product owners with `security-as-code`

### DIFF
--- a/.github/workflows/react-to-product-owners-yml-changes.yml
+++ b/.github/workflows/react-to-product-owners-yml-changes.yml
@@ -1,0 +1,29 @@
+name: React to product-owners.yml changes
+on:
+  # This could be run manually, but the general expectation is that this fires
+  # from GHA in getsentry/security-as-code on changes there.
+
+  workflow_dispatch:
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: React to product-owners.yml changes
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: getsentry/action-setup-venv@v1.0.5
+        with:
+          python-version: 3.11.3
+
+      - name: Get an auth token
+        id: token
+        uses: getsentry/action-github-app-token@v2.0.0
+        with:
+          app_id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
+          private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
+
+      - name: React to product-owners.yml changes
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+        run: ./bin/react-to-product-owners-yml-changes.sh

--- a/bin/react-to-product-owners-yml-changes.py
+++ b/bin/react-to-product-owners-yml-changes.py
@@ -7,9 +7,6 @@ from os.path import dirname, join, realpath
 
 import yaml
 
-PREFIX = "Product Area: "
-
-
 def main():
     # Run from project root.
     os.chdir(realpath(join(dirname(sys.argv[0]), "..")))

--- a/bin/react-to-product-owners-yml-changes.py
+++ b/bin/react-to-product-owners-yml-changes.py
@@ -17,18 +17,27 @@ def main():
     product_owners_yml = yaml.safe_load(open(sys.argv[1]))
     product_area_to_team_map = {}
     team_to_slack_channel_map = {}
+    repo_to_team_map = {}
 
     for product_area, fields in product_owners_yml['by_area'].items():
         product_area_to_team_map[product_area] = fields['teams']
 
-    for team, fields in product_owners_yml['by_team']:
+    for team, fields in product_owners_yml['by_team'].items():
         # TODO: remove ternary here and require a slack channel for teams
         team_to_slack_channel_map[team] = fields['slack_channel'] if 'slack_channel' in fields else None
+
+    for repo, team in product_owners_yml['by_repo'].items():
+        repo_to_team_map[repo] = team
 
     fp = 'product-owners.yml'
 
     with open(fp, 'w') as file:
-        yaml.dump({ 'product_areas': product_area_to_team_map, 'teams': team_to_slack_channel_map}, file)
+        data = {
+            'product_areas': product_area_to_team_map,
+            'teams': team_to_slack_channel_map,
+            'repos': repo_to_team_map
+        }
+        yaml.dump(data, file)
 
     return 0
 

--- a/bin/react-to-product-owners-yml-changes.py
+++ b/bin/react-to-product-owners-yml-changes.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import sys
+from os.path import dirname, join, realpath
+
+import yaml
+
+PREFIX = "Product Area: "
+
+
+def main():
+    # Run from project root.
+    os.chdir(realpath(join(dirname(sys.argv[0]), "..")))
+
+    product_owners_yml = yaml.safe_load(open(sys.argv[1]))
+    product_area_to_team_map = {}
+    team_to_slack_channel_map = {}
+
+    for product_area, fields in product_owners_yml['by_area'].items():
+        product_area_to_team_map[product_area] = fields['teams']
+
+    for team, fields in product_owners_yml['by_team']:
+        # TODO: remove ternary here and require a slack channel for teams
+        team_to_slack_channel_map[team] = fields['slack_channel'] if 'slack_channel' in fields else None
+
+    fp = 'product-owners.yml'
+
+    with open(fp, 'w') as file:
+        yaml.dump({ 'product_areas': product_area_to_team_map, 'teams': team_to_slack_channel_map}, file)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/react-to-product-owners-yml-changes.sh
+++ b/bin/react-to-product-owners-yml-changes.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+cd ..
+gh repo clone https://github.com/getsentry/security-as-code /tmp/security-as-code
+sha=$(git -C /tmp/security-as-code rev-parse @)
+pip3 install pyyaml==6.0
+./bin/react-to-product-owners-yml-changes.py /tmp/security-as-code/rbac/lib/product-owners.yml
+branch="getsantry/update-product-areas-${sha:0:8}"
+message="Sync with product-owners.yml in security-as-code@${sha:0:8}"
+git config user.email "getsantry[bot]@users.noreply.github.com"
+git config user.name "getsantry[bot]"
+git checkout -b "$branch"
+git add .github/labels.yml
+git add .github/ISSUE_TEMPLATE/bug.yml
+git add .github/ISSUE_TEMPLATE/feature.yml
+git commit -n -m "$message" || exit 0
+git push --set-upstream origin "$branch"
+gh pr create --title "meta(routing) $message" --body="Syncing with [``product-owners.yml``](https://github.com/getsentry/security-as-code/blob/$sha/rbac/lib/product-owners.yml) ([docs](https://www.notion.so/473791bae5bf43399d46093050b77bf0))."

--- a/bin/react-to-product-owners-yml-changes.sh
+++ b/bin/react-to-product-owners-yml-changes.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 cd "$(dirname "$0")"
 cd ..
 gh repo clone https://github.com/getsentry/security-as-code /tmp/security-as-code

--- a/product-owners.yml
+++ b/product-owners.yml
@@ -1,0 +1,131 @@
+product_areas:
+  Alerts:
+  - team-issues
+  Crons:
+  - team-crons
+  Dashboards:
+  - team-discover-and-dashboards
+  Discover:
+  - team-discover-and-dashboards
+  Docs:
+  - team-docs
+  Footer:
+  - team-issues
+  Help:
+  - team-support
+  Issues:
+  - team-issues
+  Issues - Source Maps:
+  - team-processing
+  - team-web-sdks
+  - team-mobile-sdks
+  Issues - Suggested Fix:
+  - team-telemetry-experience
+  Performance:
+  - team-performance
+  Profiling:
+  - team-profiling
+  Projects:
+  - team-projects
+  Releases:
+  - team-issues
+  Replays:
+  - team-replays
+  SDKs - Mobile:
+  - team-mobile-sdks
+  SDKs - Native:
+  - team-mobile-sdks
+  - team-processing
+  SDKs - Web Backend:
+  - team-web-sdks
+  SDKs - Web Frontend:
+  - team-web-sdks
+  Settings:
+  - team-issues
+  Settings - Auth:
+  - team-enterprise
+  Settings - Developer Settings:
+  - team-enterprise
+  Settings - General:
+  - team-issues
+  Settings - Integrations:
+  - team-enterprise
+  Settings - Members:
+  - team-enterprise
+  Settings - Projects:
+  - team-enterprise
+  Settings - Relay:
+  - team-ingest
+  Settings - Repositories:
+  - team-enterprise
+  Settings - Security & Privacy:
+  - team-sentry-at-scale
+  Settings - Spend Allocation:
+  - team-enterprise
+  Settings - Spike Protection:
+  - team-enterprise
+  Settings - Teams:
+  - team-enterprise
+  Sign In:
+  - team-enterprise
+  Starfish:
+  - team-starfish
+  Starfish - API:
+  - team-starfish
+  Starfish - Database:
+  - team-starfish
+  Stats:
+  - team-enterprise
+  User Feedback:
+  - team-issues
+  What's New:
+  - team-product
+repos:
+  arroyo: team-sns
+  cdc: team-sns
+  craft: team-ospo
+  relay: team-ingest
+  responses: team-ospo
+  self-hosted: team-ospo
+  sentry-android-gradle-plugin: team-mobile-sdks
+  sentry-cocoa: team-mobile-sdks
+  sentry-dart: team-mobile-sdks
+  sentry-dart-plugin: team-mobile-sdks
+  sentry-dotnet: team-mobile-sdks
+  sentry-java: team-mobile-sdks
+  sentry-javascript: team-web-sdks
+  sentry-javascript-bundler-plugins: team-web-sdks
+  sentry-laravel: team-web-sdks
+  sentry-native: team-processing
+  sentry-php: team-web-sdks
+  sentry-python: team-web-sdks
+  sentry-react-native: team-mobile-sdks
+  sentry-ruby: team-web-sdks
+  sentry-symfony: team-web-sdks
+  sentry-unity: team-mobile-sdks
+  snuba: team-sns
+  snuba-sdk: team-sns
+  symbolic: team-processing
+  symbolicator: team-processing
+  wal2json: team-sns
+teams:
+  team-crons: null
+  team-discover-and-dashboards: null
+  team-docs: null
+  team-enterprise: null
+  team-ingest: null
+  team-issues: null
+  team-mobile-sdks: null
+  team-ospo: C04B27EECUB
+  team-performance: null
+  team-processing: null
+  team-product: null
+  team-profiling: null
+  team-projects: null
+  team-replays: null
+  team-sentry-at-scale: null
+  team-sns: null
+  team-starfish: null
+  team-support: null
+  team-telemetry-experience: null
+  team-web-sdks: null


### PR DESCRIPTION
This writes to a yaml file in eng-pipes containing information relevant for automations regarding product owners.

Must go in before https://github.com/getsentry/security-as-code/pull/311

This is similar to the setup for sentry and sentry-docs. See here for more details:
https://github.com/getsentry/sentry/pull/48600