### PR TITLE
Fixing flaky test

### DIFF
--- a/src/brain/requiredChecks/index.test.ts
+++ b/src/brain/requiredChecks/index.test.ts
@@ -1138,23 +1138,32 @@ describe('requiredChecks', function () {
     expect(updateMessage).toHaveBeenCalledTimes(3);
 
     expect(saveSlackMessage.saveSlackMessage).toHaveBeenCalledTimes(3);
-    expect(saveSlackMessage.saveSlackMessage).toHaveBeenNthCalledWith(
-      1,
-      expect.anything(),
-      expect.anything(),
-      expect.objectContaining({ status: BuildStatus.UNKNOWN })
-    );
-    expect(saveSlackMessage.saveSlackMessage).toHaveBeenNthCalledWith(
-      2,
-      expect.anything(),
-      expect.anything(),
-      expect.objectContaining({ status: BuildStatus.UNKNOWN })
-    );
-    expect(saveSlackMessage.saveSlackMessage).toHaveBeenNthCalledWith(
-      3,
-      expect.anything(),
-      expect.anything(),
-      expect.objectContaining({ status: BuildStatus.FIXED })
-    );
+
+    const calls = (saveSlackMessage.saveSlackMessage as jest.Mock).mock.calls;
+    const sortedCalls = calls.sort((callA, callB) => {
+      expect(callA.length).toBe(3);
+      expect(callB.length).toBe(3);
+      expect(callA[1]).toHaveProperty('id');
+      expect(callB[1]).toHaveProperty('id');
+      return Number(callB[1].id) - Number(callA[1].id);
+    });
+
+    expect(sortedCalls).toEqual([
+      [
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ status: BuildStatus.UNKNOWN }),
+      ],
+      [
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ status: BuildStatus.UNKNOWN }),
+      ],
+      [
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ status: BuildStatus.FIXED }),
+      ],
+    ]);
   });
 });

--- a/src/brain/requiredChecks/index.test.ts
+++ b/src/brain/requiredChecks/index.test.ts
@@ -1140,7 +1140,9 @@ describe('requiredChecks', function () {
     expect(saveSlackMessage.saveSlackMessage).toHaveBeenCalledTimes(3);
 
     const calls = (saveSlackMessage.saveSlackMessage as jest.Mock).mock.calls;
+    // Was causing a flakey test, so we sort the calls to make sure they are in the right order
     const sortedCalls = calls.sort((callA, callB) => {
+      // Some extra assertions to make sure the calls are what we expect
       expect(callA.length).toBe(3);
       expect(callB.length).toBe(3);
       expect(callA[1]).toHaveProperty('id');


### PR DESCRIPTION
This test was causing failing intermittently which seemed to happen due to inconsistent ordering. This PR addresses it by making sure the calls are sorted by their id.