### PR TITLE
Don't report of checks failures

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+/brain/gocdSlackFeeds/                    @getsentry/dev-infra
+/brain/notifyOnGoCDStageEvent/            @getsentry/dev-infra
+/brain/pleaseDeployNotifier/              @getsentry/dev-infra
+/brain/saveGoCDStageEvents/               @getsentry/dev-infra

--- a/src/brain/gocdSlackFeeds/index.test.ts
+++ b/src/brain/gocdSlackFeeds/index.test.ts
@@ -231,7 +231,7 @@ describe('gocdSlackFeeds', function () {
     });
   });
 
-  it('post message to feed-deploy and feed-engineering for failing checks', async function () {
+  it('post message to feed-deploy and not feed-engineering for failing checks', async function () {
     const gocdPayload = merge({}, payload, {
       data: {
         pipeline: {
@@ -247,43 +247,12 @@ describe('gocdSlackFeeds', function () {
     // First Event
     await handler(gocdPayload);
 
-    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(2);
+    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(1);
     const postCalls = bolt.client.chat.postMessage.mock.calls;
     postCalls.sort(sortMessages);
     expect(postCalls[0][0]).toMatchObject({
       text: 'GoCD deployment started',
       channel: FEED_DEPLOY_CHANNEL_ID,
-      attachments: [
-        {
-          color: Color.DANGER,
-          blocks: [
-            slackblocks.section(
-              slackblocks.markdown('*sentryio/getsentry-backend*')
-            ),
-            {
-              elements: [
-                slackblocks.markdown('Deploying'),
-                slackblocks.markdown(
-                  '<https://github.com/getsentry/getsentry/commits/2b0034becc4ab26b985f4c1a08ab068f153c274c|getsentry@2b0034becc4a>'
-                ),
-              ],
-            },
-            slackblocks.divider(),
-            {
-              elements: [
-                slackblocks.markdown('❌ *checks*'),
-                slackblocks.markdown(
-                  '<https://deploy.getsentry.net/go/pipelines/getsentry-backend/20/checks/1|Failed>'
-                ),
-              ],
-            },
-          ],
-        },
-      ],
-    });
-    expect(postCalls[1][0]).toMatchObject({
-      text: 'GoCD deployment started',
-      channel: FEED_ENGINEERING_CHANNEL_ID,
       attachments: [
         {
           color: Color.DANGER,

--- a/src/brain/gocdSlackFeeds/index.ts
+++ b/src/brain/gocdSlackFeeds/index.ts
@@ -100,6 +100,11 @@ const engineeringFeed = new DeployFeed({
       return false;
     }
 
+    // Checks create a lot of noise that is normally not actionable
+    if (pipeline.stage.name === 'checks') {
+      return false;
+    }
+
     // We only really care about creating new messages if the pipeline has
     // failed.
     return pipeline.stage.result.toLowerCase() === 'failed';


### PR DESCRIPTION
We should shift to a model of complaining when now deploy has happened in 2 hours instead.

I'll follow up with that change shortly