### PR TITLE
For slack notifications, default office to 'sfo'

### DIFF
--- a/src/webhooks/pubsub/slackNotifications.test.ts
+++ b/src/webhooks/pubsub/slackNotifications.test.ts
@@ -125,6 +125,9 @@ describe('Triage Notification Tests', function () {
     it('will return null if inputs are invalid', () => {
       expect(getOfficesForRepo('garbage-repo', 'getsentry')).toEqual([]);
     });
+    it('will return sfo if office for repo is null', () => {
+      expect(getOfficesForRepo('test-null', 'getsentry')).toEqual(['sfo']);
+    });
   });
   describe('constructSlackMessage', function () {
     let boltPostMessageSpy;

--- a/src/webhooks/pubsub/slackNotifications.ts
+++ b/src/webhooks/pubsub/slackNotifications.ts
@@ -402,8 +402,8 @@ export const getOfficesForRepo = (repo: string, org: string) => {
   if (!teams.length) {
     return [];
   }
-  // TODO(team-ospo/issues#198): Support multiple teams
-  return PRODUCT_OWNERS_INFO['teams'][teams[0]]['offices'];
+  // TODO(team-ospo/issues#198): Support multiple teams, default to sfo for now if offices is null
+  return PRODUCT_OWNERS_INFO['teams'][teams[0]]['offices'] || ['sfo'];
 };
 
 export const notifyProductOwnersForUntriagedIssues = async (

--- a/test/github-orgs.yml
+++ b/test/github-orgs.yml
@@ -16,6 +16,7 @@ getsentry:
       - test-ttt-simple
       - undefined-team-repo
       - vie-repo
+      - test-null
 
 codecov:
   appAuth:

--- a/test/product-owners.yml
+++ b/test/product-owners.yml
@@ -10,6 +10,7 @@ repos:
   test-ttt-simple: team-ospo
   routing-repo: team-ospo
   vie-repo: team-ingest
+  test-null: team-null
 teams:
   team-ospo:
     slack_channel: C05A6BW303Y
@@ -23,3 +24,6 @@ teams:
     slack_channel: C05A6BW303X
     offices:
       - vie
+  team-null:
+    slack_channel: null
+    offices: null


### PR DESCRIPTION
Seeing this: https://sentry.sentry.io/issues/4487576749/?alert_rule_id=13633623&alert_type=issue&notification_uuid=eee97dfe-c25e-4c3a-a259-5014bbd95b89&project=5246761&referrer=slack

This fixes that