### PR TITLE
Set teams field default value to empty array

### DIFF
--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -259,7 +259,7 @@ export async function insertOss(
     timeToRouteBy: null,
     timeToTriageBy: null,
     product_area: null,
-    teams: null,
+    teams: [],
   };
 
   if (eventType === 'issues') {


### PR DESCRIPTION
was set to null, probably why errors are triggering now

https://sentry.sentry.io/issues/4371880494/?project=5246761&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=7d&stream_index=1&utc=true