### PR TITLE
Fix project linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "migrate": "yarn knex --knexfile ./src/knexfile.ts",
     "start:clean": "yarn build && yarn start",
     "start": "node --async-stack-traces ./lib/index.js",
-    "lint": "yarn eslint --ext .ts \"src\" \"test/**/*.ts\" --fix",
+    "lint": "yarn eslint --ext .ts \"src\" \"test/**/*.ts\"",
+    "lint:fix": "yarn lint --fix",
     "test": "yarn jest --useStderr --runInBand",
     "test:debug": "yarn run --inspect jest --runInBand",
     "test:ci": "yarn test --forceExit",
@@ -108,7 +109,7 @@
   },
   "lint-staged": {
     "*.ts": [
-      "eslint --cache --fix"
+      "yarn lint:fix"
     ],
     "*.md": [
       "markdownlint"

--- a/src/brain/apis/getOwnershipData.ts
+++ b/src/brain/apis/getOwnershipData.ts
@@ -1,24 +1,25 @@
-import { GETSENTRY_ORG, SENTRY_REPO_SLUG } from "@/config";
+import { GETSENTRY_ORG, SENTRY_REPO_SLUG } from '@/config';
 
-const OWNERSHIP_FILE_PATH = "src/sentry/apidocs/api_ownership_stats_dont_modify.json";
+const OWNERSHIP_FILE_PATH =
+  'src/sentry/apidocs/api_ownership_stats_dont_modify.json';
 
 export default async function getOwnershipData() {
-    const resp = await GETSENTRY_ORG.api.rest.repos.getContent({
-      owner: GETSENTRY_ORG.slug,
-      repo: SENTRY_REPO_SLUG,
-      path: OWNERSHIP_FILE_PATH,
-    });
-  
-    if (!('content' in resp.data)) {
-      throw new Error('content not in response');
-    }
-    if (!('encoding' in resp.data)) {
-      throw new Error('encoding not in response');
-    }
-    if (resp.data.encoding !== 'base64') {
-      throw new Error(`Unexpected content encoding: ${resp.data.encoding}`);
-    }
-  
-    const buff = Buffer.from(resp.data.content, 'base64');
-    return JSON.parse(buff.toString('ascii'));
+  const resp = await GETSENTRY_ORG.api.rest.repos.getContent({
+    owner: GETSENTRY_ORG.slug,
+    repo: SENTRY_REPO_SLUG,
+    path: OWNERSHIP_FILE_PATH,
+  });
+
+  if (!('content' in resp.data)) {
+    throw new Error('content not in response');
   }
+  if (!('encoding' in resp.data)) {
+    throw new Error('encoding not in response');
+  }
+  if (resp.data.encoding !== 'base64') {
+    throw new Error(`Unexpected content encoding: ${resp.data.encoding}`);
+  }
+
+  const buff = Buffer.from(resp.data.content, 'base64');
+  return JSON.parse(buff.toString('ascii'));
+}

--- a/src/brain/apis/getStatsMessage.test.ts
+++ b/src/brain/apis/getStatsMessage.test.ts
@@ -3,38 +3,41 @@ import getStatsMessage from './getStatsMessage';
 const STATS_TEXT = 'Some random team stats';
 
 jest.mock('./getOwnershipData', () =>
-    jest.fn(() => ({
-        "team1" : {
-            "block_start": 1,
-            "public": ["p1"],
-            "private": [],
-            "experimental": [],
-            "unknown": [],
-        },
-        "team2" : {
-            "block_start": 7,
-            "public": [],
-            "private": [],
-            "experimental": ["e1"],
-            "unknown": ["u1", "u2"],
-        }
-    }))
+  jest.fn(() => ({
+    team1: {
+      block_start: 1,
+      public: ['p1'],
+      private: [],
+      experimental: [],
+      unknown: [],
+    },
+    team2: {
+      block_start: 7,
+      public: [],
+      private: [],
+      experimental: ['e1'],
+      unknown: ['u1', 'u2'],
+    },
+  }))
 );
 describe('api stats', function () {
-    it('calculates team stats', async function () {
-        const response = await getStatsMessage("team1");
-        expect(response.message).toBe("Publish status for team1 APIs:\n" +
-            "• public: 1 (100%) :party-sunglasses-blob: \n" +
-            "• private: 0 (0%)  \n" +
-            "• experimental: 0 (0%) :party-sunglasses-blob: \n" +
-            "• unknown: 0 (0%) :party-sunglasses-blob: \n");
-    });
+  it('calculates team stats', async function () {
+    const response = await getStatsMessage('team1');
+    expect(response.message).toBe(
+      'Publish status for team1 APIs:\n' +
+        '• public: 1 (100%) :party-sunglasses-blob: \n' +
+        '• private: 0 (0%)  \n' +
+        '• experimental: 0 (0%) :party-sunglasses-blob: \n' +
+        '• unknown: 0 (0%) :party-sunglasses-blob: \n'
+    );
+  });
 
-    it('calculates overall stats', async function () {
-        const response = await getStatsMessage("");
-        expect(response.message).toBe(
-            "Team Name            | Public(%) | Private(%) | Experimental(%) | Unknown(%)\n" +
-            "<https://github.com/getsentry/sentry/blob/master/src/sentry/apidocs/api_ownership_stats_dont_modify.json#L1|team1>                | 100       | 0          | 0               | 0         \n" +
-            "<https://github.com/getsentry/sentry/blob/master/src/sentry/apidocs/api_ownership_stats_dont_modify.json#L7|team2>                | 0   ☒     | 0          | 33  ☒           | 67  ☒     \n"); 
-    });
+  it('calculates overall stats', async function () {
+    const response = await getStatsMessage('');
+    expect(response.message).toBe(
+      'Team Name            | Public(%) | Private(%) | Experimental(%) | Unknown(%)\n' +
+        '<https://github.com/getsentry/sentry/blob/master/src/sentry/apidocs/api_ownership_stats_dont_modify.json#L1|team1>                | 100       | 0          | 0               | 0         \n' +
+        '<https://github.com/getsentry/sentry/blob/master/src/sentry/apidocs/api_ownership_stats_dont_modify.json#L7|team2>                | 0   ☒     | 0          | 33  ☒           | 67  ☒     \n'
+    );
+  });
 });

--- a/src/brain/apis/getStatsMessage.ts
+++ b/src/brain/apis/getStatsMessage.ts
@@ -1,104 +1,134 @@
 import getOwnershipData from './getOwnershipData';
 
-export const OWNERSHIP_FILE_LINK = "https://github.com/getsentry/sentry/blob/master/src/sentry/apidocs/api_ownership_stats_dont_modify.json";
-export const INVALID_TEAM_ERROR = "INVALID_TEAM_ERROR";
+export const OWNERSHIP_FILE_LINK =
+  'https://github.com/getsentry/sentry/blob/master/src/sentry/apidocs/api_ownership_stats_dont_modify.json';
+export const INVALID_TEAM_ERROR = 'INVALID_TEAM_ERROR';
 
 const COLUMN_WIDTH = 21;
-function getEmojiForType(type: string, api_rate: number, is_short_message: boolean) {
+function getEmojiForType(
+  type: string,
+  api_rate: number,
+  is_short_message: boolean
+) {
   if (is_short_message) {
     switch (type) {
-      case "public":
-        return api_rate < 10 ? "☒" : "";
-      case "private":
-        return "";
-      case "unknown": 
-        return api_rate > 0 ? "☒" : "";
-      case "experimental":
-        return api_rate > 0 ? "☒" : "";
+      case 'public':
+        return api_rate < 10 ? '☒' : '';
+      case 'private':
+        return '';
+      case 'unknown':
+        return api_rate > 0 ? '☒' : '';
+      case 'experimental':
+        return api_rate > 0 ? '☒' : '';
     }
-    return "";
+    return '';
   }
 
   switch (type) {
-    case "public":
-      return api_rate == 0 ? ":sad_blob:" : api_rate < 20 ? ":blob-unamused:" : api_rate > 50 ? ":party-sunglasses-blob:" : "";
-    case "private":
-      return "";
-    case "unknown": case "experimental":
-      return api_rate == 0 ? ":party-sunglasses-blob:" : api_rate > 50 ? ":sad_blob:" : ":blob-unamused:";
+    case 'public':
+      return api_rate == 0
+        ? ':sad_blob:'
+        : api_rate < 20
+        ? ':blob-unamused:'
+        : api_rate > 50
+        ? ':party-sunglasses-blob:'
+        : '';
+    case 'private':
+      return '';
+    case 'unknown':
+    case 'experimental':
+      return api_rate == 0
+        ? ':party-sunglasses-blob:'
+        : api_rate > 50
+        ? ':sad_blob:'
+        : ':blob-unamused:';
   }
-  return "";
+  return '';
 }
 
 function getShortMessageForType(team_data, type, total) {
-  const api_rate = Math.round(team_data[type].length* 100/total)
-  const emoji = getEmojiForType(type, api_rate, true)
+  const api_rate = Math.round((team_data[type].length * 100) / total);
+  const emoji = getEmojiForType(type, api_rate, true);
   const rate_string = strAdjustLength(api_rate.toString(), 3);
   return strAdjustLength(`${rate_string} ${emoji}`, type.length + 3);
 }
 
 function getMessageLineForType(team_data, type, total) {
-  const api_rate = Math.round(team_data[type].length* 100/total)
+  const api_rate = Math.round((team_data[type].length * 100) / total);
   const emoji = getEmojiForType(type, api_rate, false);
-  return `• ${type}: ${team_data[type].length} (${api_rate}%) ${emoji} \n`
+  return `• ${type}: ${team_data[type].length} (${api_rate}%) ${emoji} \n`;
 }
 
 function getTotalApisForTeam(team_data) {
-  return team_data["public"].length + 
-    team_data["private"].length + 
-    team_data["experimental"].length + 
-    team_data["unknown"].length; 
+  return (
+    team_data['public'].length +
+    team_data['private'].length +
+    team_data['experimental'].length +
+    team_data['unknown'].length
+  );
 }
 
 function getMessageForTeam(ownership_data, team) {
   const team_data = ownership_data[team];
   const total = getTotalApisForTeam(team_data);
   return {
-    message: `Publish status for ${team} APIs:\n` +
-      getMessageLineForType(team_data, 'public', total) + 
+    message:
+      `Publish status for ${team} APIs:\n` +
+      getMessageLineForType(team_data, 'public', total) +
       getMessageLineForType(team_data, 'private', total) +
-      getMessageLineForType(team_data, 'experimental', total) + 
+      getMessageLineForType(team_data, 'experimental', total) +
       getMessageLineForType(team_data, 'unknown', total),
-    should_show_docs: team_data["unknown"].length + team_data["experimental"].length > 0,
-    review_link: `${OWNERSHIP_FILE_LINK}#L${team_data["block_start"]}`,
-  }
+    should_show_docs:
+      team_data['unknown'].length + team_data['experimental'].length > 0,
+    review_link: `${OWNERSHIP_FILE_LINK}#L${team_data['block_start']}`,
+  };
 }
 
 function strAdjustLength(word: string, target: number) {
   if (word.length < target) {
     return word + ' '.repeat(target - word.length);
-  } 
+  }
   return word;
 }
 
 function getOverallStats(ownership_data) {
-  let response = strAdjustLength('Team Name', COLUMN_WIDTH) + '| Public(%) | Private(%) | Experimental(%) | Unknown(%)\n';
+  let response =
+    strAdjustLength('Team Name', COLUMN_WIDTH) +
+    '| Public(%) | Private(%) | Experimental(%) | Unknown(%)\n';
   ownership_data.forEach((team_data, team) => {
     const total = getTotalApisForTeam(team_data);
-    response = response + `<${OWNERSHIP_FILE_LINK}#L${team_data["block_start"]}|${team}>` + strAdjustLength("", COLUMN_WIDTH - team.length) + "| " + 
-      getShortMessageForType(team_data, "public", total) + ' | ' +
-      getShortMessageForType(team_data, "private", total) + ' | ' +
-      getShortMessageForType(team_data, "experimental", total) + ' | ' +
-      getShortMessageForType(team_data, "unknown", total) + "\n"
+    response =
+      response +
+      `<${OWNERSHIP_FILE_LINK}#L${team_data['block_start']}|${team}>` +
+      strAdjustLength('', COLUMN_WIDTH - team.length) +
+      '| ' +
+      getShortMessageForType(team_data, 'public', total) +
+      ' | ' +
+      getShortMessageForType(team_data, 'private', total) +
+      ' | ' +
+      getShortMessageForType(team_data, 'experimental', total) +
+      ' | ' +
+      getShortMessageForType(team_data, 'unknown', total) +
+      '\n';
   });
   return response;
 }
 
 export default async function getStatsMessage(team: string) {
-  const ownership_data = await getOwnershipData()
+  const ownership_data = await getOwnershipData();
   // If team is not mentioned return stats for all
   if (team == '') {
     return {
       message: getOverallStats(new Map(Object.entries(ownership_data))),
       should_show_docs: true,
       review_link: OWNERSHIP_FILE_LINK,
-    }
-  } 
-  
+    };
+  }
+
   if (ownership_data[team] != null) {
     return getMessageForTeam(ownership_data, team);
   }
-  
+
   return {
     message: INVALID_TEAM_ERROR,
     should_show_docs: false,

--- a/src/brain/apis/index.ts
+++ b/src/brain/apis/index.ts
@@ -1,93 +1,101 @@
 import { bolt } from '@api/slack';
 import { wrapHandler } from '@utils/wrapHandler';
 
-import getStatsMessage, { INVALID_TEAM_ERROR, OWNERSHIP_FILE_LINK } from './getStatsMessage';
+import getStatsMessage, {
+  INVALID_TEAM_ERROR,
+  OWNERSHIP_FILE_LINK,
+} from './getStatsMessage';
 
 export function apis() {
-    bolt.event(
-        'app_mention',
-        wrapHandler('apis', async ({ event, say, client }) => {
-            if (!event.text.includes('apis')) {
-                return;
-            }
+  bolt.event(
+    'app_mention',
+    wrapHandler('apis', async ({ event, say, client }) => {
+      if (!event.text.includes('apis')) {
+        return;
+      }
 
-            const params = event.text.trim().split("apis ")
-            const team = params.length == 2 ? params[1] : '';
-            const message = await say({
+      const params = event.text.trim().split('apis ');
+      const team = params.length == 2 ? params[1] : '';
+      const message = await say({
+        text: ':sentry-loading: fetching status ...',
+        blocks: [
+          {
+            type: 'context',
+            elements: [
+              {
+                type: 'mrkdwn',
                 text: ':sentry-loading: fetching status ...',
-                blocks: [
-                {
-                    type: 'context',
-                    elements: [
-                    {
-                        type: 'mrkdwn',
-                        text: ':sentry-loading: fetching status ...',
-                    },
-                    ],
+              },
+            ],
+          },
+        ],
+      });
+
+      try {
+        const response = await getStatsMessage(team);
+        if (response.message === INVALID_TEAM_ERROR) {
+          await client.chat.update({
+            channel: String(message.channel),
+            ts: String(message.ts),
+            text: `Team name is not valid.`,
+            blocks: [
+              {
+                type: 'section',
+                text: {
+                  type: 'mrkdwn',
+                  text: `Team name is not valid or does not own any APIs. Review <${OWNERSHIP_FILE_LINK}|ownerhisp> and <https://develop.sentry.dev/api/public/#1-declaring-owner-for-the-endpoint|update on the endpoints> if needed. `,
                 },
-                ],
-            });
+              },
+            ],
+          });
+          return;
+        }
 
-            try {
-                const response = await getStatsMessage(team);
-                if (response.message === INVALID_TEAM_ERROR) {
-                    await client.chat.update({
-                        channel: String(message.channel),
-                        ts: String(message.ts),
-                        text: `Team name is not valid.`,
-                        blocks: [
-                            {
-                                type: 'section',
-                                text: {
-                                    type: 'mrkdwn',
-                                    text: `Team name is not valid or does not own any APIs. Review <${OWNERSHIP_FILE_LINK}|ownerhisp> and <https://develop.sentry.dev/api/public/#1-declaring-owner-for-the-endpoint|update on the endpoints> if needed. `,
-                                },
-                            },
-                        ],
-                    });
-                    return;
-                }
+        const blocks = [
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text:
+                team == ''
+                  ? '```' + response.message + '```'
+                  : response.message,
+            },
+          },
+        ];
 
-                let blocks = [{
-                    type: 'section',
-                    text: {
-                        type: 'mrkdwn',
-                        text: team == '' ? "```" + response.message + "```" : response.message,
-                    },
-                }];
-                    
-                if (response.should_show_docs === true) {
-                    blocks.push( {
-                        type: 'section',
-                        text: {
-                            type: 'mrkdwn',
-                            text: `Please <${response.review_link}|review> unknown and experimental APIs and <https://develop.sentry.dev/api/public/#1-declaring-owner-for-the-endpoint|update the endpoints> as either public or private.`,
-                        },
-                    });
-                }
+        if (response.should_show_docs === true) {
+          blocks.push({
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: `Please <${response.review_link}|review> unknown and experimental APIs and <https://develop.sentry.dev/api/public/#1-declaring-owner-for-the-endpoint|update the endpoints> as either public or private.`,
+            },
+          });
+        }
 
-                await client.chat.update({
-                    channel: String(message.channel),
-                    ts: String(message.ts),
-                    text: 'API Ownership Stats',
-                    blocks,
-                });
-            } catch (ex) {
-                await client.chat.update({
-                    channel: String(message.channel),
-                    ts: String(message.ts),
-                    text: ':fire_elmo: Something went wrong. Please try again and ping #discuss-apis if the issue persists.',
-                    blocks: [
-                        {
-                            type: 'section',
-                            text: {
-                                type: 'mrkdwn',
-                                text: ':fire_elmo: Something went wrong. Please try again and ping #discuss-apis if the issue persists.',
-                            },
-                        }
-                    ],
-                });
-            }
-        })
-    );
+        await client.chat.update({
+          channel: String(message.channel),
+          ts: String(message.ts),
+          text: 'API Ownership Stats',
+          blocks,
+        });
+      } catch (ex) {
+        await client.chat.update({
+          channel: String(message.channel),
+          ts: String(message.ts),
+          text: ':fire_elmo: Something went wrong. Please try again and ping #discuss-apis if the issue persists.',
+          blocks: [
+            {
+              type: 'section',
+              text: {
+                type: 'mrkdwn',
+                text: ':fire_elmo: Something went wrong. Please try again and ping #discuss-apis if the issue persists.',
+              },
+            },
+          ],
+        });
+      }
+    })
+  );
 }

--- a/src/brain/apis/indext.test.ts
+++ b/src/brain/apis/indext.test.ts
@@ -36,9 +36,11 @@ describe('slack app', function () {
     );
     expect(response.statusCode).toBe(200);
     expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(1);
-    expect(getStatsMessage).toHaveBeenCalledWith("enterprise");
-    
+    expect(getStatsMessage).toHaveBeenCalledWith('enterprise');
+
     expect(bolt.client.chat.update).toHaveBeenCalledTimes(1);
-    expect(bolt.client.chat.update.mock.calls[0][0].blocks[0].text.text).toBe(STATS_TEXT)
+    expect(bolt.client.chat.update.mock.calls[0][0].blocks[0].text.text).toBe(
+      STATS_TEXT
+    );
   });
 });

--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -296,7 +296,7 @@ export async function insertOss(
             data.target_name,
             issue.labels,
             payload.repository.name,
-            payload.organization.login,
+            payload.organization.login
           );
         }
       }


### PR DESCRIPTION
1. CI was running `eslint --fix`, so it never failed when it should
2. Husky was using it's own version of eslint, causing issues due to version differences, now it runs `yarn lint:fix`
3. We now have `yarn lint` and `yarn lint:fix` so CI can fail, and locally we can run fix.