### PR TITLE
Fix sending duplicate new issue notifications

### DIFF
--- a/src/brain/issueNotifier/index.test.ts
+++ b/src/brain/issueNotifier/index.test.ts
@@ -66,7 +66,7 @@ describe('issueNotifier Tests', function () {
           label: { name: WAITING_FOR_PRODUCT_OWNER_LABEL, id: 'test-id1' },
           issue: { labels: [{ name: 'Product Area: Test', id: 'test-id2' }] },
         },
-        true,
+        false,
       ],
       [
         `Random label on Product Area + ${WAITING_FOR_PRODUCT_OWNER_LABEL}`,

--- a/src/brain/issueNotifier/index.ts
+++ b/src/brain/issueNotifier/index.ts
@@ -30,10 +30,6 @@ export const githubLabelHandler = async ({
     )
   ) {
     productAreaLabel = label.name;
-  } else if (label.name === WAITING_FOR_PRODUCT_OWNER_LABEL) {
-    productAreaLabel = issue.labels?.find((label) =>
-      label.name.startsWith(PRODUCT_AREA_LABEL_PREFIX)
-    )?.name;
   } else if (label.name === WAITING_FOR_SUPPORT_LABEL) {
     bolt.client.chat.postMessage({
       text: `⏲ Issue ready to route: <${issue.html_url}|#${issue.number} ${issue.title}>`,


### PR DESCRIPTION
Closes https://github.com/getsentry/eng-pipes/issues/528

This comes from the migration from using `Status: Untriaged` -> `Waiting for: Product Owner`. `Waiting for: Product Owner` does not necessarily mean an issue is new, so disable sending notifications when the label is applied.