### PR TITLE
Revert "Use product-owners.yml as source of truth for slack triage notifications"

### DIFF
--- a/src/brain/githubMetrics/index.test.ts
+++ b/src/brain/githubMetrics/index.test.ts
@@ -109,7 +109,7 @@ describe('github webhook', function () {
         timeToTriageBy: null,
         timeToRouteBy: null,
         product_area: null,
-        teams: ['team-ospo'],
+        teams: [],
       },
       { schema: SCHEMA }
     );
@@ -142,7 +142,7 @@ describe('github webhook', function () {
         timeToTriageBy: null,
         timeToRouteBy: null,
         product_area: null,
-        teams: ['team-ospo'],
+        teams: [],
       },
       { schema: SCHEMA }
     );
@@ -187,7 +187,7 @@ describe('github webhook', function () {
         timeToTriageBy: null,
         timeToRouteBy: null,
         product_area: null,
-        teams: ['team-ospo'],
+        teams: [],
       },
       { schema: SCHEMA }
     );
@@ -220,7 +220,7 @@ describe('github webhook', function () {
         timeToTriageBy: null,
         timeToRouteBy: null,
         product_area: null,
-        teams: ['team-ospo'],
+        teams: [],
       },
       { schema: SCHEMA }
     );

--- a/src/brain/issueLabelHandler/followups.ts
+++ b/src/brain/issueLabelHandler/followups.ts
@@ -242,15 +242,12 @@ export async function ensureOneWaitingForLabel({
         WAITING_FOR_PRODUCT_OWNER_LABEL,
         issue.labels,
         repo,
-        org.slug
+        payload.organization?.login
       )) || moment().toISOString();
   } else if (labelName === WAITING_FOR_SUPPORT_LABEL) {
     timeToRespondBy =
-      (await calculateSLOViolationRoute(
-        WAITING_FOR_SUPPORT_LABEL,
-        repo,
-        org.slug
-      )) || moment().toISOString();
+      (await calculateSLOViolationRoute(WAITING_FOR_SUPPORT_LABEL)) ||
+      moment().toISOString();
   } else {
     timeToRespondBy = '';
   }

--- a/src/brain/issueNotifier/index.test.ts
+++ b/src/brain/issueNotifier/index.test.ts
@@ -174,4 +174,275 @@ describe('issueNotifier Tests', function () {
       });
     });
   });
+
+  describe('slackHandler', function () {
+    let say, respond, client, ack;
+    beforeAll(async function () {
+      say = jest.fn();
+      respond = jest.fn();
+      client = {
+        conversations: {
+          info: jest
+            .fn()
+            .mockReturnValue({ channel: { name: 'test', is_member: true } }),
+          join: jest.fn(),
+        },
+      };
+      ack = jest.fn();
+    });
+
+    it('should respond that channel is not subscribed to any product area notifications if channel does not exist', async function () {
+      const channel_id = channelId(3);
+      const command = {
+        channel_id,
+        text: '',
+      };
+      await slackHandler({ command, ack, say, respond, client });
+      expect(say).lastCalledWith(
+        'This channel is not subscribed to any product area notifications.'
+      );
+      expect(await getLabelsTable().where({ channel_id })).toEqual([]);
+    });
+
+    it('should add new subscription to product area for channel', async function () {
+      const channel_id = channelId(3);
+      const command = {
+        channel_id,
+        text: 'Test sea',
+      };
+      await slackHandler({ command, ack, say, respond, client });
+      expect(say).lastCalledWith(
+        "Set untriaged issue notifications for 'Product Area: Test' on the current channel (test). Notifications will come in during sea business hours."
+      );
+      expect(await getLabelsTable().where({ channel_id })).toMatchObject([
+        {
+          channel_id: 'CHNLIDRND3',
+          label_name: 'Product Area: Test',
+          offices: ['sea'],
+        },
+      ]);
+    });
+
+    it('should respond that channel is subscribed to product area test if office is null', async function () {
+      const channel_id = channelId(1);
+      const command = {
+        channel_id,
+        text: '',
+      };
+      await slackHandler({ command, ack, say, respond, client });
+      expect(say).lastCalledWith(
+        'This channel is set to receive notifications for: Product Area: Test (no office specified)'
+      );
+      expect(await getLabelsTable().where({ channel_id })).toMatchObject([
+        {
+          channel_id: 'CHNLIDRND1',
+          label_name: 'Product Area: Test',
+          offices: null,
+        },
+      ]);
+    });
+
+    it('should add sfo office', async function () {
+      const channel_id = channelId(1);
+      const command = {
+        channel_id,
+        text: 'Test sfo',
+      };
+      await slackHandler({ command, ack, say, respond, client });
+      expect(say).lastCalledWith(
+        'Add office location sfo on the current channel (test) for Product Area: Test'
+      );
+      expect(await getLabelsTable().where({ channel_id })).toMatchObject([
+        {
+          channel_id: 'CHNLIDRND1',
+          label_name: 'Product Area: Test',
+          offices: ['sfo'],
+        },
+      ]);
+    });
+
+    it('should respond that channel is subscribed to product area test if office is sfo', async function () {
+      const channel_id = channelId(1);
+      const command = {
+        channel_id,
+        text: '',
+      };
+      await slackHandler({ command, ack, say, respond, client });
+      expect(say).lastCalledWith(
+        'This channel is set to receive notifications for: Product Area: Test (sfo)'
+      );
+      expect(await getLabelsTable().where({ channel_id })).toMatchObject([
+        {
+          channel_id: 'CHNLIDRND1',
+          label_name: 'Product Area: Test',
+          offices: ['sfo'],
+        },
+      ]);
+    });
+
+    it('should add sea office', async function () {
+      const channel_id = channelId(1);
+      const command = {
+        channel_id,
+        text: 'Test sea',
+      };
+      await slackHandler({ command, ack, say, respond, client });
+      expect(say).lastCalledWith(
+        'Add office location sea on the current channel (test) for Product Area: Test'
+      );
+      expect(await getLabelsTable().where({ channel_id })).toMatchObject([
+        {
+          channel_id: 'CHNLIDRND1',
+          label_name: 'Product Area: Test',
+          offices: ['sfo', 'sea'],
+        },
+      ]);
+    });
+
+    it('should not add office if office input is invalid', async function () {
+      const channel_id = channelId(1);
+      const command = {
+        channel_id,
+        text: 'Test blah',
+      };
+      await slackHandler({ command, ack, say, respond, client });
+      expect(say).lastCalledWith(
+        'This channel is set to receive notifications for: Product Area: Test (sfo, sea)'
+      );
+      expect(await getLabelsTable().where({ channel_id })).toMatchObject([
+        {
+          channel_id: 'CHNLIDRND1',
+          label_name: 'Product Area: Test',
+          offices: ['sfo', 'sea'],
+        },
+      ]);
+    });
+
+    it('should add vie office', async function () {
+      const channel_id = channelId(1);
+      const command = {
+        channel_id,
+        text: 'Test vie',
+      };
+      await slackHandler({ command, ack, say, respond, client });
+      expect(say).lastCalledWith(
+        'Add office location vie on the current channel (test) for Product Area: Test'
+      );
+      expect(await getLabelsTable().where({ channel_id })).toMatchObject([
+        {
+          channel_id: 'CHNLIDRND1',
+          label_name: 'Product Area: Test',
+          offices: ['sfo', 'sea', 'vie'],
+        },
+      ]);
+    });
+
+    it('should add yyz office', async function () {
+      const channel_id = channelId(1);
+      const command = {
+        channel_id,
+        text: 'Test yyz',
+      };
+      await slackHandler({ command, ack, say, respond, client });
+      expect(say).lastCalledWith(
+        'Add office location yyz on the current channel (test) for Product Area: Test'
+      );
+      expect(await getLabelsTable().where({ channel_id })).toMatchObject([
+        {
+          channel_id: 'CHNLIDRND1',
+          label_name: 'Product Area: Test',
+          offices: ['sfo', 'sea', 'vie', 'yyz'],
+        },
+      ]);
+    });
+
+    it('should delete notifications for Product Area test for office sea', async function () {
+      const channel_id = channelId(1);
+      const command = {
+        channel_id,
+        text: '-Test sea',
+      };
+      await slackHandler({ command, ack, say, respond, client });
+      expect(say).lastCalledWith(
+        'This channel (test) will no longer get notifications for Product Area: Test during sea business hours.'
+      );
+      expect(await getLabelsTable().where({ channel_id })).toMatchObject([
+        {
+          channel_id: 'CHNLIDRND1',
+          label_name: 'Product Area: Test',
+          offices: ['sfo', 'vie', 'yyz'],
+        },
+      ]);
+    });
+
+    it('should not delete notifications for Product Area test if office is not included', async function () {
+      const channel_id = channelId(1);
+      const command = {
+        channel_id,
+        text: '-Test sea',
+      };
+      await slackHandler({ command, ack, say, respond, client });
+      expect(say).lastCalledWith(
+        'This channel (test) is not subscribed to Product Area: Test during sea business hours.'
+      );
+      expect(await getLabelsTable().where({ channel_id })).toMatchObject([
+        {
+          channel_id: 'CHNLIDRND1',
+          label_name: 'Product Area: Test',
+          offices: ['sfo', 'vie', 'yyz'],
+        },
+      ]);
+    });
+
+    it('should delete notifications for Product Area test for office yyz', async function () {
+      const channel_id = channelId(1);
+      const command = {
+        channel_id,
+        text: '-Test yyz',
+      };
+      await slackHandler({ command, ack, say, respond, client });
+      expect(say).lastCalledWith(
+        'This channel (test) will no longer get notifications for Product Area: Test during yyz business hours.'
+      );
+      expect(await getLabelsTable().where({ channel_id })).toMatchObject([
+        {
+          channel_id: 'CHNLIDRND1',
+          label_name: 'Product Area: Test',
+          offices: ['sfo', 'vie'],
+        },
+      ]);
+    });
+
+    it('should delete notifications for Product Area test for office sfo', async function () {
+      const channel_id = channelId(1);
+      const command = {
+        channel_id,
+        text: '-Test sfo',
+      };
+      await slackHandler({ command, ack, say, respond, client });
+      expect(say).lastCalledWith(
+        'This channel (test) will no longer get notifications for Product Area: Test during sfo business hours.'
+      );
+      expect(await getLabelsTable().where({ channel_id })).toMatchObject([
+        {
+          channel_id: 'CHNLIDRND1',
+          label_name: 'Product Area: Test',
+          offices: ['vie'],
+        },
+      ]);
+    });
+
+    it('should delete notifications for Product Area test for office vie', async function () {
+      const channel_id = channelId(1);
+      const command = {
+        channel_id,
+        text: '-Test vie',
+      };
+      await slackHandler({ command, ack, say, respond, client });
+      expect(say).lastCalledWith(
+        'This channel (test) will no longer get notifications for Product Area: Test during vie business hours.'
+      );
+      expect(await getLabelsTable().where({ channel_id })).toEqual([]);
+    });
+  });
 });

--- a/src/brain/issueNotifier/index.ts
+++ b/src/brain/issueNotifier/index.ts
@@ -3,11 +3,13 @@ import { EmitterWebhookEvent } from '@octokit/webhooks';
 import {
   PRODUCT_AREA_LABEL_PREFIX,
   SUPPORT_CHANNEL_ID,
+  TEAM_OSPO_CHANNEL_ID,
   WAITING_FOR_PRODUCT_OWNER_LABEL,
   WAITING_FOR_SUPPORT_LABEL,
 } from '@/config';
 import { githubEvents } from '@api/github';
 import { bolt } from '@api/slack';
+import { cacheOffices } from '@utils/businessHours';
 import { db } from '@utils/db';
 import { wrapHandler } from '@utils/wrapHandler';
 
@@ -66,9 +68,189 @@ export const githubLabelHandler = async ({
   );
 };
 
+// /notify-for-triage`: List all product area label subscriptions
+// /notify-for-triage <name> <office>`: Subscribe to all untriaged issues for `Product Area: <name>` label
+// /notify-for-triage -<name> <office>`: Unsubscribe from untriaged issues for `Product Area: <name>` label
+export const slackHandler = async ({ command, ack, say, respond, client }) => {
+  const pending: Promise<unknown>[] = [];
+  // Acknowledge command request
+  pending.push(ack());
+  const { channel_id, text } = command;
+  const args = text.match(
+    /^\s*(?<op>[+-]?)(?<label>.+)\s(?<office>yyz|vie|sea|sfo|ams?)/
+  )?.groups;
+  if (!args) {
+    if (
+      channel_id === TEAM_OSPO_CHANNEL_ID ||
+      channel_id === SUPPORT_CHANNEL_ID
+    ) {
+      const getName = async (channel_id: string) =>
+        (await client.conversations.info({ channel: channel_id })).channel.name;
+      const allRows = await getLabelsTable().orderBy('label_name');
+      const subs = await Promise.all(
+        allRows.map(async (row) => {
+          const channelName = await getName(row.channel_id);
+          const offices = (row.offices || ['no office specified']).join(', ');
+          return `"${row.label_name}" ⇒ #${channelName} (${offices})`;
+        })
+      );
+      const response =
+        subs.length > 0
+          ? `${subs.join('\n')}`
+          : `There are no notification subscriptions set up.`;
+      pending.push(say(response));
+    } else {
+      const labels = (await getLabelsTable().where({ channel_id })).map(
+        (row) =>
+          `${row.label_name} (${(row.offices || ['no office specified']).join(
+            ', '
+          )})`
+      );
+      const response =
+        labels.length > 0
+          ? `This channel is set to receive notifications for: ${labels.join(
+              ', '
+            )}`
+          : `This channel is not subscribed to any product area notifications.`;
+      pending.push(say(response));
+    }
+  } else {
+    const op = args.op || '+';
+    const label_name = `Product Area: ${args.label}`;
+    const newOffice = args.office;
+    const currentOffices =
+      (
+        await getLabelsTable()
+          .where({
+            label_name,
+            channel_id,
+          })
+          .select('offices')
+      )[0]?.offices || [];
+    let channelInfo;
+    let result;
+
+    try {
+      channelInfo = await client.conversations.info({
+        channel: channel_id,
+      });
+    } catch (err) {
+      // @ts-expect-error
+      if (err instanceof Error && err.data.error === 'channel_not_found') {
+        pending.push(
+          respond({
+            response_type: 'ephemeral',
+            text: `You need to invite me to the channel as it is private.`,
+          })
+        );
+        await Promise.all(pending);
+        return;
+      } else {
+        throw err;
+      }
+    }
+
+    switch (op) {
+      case '+':
+        if (!channelInfo.channel.is_member) {
+          await client.conversations.join({ channel: channel_id });
+        }
+
+        result = await getLabelsTable()
+          .insert(
+            {
+              label_name,
+              channel_id,
+              offices: [newOffice],
+            },
+            'label_name'
+          )
+          .onConflict(['label_name', 'channel_id'])
+          .ignore();
+
+        if (result.length > 0) {
+          pending.push(
+            say(
+              `Set untriaged issue notifications for '${result[0]?.label_name}' on the current channel (${channelInfo.channel.name}). Notifications will come in during ${newOffice} business hours.`
+            )
+          );
+        } else if (!currentOffices.includes(newOffice)) {
+          result = await getLabelsTable()
+            .where({
+              label_name,
+              channel_id,
+            })
+            .update({
+              offices: currentOffices.concat(newOffice),
+            });
+          pending.push(
+            say(
+              `Add office location ${newOffice} on the current channel (${channelInfo.channel.name}) for ${label_name}`
+            )
+          );
+        } else {
+          pending.push(
+            respond({
+              response_type: 'ephemeral',
+              text: `This channel (${channelInfo.channel.name}) is already subscribed to '${label_name} during ${newOffice} business hours'.`,
+            })
+          );
+        }
+        break;
+      case '-':
+        if (currentOffices.includes(newOffice)) {
+          if (currentOffices.length > 1) {
+            currentOffices.splice(currentOffices.indexOf(newOffice), 1);
+            result = await getLabelsTable()
+              .where({
+                channel_id,
+                label_name,
+              })
+              .update({
+                offices: currentOffices,
+              });
+          } else {
+            result = await getLabelsTable()
+              .where({
+                channel_id,
+                label_name,
+              })
+              .del('label_name');
+          }
+          pending.push(
+            say(
+              `This channel (${channelInfo.channel.name}) will no longer get notifications for ${label_name} during ${newOffice} business hours.`
+            )
+          );
+        } else {
+          pending.push(
+            say(
+              `This channel (${channelInfo.channel.name}) is not subscribed to ${label_name} during ${newOffice} business hours.`
+            )
+          );
+        }
+
+        // Unlike in the subscribe action, we do not leave the channel here because the
+        // bot might have been invited to the channel for other purposes too. So making
+        // sure we are in the channel when they subscribe to notifications makes sense
+        // but leaving when they unsubscribe is not sure game.
+        break;
+      default:
+    }
+    // Update cache for the offices mapped to each product area
+    await cacheOffices(label_name);
+  }
+  await Promise.all(pending);
+};
+
 export async function issueNotifier() {
   githubEvents.on(
     'issues.labeled',
     wrapHandler('issueNotifier', githubLabelHandler)
+  );
+
+  bolt.command(
+    '/notify-for-triage',
+    wrapHandler('issueNotifier', slackHandler)
   );
 }

--- a/src/utils/businessHours.test.ts
+++ b/src/utils/businessHours.test.ts
@@ -19,7 +19,6 @@ import moment from 'moment-timezone';
 
 import { getLabelsTable, slackHandler } from '@/brain/issueNotifier';
 import {
-  GETSENTRY_ORG,
   MAX_ROUTE_DAYS,
   MAX_TRIAGE_DAYS,
   WAITING_FOR_PRODUCT_OWNER_LABEL,
@@ -33,6 +32,8 @@ import {
   calculateSLOViolationTriage,
   calculateTimeToRespondBy,
   getNextAvailableBusinessHourWindow,
+  getOffices,
+  isChannelInBusinessHours,
 } from './businessHours';
 import * as businessHourfunctions from './businessHours';
 
@@ -41,22 +42,22 @@ describe('businessHours tests', function () {
   beforeAll(async function () {
     await db.migrate.latest();
     await getLabelsTable().insert({
-      label_name: 'Test',
+      label_name: 'Product Area: Test',
       channel_id: 'CHNLIDRND1',
       offices: ['sfo'],
     });
     await getLabelsTable().insert({
-      label_name: 'Undefined',
+      label_name: 'Product Area: Undefined',
       channel_id: 'CHNLIDRND1',
       offices: undefined,
     });
     await getLabelsTable().insert({
-      label_name: 'Null',
+      label_name: 'Product Area: Null',
       channel_id: 'CHNLIDRND1',
       offices: null,
     });
     await getLabelsTable().insert({
-      label_name: 'Other',
+      label_name: 'Product Area: Other',
       channel_id: 'CHNLIDRND1',
       offices: ['sfo'],
     });
@@ -111,9 +112,9 @@ describe('businessHours tests', function () {
       it(`should calculate TTT SLO violation for ${testTimestamps[i].day}`, async function () {
         const result = await calculateTimeToRespondBy(
           MAX_TRIAGE_DAYS,
-          'Test',
-          'routing-repo',
-          GETSENTRY_ORG.slug,
+          'Product Area: Test',
+          undefined,
+          undefined,
           testTimestamps[i].timestamp
         );
         expect(result).toEqual(triageResults[i]);
@@ -122,9 +123,9 @@ describe('businessHours tests', function () {
       it(`should calculate TTR SLO violation for ${testTimestamps[i].day}`, async function () {
         const result = await calculateTimeToRespondBy(
           MAX_ROUTE_DAYS,
-          'Test',
-          'routing-repo',
-          GETSENTRY_ORG.slug,
+          'Product Area: Test',
+          undefined,
+          undefined,
           testTimestamps[i].timestamp
         );
         expect(result).toEqual(routingResults[i]);
@@ -134,9 +135,9 @@ describe('businessHours tests', function () {
     it('should handle case when offices is undefined', async function () {
       const result = await calculateTimeToRespondBy(
         MAX_TRIAGE_DAYS,
-        'Undefined',
-        'routing-repo',
-        GETSENTRY_ORG.slug,
+        'Product Area: Undefined',
+        undefined,
+        undefined,
         '2023-12-18T00:00:00.000Z'
       );
       expect(result).toEqual('2023-12-20T01:00:00.000Z');
@@ -145,9 +146,9 @@ describe('businessHours tests', function () {
     it('should handle case when offices is null', async function () {
       const result = await calculateTimeToRespondBy(
         MAX_TRIAGE_DAYS,
-        'Null',
-        'routing-repo',
-        GETSENTRY_ORG.slug,
+        'Product Area: Null',
+        undefined,
+        undefined,
         '2023-12-18T00:00:00.000Z'
       );
       expect(result).toEqual('2023-12-20T01:00:00.000Z');
@@ -156,9 +157,9 @@ describe('businessHours tests', function () {
     it('should handle the last day of the month for TTR', async function () {
       const result = await calculateTimeToRespondBy(
         MAX_ROUTE_DAYS,
-        'Test',
-        'routing-repo',
-        GETSENTRY_ORG.slug,
+        'Product Area: Test',
+        undefined,
+        undefined,
         '2023-01-31T00:00:00.000Z'
       );
       expect(result).toEqual('2023-02-01T00:00:00.000Z');
@@ -167,9 +168,9 @@ describe('businessHours tests', function () {
     it('should handle the last day of the year for TTR', async function () {
       const result = await calculateTimeToRespondBy(
         MAX_ROUTE_DAYS,
-        'Test',
-        'routing-repo',
-        GETSENTRY_ORG.slug,
+        'Product Area: Test',
+        undefined,
+        undefined,
         '2022-12-31T00:00:00.000Z'
       );
       expect(result).toEqual('2023-01-04T01:00:00.000Z');
@@ -179,9 +180,9 @@ describe('businessHours tests', function () {
       it('should calculate TTT SLO violation for Christmas', async function () {
         const result = await calculateTimeToRespondBy(
           MAX_TRIAGE_DAYS,
-          'Test',
-          'routing-repo',
-          GETSENTRY_ORG.slug,
+          'Product Area: Test',
+          undefined,
+          undefined,
           '2023-12-24T00:00:00.000Z'
         );
         // 2023-12-24 is Sunday, 2023-12-25/2022-12-26 are holidays
@@ -191,9 +192,9 @@ describe('businessHours tests', function () {
       it('should calculate TTR SLO violation for Christmas', async function () {
         const result = await calculateTimeToRespondBy(
           MAX_ROUTE_DAYS,
-          'Test',
-          'routing-repo',
-          GETSENTRY_ORG.slug,
+          'Product Area: Test',
+          undefined,
+          undefined,
           '2023-12-24T00:00:00.000Z'
         );
         // 2023-12-24 is Sunday, 2023-12-25/2022-12-26 are holidays
@@ -201,22 +202,34 @@ describe('businessHours tests', function () {
       });
 
       it('should not include holiday in TTR if at least one office is still open', async function () {
+        const command = {
+          channel_id: 'CHNLIDRND2',
+          text: 'Test yyz',
+        };
+        await slackHandler({ command, ack, say, respond, client });
         const result = await calculateTimeToRespondBy(
           MAX_ROUTE_DAYS,
-          'Test',
-          'routing-repo',
-          GETSENTRY_ORG.slug,
+          'Product Area: Test',
+          undefined,
+          undefined,
           '2023-10-02T00:00:00.000Z'
         );
         expect(result).toEqual('2023-10-03T00:00:00.000Z');
+        command.text = '-Test yyz';
+        await slackHandler({ command, ack, say, respond, client });
       });
 
       it('should triage on the same day if two office timezones do not overlap', async function () {
+        const command = {
+          channel_id: 'CHNLIDRND2',
+          text: 'Test vie',
+        };
+        await slackHandler({ command, ack, say, respond, client });
         const result = await calculateTimeToRespondBy(
           MAX_TRIAGE_DAYS,
-          'Non-Overlapping Timezone',
-          'routing-repo',
-          GETSENTRY_ORG.slug,
+          'Product Area: Test',
+          undefined,
+          undefined,
           '2023-10-02T00:00:00.000Z'
         );
         expect(result).toEqual('2023-10-03T00:00:00.000Z');
@@ -225,93 +238,191 @@ describe('businessHours tests', function () {
       it('should calculate weekends properly for friday in sfo, weekend in vie', async function () {
         const result = await calculateTimeToRespondBy(
           MAX_TRIAGE_DAYS,
-          'Non-Overlapping Timezone',
-          'routing-repo',
-          GETSENTRY_ORG.slug,
+          'Product Area: Test',
+          undefined,
+          undefined,
           '2022-12-17T00:00:00.000Z'
         );
         expect(result).toEqual('2022-12-20T00:00:00.000Z');
       });
 
       it('should route properly when product area is subscribed to sfo, vie, and yyz', async function () {
+        const command = {
+          channel_id: 'CHNLIDRND2',
+          text: 'Test yyz',
+        };
+        await slackHandler({ command, ack, say, respond, client });
         const result = await calculateTimeToRespondBy(
           MAX_ROUTE_DAYS,
-          'All-Timezones',
-          'routing-repo',
-          GETSENTRY_ORG.slug,
+          'Product Area: Test',
+          undefined,
+          undefined,
           '2022-12-20T15:30:00.000Z'
         );
         expect(result).toEqual('2022-12-20T23:30:00.000Z');
       });
 
       it('should triage properly when product area is subscribed to sfo, vie, and yyz', async function () {
+        const command = {
+          channel_id: 'CHNLIDRND2',
+          text: 'Test yyz',
+        };
+        await slackHandler({ command, ack, say, respond, client });
         const result = await calculateTimeToRespondBy(
           MAX_TRIAGE_DAYS,
-          'All-Timezones',
-          'routing-repo',
-          GETSENTRY_ORG.slug,
+          'Product Area: Test',
+          undefined,
+          undefined,
           '2022-12-20T15:30:00.000Z'
         );
         expect(result).toEqual('2022-12-21T14:30:00.000Z');
+        command.text = '-Test yyz';
+        await slackHandler({ command, ack, say, respond, client });
+        command.text = '-Test vie';
+        await slackHandler({ command, ack, say, respond, client });
       });
     });
   });
 
   describe('calculateSLOViolationRoute', function () {
     it('should not calculate SLO violation if label is routed', async function () {
-      const result = await calculateSLOViolationRoute(
-        'Status: Test',
-        'routing-repo',
-        GETSENTRY_ORG.slug
-      );
+      const result = await calculateSLOViolationRoute('Status: Test');
       expect(result).toEqual(null);
     });
 
     it('should not calculate SLO violation if label is untriaged', async function () {
       const result = await calculateSLOViolationRoute(
-        WAITING_FOR_PRODUCT_OWNER_LABEL,
-        'routing-repo',
-        GETSENTRY_ORG.slug
+        WAITING_FOR_PRODUCT_OWNER_LABEL
       );
       expect(result).toEqual(null);
     });
 
     it('should not calculate SLO violation if label is waiting for product owner', async function () {
       const result = await calculateSLOViolationRoute(
-        WAITING_FOR_PRODUCT_OWNER_LABEL,
-        'routing-repo',
-        GETSENTRY_ORG.slug
+        WAITING_FOR_PRODUCT_OWNER_LABEL
       );
       expect(result).toEqual(null);
     });
 
     it('should calculate SLO violation if label is unrouted', async function () {
       const result = await calculateSLOViolationRoute(
-        WAITING_FOR_SUPPORT_LABEL,
-        'routing-repo',
-        GETSENTRY_ORG.slug
+        WAITING_FOR_SUPPORT_LABEL
       );
       expect(result).not.toEqual(null);
     });
   });
 
+  describe('isChannelInBusinessHours', function () {
+    beforeAll(async function () {
+      await getLabelsTable().insert({
+        label_name: 'Product Area: Other',
+        channel_id: 'CHNLIDRND4',
+        offices: ['sfo', 'vie'],
+      });
+      await getLabelsTable().insert({
+        label_name: 'Product Area: Test',
+        channel_id: 'CHNLIDRND4',
+        offices: ['yyz'],
+      });
+      await getLabelsTable().insert({
+        label_name: 'Product Area: Undefined',
+        channel_id: 'CHNLIDRND5',
+        offices: undefined,
+      });
+    });
+    afterAll(async function () {
+      await getLabelsTable().where({ channel_id: 'CHNLIDRND4' }).del();
+    });
+    it('should return true for sfo office if in between 9am-5pm sfo business hours on workday', async function () {
+      const nowForTest = moment('2023-01-05T18:00:00.000Z').utc();
+      const result = await isChannelInBusinessHours('CHNLIDRND1', nowForTest);
+      expect(result).toEqual(true);
+    });
+
+    it('should return true for sfo office if utc day is Saturday, but local sfo time is Friday', async function () {
+      const nowForTest = moment('2023-02-04T01:00:00.000Z').utc();
+      const result = await isChannelInBusinessHours('CHNLIDRND1', nowForTest);
+      expect(result).toEqual(true);
+    });
+
+    it('should post message to OSPO channel if offices is undefined', async function () {
+      const nowForTest = moment('2023-01-05T18:00:00.000Z').utc();
+      const postMessageSpy = jest.spyOn(bolt.client.chat, 'postMessage');
+      const result = await isChannelInBusinessHours('CHNLIDRND5', nowForTest);
+      expect(postMessageSpy).toHaveBeenCalledWith({
+        channel: 'G01F3FQ0T41',
+        text: "Hey OSPO, looks like #test-channel doesn't have offices set.",
+      });
+      expect(result).toEqual(true);
+    });
+
+    it('should return true if no office specified and in between 9am-5pm sfo business hours on workday', async function () {
+      const nowForTest = moment('2023-01-05T18:00:00.000Z').utc();
+      const result = await isChannelInBusinessHours('CHNLIDRND3', nowForTest);
+      expect(result).toEqual(true);
+    });
+
+    it('should return true for sfo office if on 9am sfo business hours on workday', async function () {
+      const nowForTest = moment('2023-01-05T17:00:00.000Z');
+      const result = await isChannelInBusinessHours('CHNLIDRND1', nowForTest);
+      expect(result).toEqual(true);
+    });
+
+    it('should return true for sfo office if on 5pm sfo business hours on workday', async function () {
+      const nowForTest = moment('2023-01-06T01:00:00.000Z');
+      const result = await isChannelInBusinessHours('CHNLIDRND1', nowForTest);
+      expect(result).toEqual(true);
+    });
+
+    it('should return false for sfo office if not in sfo business hours on workday', async function () {
+      const nowForTest = moment('2023-01-05T09:00:00.000Z');
+      const result = await isChannelInBusinessHours('CHNLIDRND1', nowForTest);
+      expect(result).toEqual(false);
+    });
+
+    it('should return false for sfo office if it is Christmas during business hours', async function () {
+      const nowForTest = moment('2023-12-24T17:00:00.000Z');
+      const result = await isChannelInBusinessHours('CHNLIDRND1', nowForTest);
+      expect(result).toEqual(false);
+    });
+
+    it('should return true if channel subscribed to vie, yyz, sfo and time is in sfo business hours', async function () {
+      const nowForTest = moment('2023-01-06T01:00:00.000Z');
+      const result = await isChannelInBusinessHours('CHNLIDRND4', nowForTest);
+      expect(result).toEqual(true);
+    });
+
+    it('should return true if channel subscribed to vie, yyz, sfo and time is in yyz business hours', async function () {
+      const nowForTest = moment('2023-01-06T16:00:00.000Z');
+      const result = await isChannelInBusinessHours('CHNLIDRND4', nowForTest);
+      expect(result).toEqual(true);
+    });
+
+    it('should return true if channel subscribed to vie, yyz, sfo and time is in vie business hours', async function () {
+      const nowForTest = moment('2023-01-05T12:00:00.000Z');
+      const result = await isChannelInBusinessHours('CHNLIDRND4', nowForTest);
+      expect(result).toEqual(true);
+    });
+
+    it('should return false if channel subscribed to vie, yyz, sfo and time is a vie holiday', async function () {
+      const nowForTest = moment('2023-01-06T12:00:00.000Z');
+      const result = await isChannelInBusinessHours('CHNLIDRND4', nowForTest);
+      expect(result).toEqual(false);
+    });
+  });
+
   describe('calculateSLOViolationTriage', function () {
     it('should not calculate SLO violation if label is not untriaged', async function () {
-      const result = await calculateSLOViolationTriage(
-        'Status: Test',
-        [{ name: 'Test' }],
-        'routing-repo',
-        GETSENTRY_ORG.slug
-      );
+      const result = await calculateSLOViolationTriage('Status: Test', [
+        { name: 'Product Area: Test' },
+      ]);
       expect(result).toEqual(null);
     });
 
     it('should not calculate SLO violation if label is unrouted', async function () {
       const result = await calculateSLOViolationTriage(
         WAITING_FOR_SUPPORT_LABEL,
-        [{ name: 'Test' }],
-        'routing-repo',
-        GETSENTRY_ORG.slug
+        [{ name: 'Product Area: Test' }]
       );
       expect(result).toEqual(null);
     });
@@ -319,9 +430,7 @@ describe('businessHours tests', function () {
     it('should calculate SLO violation if label is untriaged', async function () {
       const result = await calculateSLOViolationTriage(
         WAITING_FOR_PRODUCT_OWNER_LABEL,
-        [{ name: 'Test' }],
-        'routing-repo',
-        GETSENTRY_ORG.slug
+        [{ name: 'Product Area: Test' }]
       );
       expect(result).not.toEqual(null);
     });
@@ -329,9 +438,23 @@ describe('businessHours tests', function () {
     it('should calculate SLO violation if label is waiting for product owner', async function () {
       const result = await calculateSLOViolationTriage(
         WAITING_FOR_PRODUCT_OWNER_LABEL,
-        [{ name: 'Test' }],
-        'routing-repo',
-        GETSENTRY_ORG.slug
+        [{ name: 'Product Area: Test' }]
+      );
+      expect(result).not.toEqual(null);
+    });
+
+    it('should calculate SLO violation if label is assigned to another product area for untriaged label', async function () {
+      const result = await calculateSLOViolationTriage(
+        'Product Area: Rerouted',
+        [{ name: WAITING_FOR_PRODUCT_OWNER_LABEL }]
+      );
+      expect(result).not.toEqual(null);
+    });
+
+    it('should calculate SLO violation if label is assigned to another product area for waiting for product owner label', async function () {
+      const result = await calculateSLOViolationTriage(
+        'Product Area: Rerouted',
+        [{ name: WAITING_FOR_PRODUCT_OWNER_LABEL }]
       );
       expect(result).not.toEqual(null);
     });
@@ -340,10 +463,8 @@ describe('businessHours tests', function () {
   describe('getNextAvailableBusinessHourWindow', function () {
     it('should get open source product area timezones if product area does not have offices', async function () {
       const { start, end } = await getNextAvailableBusinessHourWindow(
-        'Does not exist',
-        moment('2022-12-08T12:00:00.000Z').utc(),
-        'routing-repo',
-        GETSENTRY_ORG.slug
+        'Product Area: Does not exist',
+        moment('2022-12-08T12:00:00.000Z').utc()
       );
       expect(start.valueOf()).toEqual(
         moment('2022-12-08T17:00:00.000Z').valueOf()
@@ -355,7 +476,7 @@ describe('businessHours tests', function () {
 
     it('should get sfo timezones for repo with no offices defined', async function () {
       const { start, end } = await getNextAvailableBusinessHourWindow(
-        '',
+        undefined,
         moment('2022-12-08T12:00:00.000Z').utc(),
         'test-null',
         'getsentry'
@@ -368,12 +489,10 @@ describe('businessHours tests', function () {
       );
     });
 
-    it('should get sfo timezones for Test', async function () {
+    it('should get sfo timezones for Product Area: Test', async function () {
       const { start, end } = await getNextAvailableBusinessHourWindow(
-        'Test',
-        moment('2022-12-08T12:00:00.000Z').utc(),
-        'routing-repo',
-        GETSENTRY_ORG.slug
+        'Product Area: Test',
+        moment('2022-12-08T12:00:00.000Z').utc()
       );
       expect(start.valueOf()).toEqual(
         moment('2022-12-08T17:00:00.000Z').valueOf()
@@ -383,12 +502,15 @@ describe('businessHours tests', function () {
       );
     });
 
-    it('should get vie timezone for Test if it has the closest business hours available', async function () {
+    it('should get vie timezone for Product Area: Test if it has the closest business hours available', async function () {
+      const command = {
+        channel_id: 'CHNLIDRND2',
+        text: 'Test vie',
+      };
+      await slackHandler({ command, ack, say, respond, client });
       const { start, end } = await getNextAvailableBusinessHourWindow(
-        'Non-Overlapping Timezone',
-        moment('2022-12-08T12:00:00.000Z').utc(),
-        'routing-repo',
-        GETSENTRY_ORG.slug
+        'Product Area: Test',
+        moment('2022-12-08T12:00:00.000Z').utc()
       );
       expect(start.valueOf()).toEqual(
         moment('2022-12-08T12:00:00.000Z').valueOf()
@@ -398,12 +520,15 @@ describe('businessHours tests', function () {
       );
     });
 
-    it('should get sfo timezone for Test if it has the closest business hours available', async function () {
+    it('should get sfo timezone for Product Area: Test if it has the closest business hours available', async function () {
+      const command = {
+        channel_id: 'CHNLIDRND2',
+        text: 'Test vie',
+      };
+      await slackHandler({ command, ack, say, respond, client });
       const { start, end } = await getNextAvailableBusinessHourWindow(
-        'Non-Overlapping Timezone',
-        moment('2022-12-08T16:30:00.000Z').utc(),
-        'routing-repo',
-        GETSENTRY_ORG.slug
+        'Product Area: Test',
+        moment('2022-12-08T16:30:00.000Z').utc()
       );
       expect(start.valueOf()).toEqual(
         moment('2022-12-08T17:00:00.000Z').valueOf()
@@ -413,12 +538,15 @@ describe('businessHours tests', function () {
       );
     });
 
-    it('should get yyz timezone for Test if it has the closest business hours available', async function () {
+    it('should get yyz timezone for Product Area: Test if it has the closest business hours available', async function () {
+      const command = {
+        channel_id: 'CHNLIDRND2',
+        text: 'Test yyz',
+      };
+      await slackHandler({ command, ack, say, respond, client });
       const { start, end } = await getNextAvailableBusinessHourWindow(
-        'All-Timezones',
-        moment('2022-12-08T16:30:00.000Z').utc(),
-        'routing-repo',
-        GETSENTRY_ORG.slug
+        'Product Area: Test',
+        moment('2022-12-08T16:30:00.000Z').utc()
       );
       expect(start.valueOf()).toEqual(
         moment('2022-12-08T16:30:00.000Z').valueOf()
@@ -430,10 +558,8 @@ describe('businessHours tests', function () {
 
     it('should return vie hours for Christmas for product area subscribed to vie, yyz, sfo', async function () {
       const { start, end } = await getNextAvailableBusinessHourWindow(
-        'All-Timezones',
-        moment('2023-12-23T12:00:00.000Z').utc(),
-        'routing-repo',
-        GETSENTRY_ORG.slug
+        'Product Area: Test',
+        moment('2023-12-23T12:00:00.000Z').utc()
       );
       expect(start.valueOf()).toEqual(
         moment('2024-01-02T08:00:00.000Z').valueOf()
@@ -445,10 +571,8 @@ describe('businessHours tests', function () {
 
     it('should return vie hours for Saturday for product area subscribed to vie, yyz, sfo', async function () {
       const { start, end } = await getNextAvailableBusinessHourWindow(
-        'All-Timezones',
-        moment('2022-12-17T12:00:00.000Z').utc(),
-        'routing-repo',
-        GETSENTRY_ORG.slug
+        'Product Area: Test',
+        moment('2022-12-17T12:00:00.000Z').utc()
       );
       expect(start.valueOf()).toEqual(
         moment('2022-12-19T08:00:00.000Z').valueOf()
@@ -460,10 +584,8 @@ describe('businessHours tests', function () {
 
     it('should return vie hours for Sunday for product area subscribed to vie, yyz, sfo', async function () {
       const { start, end } = await getNextAvailableBusinessHourWindow(
-        'All-Timezones',
-        moment('2022-12-18T12:00:00.000Z').utc(),
-        'routing-repo',
-        GETSENTRY_ORG.slug
+        'Product Area: Test',
+        moment('2022-12-18T12:00:00.000Z').utc()
       );
       expect(start.valueOf()).toEqual(
         moment('2022-12-19T08:00:00.000Z').valueOf()
@@ -474,11 +596,14 @@ describe('businessHours tests', function () {
     });
 
     it('should return yyz hours for Saturday for product area subscribed to yyz, sfo', async function () {
+      let command = {
+        channel_id: 'CHNLIDRND2',
+        text: '-Test vie',
+      };
+      await slackHandler({ command, ack, say, respond, client });
       const { start, end } = await getNextAvailableBusinessHourWindow(
-        'Overlapping Timezone',
-        moment('2022-12-17T12:00:00.000Z').utc(),
-        'routing-repo',
-        GETSENTRY_ORG.slug
+        'Product Area: Test',
+        moment('2022-12-17T12:00:00.000Z').utc()
       );
       expect(start.valueOf()).toEqual(
         moment('2022-12-19T14:00:00.000Z').valueOf()
@@ -486,6 +611,61 @@ describe('businessHours tests', function () {
       expect(end.valueOf()).toEqual(
         moment('2022-12-19T22:00:00.000Z').valueOf()
       );
+      command = {
+        channel_id: 'CHNLIDRND2',
+        text: '-Test yyz',
+      };
+      await slackHandler({ command, ack, say, respond, client });
+    });
+  });
+
+  describe('getOffices', function () {
+    it('should return empty array if product area label is undefined', async function () {
+      expect(await getOffices(undefined)).toEqual([]);
+    });
+
+    it('should return empty array if product area offices value is undefined', async function () {
+      expect(await getOffices('Product Area: Undefined')).toEqual([]);
+    });
+
+    it('should return empty array if product area offices value is null', async function () {
+      expect(await getOffices('Product Area: Null')).toEqual([]);
+    });
+
+    it('should get sfo office for product area test', async function () {
+      expect(await getOffices('Product Area: Test')).toEqual(['sfo']);
+    });
+
+    it('should get sfo and vie office for product area test if new office is added', async function () {
+      const command = {
+        channel_id: 'CHNLIDRND1',
+        text: 'Test vie',
+      };
+      await slackHandler({ command, ack, say, respond, client });
+      expect(await getOffices('Product Area: Test')).toEqual(['sfo', 'vie']);
+    });
+
+    it('should get vie office for product area test if existing office is removed', async function () {
+      const command = {
+        channel_id: 'CHNLIDRND1',
+        text: '-Test sfo',
+      };
+      await slackHandler({ command, ack, say, respond, client });
+      expect(await getOffices('Product Area: Test')).toEqual(['vie']);
+    });
+
+    it('should get offices from multiple channels', async function () {
+      let command = {
+        channel_id: 'CHNLIDRND2',
+        text: 'Test yyz',
+      };
+      await slackHandler({ command, ack, say, respond, client });
+      expect(await getOffices('Product Area: Test')).toEqual(['vie', 'yyz']);
+      command = {
+        channel_id: 'CHNLIDRND2',
+        text: '-Test yyz',
+      };
+      await slackHandler({ command, ack, say, respond, client });
     });
   });
 });

--- a/src/utils/businessHours.ts
+++ b/src/utils/businessHours.ts
@@ -3,15 +3,19 @@ import fs from 'fs';
 import yaml from 'js-yaml';
 import moment from 'moment-timezone';
 
+import { getLabelsTable } from '@/brain/issueNotifier';
 import {
+  GETSENTRY_ORG,
   MAX_ROUTE_DAYS,
   MAX_TRIAGE_DAYS,
   OFFICE_TIME_ZONES,
   PRODUCT_AREA_LABEL_PREFIX,
   PRODUCT_OWNERS_INFO,
+  TEAM_OSPO_CHANNEL_ID,
   WAITING_FOR_PRODUCT_OWNER_LABEL,
   WAITING_FOR_SUPPORT_LABEL,
 } from '@/config';
+import { bolt } from '@api/slack';
 
 import { getTeams } from './getTeams';
 
@@ -20,6 +24,8 @@ const BUSINESS_DAY_IN_MS = 8 * HOUR_IN_MS;
 
 const holidayFile = fs.readFileSync('holidays.yml');
 const HOLIDAY_CONFIG = yaml.load(holidayFile);
+
+const officesCache = {};
 interface BusinessHourWindow {
   start: moment.Moment;
   end: moment.Moment;
@@ -28,8 +34,8 @@ interface BusinessHourWindow {
 export async function calculateTimeToRespondBy(
   numDays: number,
   productArea: string,
-  repo: string,
-  org: string,
+  repo?: string,
+  org?: string,
   testTimestamp?: string
 ) {
   let cursor =
@@ -55,8 +61,8 @@ export async function calculateTimeToRespondBy(
 export async function calculateSLOViolationTriage(
   target_name: string,
   labels: any,
-  repo: string,
-  org: string
+  repo?: string,
+  org?: string
 ) {
   // calculate time to triage for issues that come in with untriaged label
   if (target_name === WAITING_FOR_PRODUCT_OWNER_LABEL) {
@@ -75,20 +81,29 @@ export async function calculateSLOViolationTriage(
   return null;
 }
 
-export async function calculateSLOViolationRoute(
-  target_name: string,
-  repo: string,
-  org: string
-) {
+export async function calculateSLOViolationRoute(target_name: string) {
   if (target_name === WAITING_FOR_SUPPORT_LABEL) {
-    return calculateTimeToRespondBy(
-      MAX_ROUTE_DAYS,
-      'Product Area: Unknown',
-      repo,
-      org
-    );
+    return calculateTimeToRespondBy(MAX_ROUTE_DAYS, 'Product Area: Unknown');
   }
   return null;
+}
+
+export async function cacheOffices(productArea) {
+  const offices = [
+    ...new Set(
+      (
+        await getLabelsTable()
+          .where({
+            label_name: productArea,
+          })
+          .select('offices')
+      )
+        .reduce((acc, item) => acc.concat(item.offices), [])
+        .filter((office) => office != null)
+    ),
+  ];
+  officesCache[productArea] = offices;
+  return offices;
 }
 
 export const isTimeInBusinessHours = (time: moment.Moment, office: string) => {
@@ -109,30 +124,65 @@ export const isTimeInBusinessHours = (time: moment.Moment, office: string) => {
   return false;
 };
 
+export const isChannelInBusinessHours = async (
+  channelId: string,
+  now: moment.Moment
+) => {
+  // find all offices channel is subscribed to
+  let offices = [
+    ...new Set(
+      (
+        await getLabelsTable()
+          .where({
+            channel_id: channelId,
+          })
+          .select('offices')
+      )
+        .reduce((acc, item) => acc.concat(item.offices), [])
+        .filter((office) => office != null)
+    ),
+  ];
+
+  // If no offices are found for the channel, backfill this with sfo
+  if (offices.length === 0) {
+    // @ts-expect-error
+    const channelName = (
+      await bolt.client.conversations.info({ channel: channelId })
+    ).channel?.name;
+    await bolt.client.chat.postMessage({
+      text: `Hey OSPO, looks like #${channelName} doesn't have offices set.`,
+      channel: TEAM_OSPO_CHANNEL_ID,
+    });
+    offices = ['sfo'];
+  }
+
+  // for all offices, check if the current time is in business hours
+  return offices
+    .map((office: any) => isTimeInBusinessHours(now, office))
+    .includes(true);
+};
+
 export async function getNextAvailableBusinessHourWindow(
   productArea: string,
   momentTime: moment.Moment,
-  repo: string,
-  org: string
+  repo?: string,
+  org?: string
 ): Promise<BusinessHourWindow> {
-  let offices: Set<string> = new Set<string>();
-  const teams = getTeams(repo, org, productArea);
+  let offices: string[] = [];
   // TODO(getsentry/team-ospo#200): Add codecov support
-  if (org !== 'codecov') {
-    offices = teams.reduce((acc, team) => {
-      if (PRODUCT_OWNERS_INFO['teams'][team]['offices']) {
-        PRODUCT_OWNERS_INFO['teams'][team]['offices'].forEach((office) => {
-          acc.add(office);
-        });
-      }
-      return acc;
-    }, new Set<string>());
-  }
-  if (!offices.size) {
-    offices = new Set<string>().add('sfo');
+  if (repo && org && GETSENTRY_ORG.repos.withoutRouting.includes(repo)) {
+    offices = PRODUCT_OWNERS_INFO['teams'][getTeams(repo, org, undefined)][
+      'offices'
+    ] || ['sfo'];
+  } else {
+    // TODO(team-ospo/issues#198): Stop querying db by product area
+    offices = await getOffices(productArea);
+    if (offices.length === 0) {
+      offices = await getOffices('Product Area: Other');
+    }
   }
   const businessHourWindows: BusinessHourWindow[] = [];
-  ([...offices] || ['sfo']).forEach((office) => {
+  offices.forEach((office) => {
     const momentIterator = moment(momentTime.valueOf()).utc();
     let isWeekend,
       dayOfTheWeek,
@@ -174,4 +224,18 @@ export async function getNextAvailableBusinessHourWindow(
   // Sort the business hours by the starting date, we only care about the closest business hour window
   businessHourWindows.sort((a: any, b: any) => a.start - b.start);
   return businessHourWindows[0];
+}
+
+export async function getOffices(
+  productArea: string,
+  repo?: string,
+  org?: string
+) {
+  if (!productArea) {
+    return [];
+  }
+  if (!officesCache[productArea]) {
+    await cacheOffices(productArea);
+  }
+  return officesCache[productArea];
 }

--- a/src/utils/getTeams.test.ts
+++ b/src/utils/getTeams.test.ts
@@ -4,16 +4,16 @@ import { getTeams } from './getTeams';
 
 // Check tests/product-owners.yml for data used for tests here
 describe('getTeams', function () {
-  it('should return team-ospo if no teams were found', () => {
-    expect(getTeams('repo-does-not-exist', 'getsentry')).toEqual(['team-ospo']);
+  it('should return empty array if no teams were found', () => {
+    expect(getTeams('repo-does-not-exist', 'getsentry')).toEqual([]);
   });
 
   it('should return array with one team if repo does not have routing', () => {
-    expect(getTeams('test-ttt-simple', 'getsentry')).toEqual(['team-issues']);
+    expect(getTeams('test-ttt-simple', 'getsentry')).toEqual(['team-ospo']);
   });
 
-  it('should return team-ospo if repo has routing and no product area is passed', () => {
-    expect(getTeams('routing-repo', 'getsentry')).toEqual(['team-ospo']);
+  it('should return empty array if repo has routing and no product area is passed', () => {
+    expect(getTeams('routing-repo', 'getsentry')).toEqual([]);
   });
 
   it('should return array with one team if repo has routing and product area is owned by one team', () => {
@@ -33,21 +33,21 @@ describe('getTeams', function () {
     expect(getTeams('codecov-repo', 'codecov', 'Multi-Team')).toEqual([]);
   });
 
-  it('should return team-ospo if team is not defined in product owners yml', () => {
+  it('should return empty array if team is not defined in product owners yml', () => {
     const captureMessageSpy = jest.spyOn(Sentry, 'captureMessage');
-    expect(getTeams('undefined-team-repo', 'getsentry', 'Multi-Team')).toEqual([
-      'team-ospo',
-    ]);
+    expect(getTeams('undefined-team-repo', 'getsentry', 'Multi-Team')).toEqual(
+      []
+    );
     expect(captureMessageSpy).toHaveBeenCalledWith(
       'Teams is not defined for getsentry/undefined-team-repo'
     );
   });
 
-  it('should return team-ospo if product area is not defined in product owners yml', () => {
+  it('should return empty array if product area is not defined in product owners yml', () => {
     const captureMessageSpy = jest.spyOn(Sentry, 'captureMessage');
     expect(
       getTeams('routing-repo', 'getsentry', 'Undefined Product Area')
-    ).toEqual(['team-ospo']);
+    ).toEqual([]);
     expect(captureMessageSpy).toHaveBeenCalledWith(
       'Teams is not defined for Undefined Product Area'
     );

--- a/src/utils/getTeams.ts
+++ b/src/utils/getTeams.ts
@@ -15,7 +15,7 @@ export function getTeams(
   if (orgObj.repos.withoutRouting.includes(`${repo}`)) {
     if (!PRODUCT_OWNERS_INFO['repos'][repo]) {
       Sentry.captureMessage(`Teams is not defined for ${org}/${repo}`);
-      return ['team-ospo'];
+      return [];
     }
     return [PRODUCT_OWNERS_INFO['repos'][repo]];
   }
@@ -23,10 +23,10 @@ export function getTeams(
     if (productArea) {
       if (!PRODUCT_OWNERS_INFO['product_areas'][productArea]) {
         Sentry.captureMessage(`Teams is not defined for ${productArea}`);
-        return ['team-ospo'];
+        return [];
       }
       return PRODUCT_OWNERS_INFO['product_areas'][productArea];
     }
   }
-  return ['team-ospo'];
+  return [];
 }

--- a/src/utils/metrics.test.ts
+++ b/src/utils/metrics.test.ts
@@ -187,7 +187,7 @@ describe('metrics tests', function () {
       testPayload.issue.labels = [];
       const result = await insertOss('issues', testPayload);
       expect(result).toMatchObject({
-        teams: ['team-issues'],
+        teams: ['team-ospo'],
         product_area: null,
       });
     });
@@ -199,7 +199,7 @@ describe('metrics tests', function () {
       testPayload.issue.labels = [];
       const result = await insertOss('issues', testPayload);
       expect(result).toMatchObject({
-        teams: ['team-issues'],
+        teams: ['team-ospo'],
         product_area: null,
       });
     });
@@ -211,7 +211,7 @@ describe('metrics tests', function () {
       testPayload.comment = { id: 123, created_at: null, updated_at: null };
       const result = await insertOss('issue_comment', testPayload);
       expect(result).toMatchObject({
-        teams: ['team-issues'],
+        teams: ['team-ospo'],
         product_area: null,
       });
     });

--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -290,9 +290,7 @@ export async function insertOss(
           data.product_area.slice(PRODUCT_AREA_LABEL_PREFIX.length);
         if (data.action === 'labeled') {
           data.timeToRouteBy = await calculateSLOViolationRoute(
-            data.target_name,
-            payload.repository.name,
-            payload.organization.login
+            data.target_name
           );
           data.timeToTriageBy = await calculateSLOViolationTriage(
             data.target_name,

--- a/src/webhooks/pubsub/slackNotifications.test.ts
+++ b/src/webhooks/pubsub/slackNotifications.test.ts
@@ -1,21 +1,39 @@
 import * as Sentry from '@sentry/node';
 import moment from 'moment-timezone';
 
+import { getLabelsTable } from '@/brain/issueNotifier';
 import { GETSENTRY_ORG } from '@/config';
 import { bolt } from '@api/slack';
 import { db } from '@utils/db';
 
 import {
   constructSlackMessage,
-  getChannelsForIssue,
+  getChannelIdForIssue,
+  getOfficesForRepo,
   getTriageSLOTimestamp,
   notifyProductOwnersForUntriagedIssues,
 } from './slackNotifications';
 
 describe('Triage Notification Tests', function () {
   const org = GETSENTRY_ORG;
+
   beforeAll(async function () {
     await db.migrate.latest();
+    await getLabelsTable().insert({
+      label_name: 'Product Area: Other',
+      channel_id: 'channel1',
+      offices: ['yyz'],
+    });
+    await getLabelsTable().insert({
+      label_name: 'Product Area: Test',
+      channel_id: 'channel2',
+      offices: ['yyz'],
+    });
+    await getLabelsTable().insert({
+      label_name: 'Product Area: Other',
+      channel_id: 'channel2',
+      offices: ['yyz'],
+    });
   });
   afterAll(async function () {
     await db('label_to_channel').delete();
@@ -23,6 +41,15 @@ describe('Triage Notification Tests', function () {
   });
   describe('getTriageSLOTimestamp', function () {
     let getIssueDueDateFromProjectSpy;
+    const sampleComment = {
+      user: {
+        type: 'Bot',
+        login: 'getsantry[bot]',
+      },
+      body: `Routing to @getsentry/open-source for [triage](https://develop.sentry.dev/processing-tickets/
+        #3-triage), due by **<time datetime=2023-01-05T16:00:00.000Z>Thu Jan 05 2023 16:00:00 GMT+0000</time>**.`,
+      created_at: '2022-12-27T21:14:14Z',
+    };
     beforeAll(function () {
       jest
         .spyOn(org, 'addIssueToGlobalIssuesProject')
@@ -79,45 +106,27 @@ describe('Triage Notification Tests', function () {
       );
     });
   });
-  describe('getChannelsForIssue', () => {
-    it('will get channel info for repo without routing', () => {
-      expect(
-        getChannelsForIssue(
-          'test-ttt-simple',
-          'getsentry',
-          '',
-          moment('2022-12-12T17:00:00.000Z')
-        )
-      ).toEqual([{ channelId: 'C05A6BW303Z', isChannelInBusinessHours: true }]);
+  describe('getChannelIdForIssue', () => {
+    it('will get channelId for valid repo and org', () => {
+      expect(getChannelIdForIssue('test-ttt-simple', 'getsentry')).toEqual(
+        'C05A6BW303Y'
+      );
     });
-    it('will get channel info for repo with routing', () => {
-      expect(
-        getChannelsForIssue(
-          'routing-repo',
-          'getsentry',
-          'Multi-Team',
-          moment('2022-12-14T00:00:00.000Z')
-        )
-      ).toEqual([
-        {
-          channelId: 'C05A6BW303Z',
-          isChannelInBusinessHours: true,
-        },
-        {
-          channelId: 'C05A6BW303B',
-          isChannelInBusinessHours: false,
-        },
+    it('will return null if inputs are invalid', () => {
+      expect(getChannelIdForIssue('garbage-repo', 'getsentry')).toEqual(null);
+    });
+  });
+  describe('getOfficesForRepo', () => {
+    it('will get channelId for valid repo and org', () => {
+      expect(getOfficesForRepo('test-ttt-simple', 'getsentry')).toEqual([
+        'sea',
       ]);
     });
-    it('will return team-ospo channel if inputs are invalid', () => {
-      expect(
-        getChannelsForIssue(
-          'garbage-repo',
-          'getsentry',
-          '',
-          moment('2022-12-12T17:00:00.000Z')
-        )
-      ).toEqual([{ channelId: 'C05A6BW303Y', isChannelInBusinessHours: true }]);
+    it('will return null if inputs are invalid', () => {
+      expect(getOfficesForRepo('garbage-repo', 'getsentry')).toEqual([]);
+    });
+    it('will return sfo if office for repo is null', () => {
+      expect(getOfficesForRepo('test-null', 'getsentry')).toEqual(['sfo']);
     });
   });
   describe('constructSlackMessage', function () {
@@ -130,51 +139,103 @@ describe('Triage Notification Tests', function () {
       jest.clearAllMocks();
     });
     it('should return empty promise if no issues are untriaged', async function () {
+      const notificationChannels = {
+        channel1: ['Product Area: Test'],
+        channel2: ['Product Area: Test', 'Product Area: Other'],
+      };
+      const productAreaToIssuesMap = {
+        'Product Area: Test': [],
+        'Product Area: Other': [],
+      };
       const channelToIssuesMap = { channel1: [], channel2: [] };
       const now = moment('2022-12-12T17:00:00.000Z');
-      await Promise.all(constructSlackMessage(channelToIssuesMap, now));
+      await Promise.all(
+        constructSlackMessage(
+          notificationChannels,
+          productAreaToIssuesMap,
+          channelToIssuesMap,
+          now
+        )
+      );
       expect(boltPostMessageSpy).toHaveBeenCalledTimes(0);
     });
-    it('should return all issues in overdue if SLA has passed', async function () {
-      const channelToIssuesMap = {
-        channel1: [
+    it('should return empty promise if outside business hours', async function () {
+      const notificationChannels = {
+        channel1: ['Product Area: Test'],
+        channel2: ['Product Area: Test', 'Product Area: Other'],
+      };
+      const productAreaToIssuesMap = {
+        'Product Area: Test': [
           {
             url: 'https://test.com/issues/1',
             number: 1,
             title: 'Test Issue',
+            productAreaLabel: 'Product Area: Test',
             triageBy: '2022-12-12T21:00:00.000Z',
             createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel1', isChannelInBusinessHours: true },
-            ],
           },
         ],
-        channel2: [
-          {
-            url: 'https://test.com/issues/1',
-            number: 1,
-            title: 'Test Issue',
-            triageBy: '2022-12-12T21:00:00.000Z',
-            createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel2', isChannelInBusinessHours: true },
-            ],
-          },
+        'Product Area: Other': [
           {
             url: 'https://test.com/issues/2',
             number: 2,
             title: 'Open Source Issue',
+            productAreaLabel: 'Product Area: Other',
             triageBy: '2022-12-12T20:00:00.000Z',
             createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel2', isChannelInBusinessHours: true },
-            ],
           },
         ],
       };
+      const channelToIssuesMap = { channel1: [], channel2: [] };
+      const now = moment('2022-12-12T00:00:00.000Z');
+      await Promise.all(
+        constructSlackMessage(
+          notificationChannels,
+          productAreaToIssuesMap,
+          channelToIssuesMap,
+          now
+        )
+      );
+      expect(boltPostMessageSpy).toHaveBeenCalledTimes(0);
+    });
+    it('should return all issues in overdue if SLA has passed', async function () {
+      const notificationChannels = {
+        channel1: ['Product Area: Test'],
+        channel2: ['Product Area: Test', 'Product Area: Other'],
+      };
+      const productAreaToIssuesMap = {
+        'Product Area: Test': [
+          {
+            url: 'https://test.com/issues/1',
+            number: 1,
+            title: 'Test Issue',
+            productAreaLabel: 'Product Area: Test',
+            triageBy: '2022-12-12T21:00:00.000Z',
+            createdAt: '2022-12-10T21:00:00.000Z',
+          },
+        ],
+        'Product Area: Other': [
+          {
+            url: 'https://test.com/issues/2',
+            number: 2,
+            title: 'Open Source Issue',
+            productAreaLabel: 'Product Area: Other',
+            triageBy: '2022-12-12T20:00:00.000Z',
+            createdAt: '2022-12-10T21:00:00.000Z',
+          },
+        ],
+      };
+      const channelToIssuesMap = { channel1: [], channel2: [] };
       const now = moment('2022-12-12T21:00:00.000Z');
       const postMessageSpy = jest.spyOn(bolt.client.chat, 'postMessage');
-      await Promise.all(constructSlackMessage(channelToIssuesMap, now));
+      await Promise.all(
+        constructSlackMessage(
+          notificationChannels,
+          productAreaToIssuesMap,
+          channelToIssuesMap,
+          now
+        )
+      );
       expect(postMessageSpy).toHaveBeenCalledTimes(2);
       expect(postMessageSpy).toHaveBeenCalledWith({
         blocks: [
@@ -263,33 +324,44 @@ describe('Triage Notification Tests', function () {
       });
     });
     it('should sort issues before assigning ordinals to them', async function () {
-      const channelToIssuesMap = {
-        channel1: [
+      const notificationChannels = {
+        channel1: ['Product Area: Test', 'Product Area: Other'],
+      };
+
+      // Note that these issues come in in reverse order.
+      const productAreaToIssuesMap = {
+        'Product Area: Other': [
           {
             url: 'https://test.com/issues/2',
             number: 2,
             title: 'Open Source Issue',
+            productAreaLabel: 'Product Area: Other',
             triageBy: '2022-12-12T20:00:00.000Z',
             createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel1', isChannelInBusinessHours: true },
-            ],
           },
+        ],
+        'Product Area: Test': [
           {
             url: 'https://test.com/issues/1',
             number: 1,
             title: 'Test Issue',
+            productAreaLabel: 'Product Area: Test',
             triageBy: '2022-12-12T21:00:00.000Z',
             createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel1', isChannelInBusinessHours: true },
-            ],
           },
         ],
       };
+      const channelToIssuesMap = { channel1: [], channel2: [] };
       const now = moment('2022-12-12T21:00:00.000Z');
       const postMessageSpy = jest.spyOn(bolt.client.chat, 'postMessage');
-      await Promise.all(constructSlackMessage(channelToIssuesMap, now));
+      await Promise.all(
+        constructSlackMessage(
+          notificationChannels,
+          productAreaToIssuesMap,
+          channelToIssuesMap,
+          now
+        )
+      );
       expect(postMessageSpy).toHaveBeenCalledTimes(1);
       expect(postMessageSpy).toHaveBeenCalledWith({
         blocks: [
@@ -342,53 +414,62 @@ describe('Triage Notification Tests', function () {
       });
     });
     it('should maintain independent and properly sorted ordinals for adjacent issue lists', async function () {
-      const channelToIssuesMap = {
-        channel1: [
+      const notificationChannels = {
+        channel1: ['Product Area: Test', 'Product Area: Other'],
+      };
+
+      // Note that the orders of the two lists are flipped relative to one another: one is
+      // ascending, the other is descending. This let's us validate that the final ordinal
+      // assignment is done independent of the ordering of the array we receive.
+      const productAreaToIssuesMap = {
+        'Product Area: Test': [
           {
             url: 'https://test.com/issues/3',
             number: 3,
             title: 'Test Issue Overdue',
+            productAreaLabel: 'Product Area: Test',
             triageBy: '2022-12-12T15:00:00.000Z',
             createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel1', isChannelInBusinessHours: true },
-            ],
           },
           {
             url: 'https://test.com/issues/1',
             number: 1,
             title: 'Test Issue Almost Due',
+            productAreaLabel: 'Product Area: Test',
             triageBy: '2022-12-12T19:00:00.000Z',
             createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel1', isChannelInBusinessHours: true },
-            ],
           },
+        ],
+        'Product Area: Other': [
           {
             url: 'https://test.com/issues/2',
             number: 2,
             title: 'Open Source Issue Almost Due',
+            productAreaLabel: 'Product Area: Other',
             triageBy: '2022-12-12T18:00:00.000Z',
             createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel1', isChannelInBusinessHours: true },
-            ],
           },
           {
             url: 'https://test.com/issues/4',
             number: 4,
             title: 'Open Source Issue Overdue',
+            productAreaLabel: 'Product Area: Other',
             triageBy: '2022-12-12T16:00:00.000Z',
             createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel1', isChannelInBusinessHours: true },
-            ],
           },
         ],
       };
+      const channelToIssuesMap = { channel1: [], channel2: [] };
       const now = moment('2022-12-12T16:58:00.000Z');
       const postMessageSpy = jest.spyOn(bolt.client.chat, 'postMessage');
-      await Promise.all(constructSlackMessage(channelToIssuesMap, now));
+      await Promise.all(
+        constructSlackMessage(
+          notificationChannels,
+          productAreaToIssuesMap,
+          channelToIssuesMap,
+          now
+        )
+      );
       expect(postMessageSpy).toHaveBeenCalledTimes(1);
       expect(postMessageSpy).toHaveBeenCalledWith({
         blocks: [
@@ -471,43 +552,48 @@ describe('Triage Notification Tests', function () {
       });
     });
     it('should strip issue of < and > characters in slack message', async function () {
-      const channelToIssuesMap = {
-        channel1: [
+      const notificationChannels = {
+        channel1: ['Product Area: Test'],
+      };
+      const productAreaToIssuesMap = {
+        'Product Area: Test': [
           {
             url: 'https://test.com/issues/1',
             number: 1,
             title: '<Test Issue 1>',
+            productAreaLabel: 'Product Area: Test',
             triageBy: '2022-12-12T21:00:00.000Z',
             createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel1', isChannelInBusinessHours: true },
-            ],
           },
           {
             url: 'https://test.com/issues/2',
             number: 2,
             title: '<Test Issue 2>',
+            productAreaLabel: 'Product Area: Test',
             triageBy: '2022-12-12T22:00:00.000Z',
             createdAt: '2022-12-10T22:00:00.000Z',
-            channels: [
-              { channelId: 'channel1', isChannelInBusinessHours: true },
-            ],
           },
           {
             url: 'https://test.com/issues/3',
             number: 3,
             title: '<Test Issue 3>',
+            productAreaLabel: 'Product Area: Test',
             triageBy: '2022-12-14T20:00:00.000Z',
             createdAt: '2022-12-12T20:00:00.000Z',
-            channels: [
-              { channelId: 'channel1', isChannelInBusinessHours: true },
-            ],
           },
         ],
       };
+      const channelToIssuesMap = { channel1: [], channel2: [] };
       const now = moment('2022-12-12T21:00:00.000Z');
       const postMessageSpy = jest.spyOn(bolt.client.chat, 'postMessage');
-      await Promise.all(constructSlackMessage(channelToIssuesMap, now));
+      await Promise.all(
+        constructSlackMessage(
+          notificationChannels,
+          productAreaToIssuesMap,
+          channelToIssuesMap,
+          now
+        )
+      );
       expect(postMessageSpy).toHaveBeenCalledTimes(1);
       expect(postMessageSpy).toHaveBeenCalledWith({
         blocks: [
@@ -567,91 +653,92 @@ describe('Triage Notification Tests', function () {
       });
     });
     it('should always notify if issues are overdue and an hour has passed', async function () {
-      const channelToIssuesMap = {
-        channel1: [
+      const notificationChannels = {
+        channel1: ['Product Area: Test'],
+        channel2: ['Product Area: Test', 'Product Area: Other'],
+      };
+      const productAreaToIssuesMap = {
+        'Product Area: Test': [
           {
             url: 'https://test.com/issues/1',
             number: 1,
             title: 'Test Issue',
+            productAreaLabel: 'Product Area: Test',
             triageBy: '2022-12-12T21:00:00.000Z',
             createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel1', isChannelInBusinessHours: true },
-            ],
           },
         ],
-        channel2: [
-          {
-            url: 'https://test.com/issues/1',
-            number: 1,
-            title: 'Test Issue',
-            triageBy: '2022-12-12T21:00:00.000Z',
-            createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel2', isChannelInBusinessHours: true },
-            ],
-          },
+        'Product Area: Other': [
           {
             url: 'https://test.com/issues/2',
             number: 2,
             title: 'Open Source Issue',
+            productAreaLabel: 'Product Area: Other',
             triageBy: '2022-12-12T20:00:00.000Z',
             createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel2', isChannelInBusinessHours: true },
-            ],
           },
         ],
       };
+      const channelToIssuesMap = { channel1: [], channel2: [] };
       const now = moment('2022-12-12T21:00:00.000Z');
       const postMessageSpy = jest.spyOn(bolt.client.chat, 'postMessage');
-      await Promise.all(constructSlackMessage(channelToIssuesMap, now));
+      await Promise.all(
+        constructSlackMessage(
+          notificationChannels,
+          productAreaToIssuesMap,
+          channelToIssuesMap,
+          now
+        )
+      );
       expect(postMessageSpy).toHaveBeenCalledTimes(2);
       await Promise.all(
-        constructSlackMessage(channelToIssuesMap, now.add(1, 'hours'))
+        constructSlackMessage(
+          notificationChannels,
+          productAreaToIssuesMap,
+          channelToIssuesMap,
+          now.add(1, 'hours')
+        )
       );
       expect(postMessageSpy).toHaveBeenCalledTimes(4);
     });
     it('should return all issues in act fast if SLA is approaching', async function () {
-      const channelToIssuesMap = {
-        channel1: [
+      const notificationChannels = {
+        channel1: ['Product Area: Test'],
+        channel2: ['Product Area: Test', 'Product Area: Other'],
+      };
+      const productAreaToIssuesMap = {
+        'Product Area: Test': [
           {
             url: 'https://test.com/issues/1',
             number: 1,
             title: 'Test Issue',
+            productAreaLabel: 'Product Area: Test',
             triageBy: '2022-12-12T21:00:00.000Z',
             createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel1', isChannelInBusinessHours: true },
-            ],
           },
         ],
-        channel2: [
-          {
-            url: 'https://test.com/issues/1',
-            number: 1,
-            title: 'Test Issue',
-            triageBy: '2022-12-12T21:00:00.000Z',
-            createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel2', isChannelInBusinessHours: true },
-            ],
-          },
+        'Product Area: Other': [
           {
             url: 'https://test.com/issues/2',
             number: 2,
             title: 'Open Source Issue',
+            productAreaLabel: 'Product Area: Other',
             triageBy: '2022-12-12T20:00:00.000Z',
             createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel2', isChannelInBusinessHours: true },
-            ],
           },
         ],
       };
+      const channelToIssuesMap = { channel1: [], channel2: [] };
       const now = moment('2022-12-12T17:00:00.000Z');
       const postMessageSpy = jest.spyOn(bolt.client.chat, 'postMessage');
-      await Promise.all(constructSlackMessage(channelToIssuesMap, now));
+      await Promise.all(
+        constructSlackMessage(
+          notificationChannels,
+          productAreaToIssuesMap,
+          channelToIssuesMap,
+          now
+        )
+      );
       expect(postMessageSpy).toHaveBeenCalledTimes(2);
       expect(postMessageSpy).toHaveBeenCalledWith({
         blocks: [
@@ -769,133 +856,106 @@ describe('Triage Notification Tests', function () {
           },
         ],
       };
-      const channelToIssuesMap = {
-        channel1: [
-          {
-            url: 'https://test.com/issues/1',
-            number: 1,
-            title: 'Test Issue',
-            triageBy: '2022-12-12T21:00:00.000Z',
-            createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel1', isChannelInBusinessHours: true },
-            ],
-          },
-        ],
-        channel2: [
-          {
-            url: 'https://test.com/issues/1',
-            number: 1,
-            title: 'Test Issue',
-            triageBy: '2022-12-12T21:00:00.000Z',
-            createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel2', isChannelInBusinessHours: true },
-            ],
-          },
-          {
-            url: 'https://test.com/issues/2',
-            number: 2,
-            title: 'Open Source Issue',
-            triageBy: '2022-12-12T20:00:00.000Z',
-            createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel2', isChannelInBusinessHours: true },
-            ],
-          },
-        ],
-      };
+      const channelToIssuesMap = { channel1: [], channel2: [] };
       const now = moment('2022-12-12T17:00:00.000Z');
       const postMessageSpy = jest.spyOn(bolt.client.chat, 'postMessage');
-      await Promise.all(constructSlackMessage(channelToIssuesMap, now));
+      await Promise.all(
+        constructSlackMessage(
+          notificationChannels,
+          productAreaToIssuesMap,
+          channelToIssuesMap,
+          now
+        )
+      );
       expect(postMessageSpy).toHaveBeenCalledTimes(2);
       await Promise.all(
-        constructSlackMessage(channelToIssuesMap, now.add(1, 'hours'))
+        constructSlackMessage(
+          notificationChannels,
+          productAreaToIssuesMap,
+          channelToIssuesMap,
+          now.add(1, 'hours')
+        )
       );
       expect(postMessageSpy).toHaveBeenCalledTimes(4);
     });
     it('should return nothing in triage queue if issues were created less than 4 hours ago', async function () {
-      const channelToIssuesMap = {
-        channel1: [
+      const notificationChannels = {
+        channel1: ['Product Area: Test'],
+        channel2: ['Product Area: Test', 'Product Area: Other'],
+      };
+      const productAreaToIssuesMap = {
+        'Product Area: Test': [
           {
             url: 'https://test.com/issues/1',
             number: 1,
             title: 'Test Issue',
+            productAreaLabel: 'Product Area: Test',
             triageBy: '2022-12-13T21:00:00.000Z',
             createdAt: '2022-12-12T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel1', isChannelInBusinessHours: true },
-            ],
           },
         ],
-        channel2: [
-          {
-            url: 'https://test.com/issues/1',
-            number: 1,
-            title: 'Test Issue',
-            triageBy: '2022-12-13T20:00:00.000Z',
-            createdAt: '2022-12-12T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel2', isChannelInBusinessHours: true },
-            ],
-          },
+        'Product Area: Other': [
           {
             url: 'https://test.com/issues/2',
             number: 2,
             title: 'Open Source Issue',
+            productAreaLabel: 'Product Area: Other',
             triageBy: '2022-12-13T20:00:00.000Z',
             createdAt: '2022-12-12T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel2', isChannelInBusinessHours: true },
-            ],
           },
         ],
       };
+      const channelToIssuesMap = { channel1: [], channel2: [] };
       const now = moment('2022-12-12T16:58:00.000Z');
       const postMessageSpy = jest.spyOn(bolt.client.chat, 'postMessage');
-      await Promise.all(constructSlackMessage(channelToIssuesMap, now));
+      await Promise.all(
+        constructSlackMessage(
+          notificationChannels,
+          productAreaToIssuesMap,
+          channelToIssuesMap,
+          now
+        )
+      );
       expect(postMessageSpy).toHaveBeenCalledTimes(0);
     });
     it('should return all issues in triage queue if SLA is more than 4 hours away', async function () {
-      const channelToIssuesMap = {
-        channel1: [
+      const notificationChannels = {
+        channel1: ['Product Area: Test'],
+        channel2: ['Product Area: Test', 'Product Area: Other'],
+      };
+      const productAreaToIssuesMap = {
+        'Product Area: Test': [
           {
             url: 'https://test.com/issues/1',
             number: 1,
             title: 'Test Issue',
+            productAreaLabel: 'Product Area: Test',
             triageBy: '2022-12-13T21:00:00.000Z',
             createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel1', isChannelInBusinessHours: true },
-            ],
           },
         ],
-        channel2: [
-          {
-            url: 'https://test.com/issues/1',
-            number: 1,
-            title: 'Test Issue',
-            triageBy: '2022-12-13T21:00:00.000Z',
-            createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel2', isChannelInBusinessHours: true },
-            ],
-          },
+        'Product Area: Other': [
           {
             url: 'https://test.com/issues/2',
             number: 2,
             title: 'Open Source Issue',
+            productAreaLabel: 'Product Area: Other',
             triageBy: '2022-12-13T20:00:00.000Z',
             createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel2', isChannelInBusinessHours: true },
-            ],
           },
         ],
       };
+      const channelToIssuesMap = { channel1: [], channel2: [] };
       const now = moment('2022-12-12T16:58:00.000Z');
       const postMessageSpy = jest.spyOn(bolt.client.chat, 'postMessage');
-      await Promise.all(constructSlackMessage(channelToIssuesMap, now));
+      await Promise.all(
+        constructSlackMessage(
+          notificationChannels,
+          productAreaToIssuesMap,
+          channelToIssuesMap,
+          now
+        )
+      );
       expect(postMessageSpy).toHaveBeenCalledTimes(2);
       expect(postMessageSpy).toHaveBeenCalledWith({
         blocks: [
@@ -984,157 +1044,149 @@ describe('Triage Notification Tests', function () {
       });
     });
     it('should not notify if issues are only in triage queue and channel has been notified less than 4 hours ago', async function () {
-      const channelToIssuesMap = {
-        channel1: [
+      const notificationChannels = {
+        channel1: ['Product Area: Test'],
+        channel2: ['Product Area: Test', 'Product Area: Other'],
+      };
+      const productAreaToIssuesMap = {
+        'Product Area: Test': [
           {
             url: 'https://test.com/issues/1',
             number: 1,
             title: 'Test Issue',
+            productAreaLabel: 'Product Area: Test',
             triageBy: '2022-12-13T21:00:00.000Z',
             createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel1', isChannelInBusinessHours: true },
-            ],
           },
         ],
-        channel2: [
-          {
-            url: 'https://test.com/issues/1',
-            number: 1,
-            title: 'Test Issue',
-            triageBy: '2022-12-13T21:00:00.000Z',
-            createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel2', isChannelInBusinessHours: true },
-            ],
-          },
+        'Product Area: Other': [
           {
             url: 'https://test.com/issues/2',
             number: 2,
             title: 'Open Source Issue',
+            productAreaLabel: 'Product Area: Other',
             triageBy: '2022-12-13T20:00:00.000Z',
             createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel2', isChannelInBusinessHours: true },
-            ],
           },
         ],
       };
+      const channelToIssuesMap = { channel1: [], channel2: [] };
       const now = moment('2022-12-12T16:58:00.000Z');
       const postMessageSpy = jest.spyOn(bolt.client.chat, 'postMessage');
-      await Promise.all(constructSlackMessage(channelToIssuesMap, now));
+      await Promise.all(
+        constructSlackMessage(
+          notificationChannels,
+          productAreaToIssuesMap,
+          channelToIssuesMap,
+          now
+        )
+      );
       expect(postMessageSpy).toHaveBeenCalledTimes(2);
       await Promise.all(
-        constructSlackMessage(channelToIssuesMap, now.add(2, 'hours'))
+        constructSlackMessage(
+          notificationChannels,
+          productAreaToIssuesMap,
+          channelToIssuesMap,
+          now.add(2, 'hours')
+        )
       );
       expect(postMessageSpy).toHaveBeenCalledTimes(2);
     });
     it('should notify if issues are only in triage queue and channel has been notified 4 hours ago', async function () {
-      const channelToIssuesMap = {
-        channel1: [
+      const notificationChannels = {
+        channel1: ['Product Area: Test'],
+        channel2: ['Product Area: Test', 'Product Area: Other'],
+      };
+      const productAreaToIssuesMap = {
+        'Product Area: Test': [
           {
             url: 'https://test.com/issues/1',
             number: 1,
             title: 'Test Issue',
+            productAreaLabel: 'Product Area: Test',
             triageBy: '2022-12-13T21:00:00.000Z',
             createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel1', isChannelInBusinessHours: true },
-            ],
           },
         ],
-        channel2: [
-          {
-            url: 'https://test.com/issues/1',
-            number: 1,
-            title: 'Test Issue',
-            triageBy: '2022-12-13T21:00:00.000Z',
-            createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel2', isChannelInBusinessHours: true },
-            ],
-          },
+        'Product Area: Other': [
           {
             url: 'https://test.com/issues/2',
             number: 2,
             title: 'Open Source Issue',
+            productAreaLabel: 'Product Area: Other',
             triageBy: '2022-12-13T20:00:00.000Z',
             createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel2', isChannelInBusinessHours: true },
-            ],
           },
         ],
       };
+      const channelToIssuesMap = { channel1: [], channel2: [] };
       const now = moment('2022-12-12T16:58:00.000Z');
       const postMessageSpy = jest.spyOn(bolt.client.chat, 'postMessage');
-      await Promise.all(constructSlackMessage(channelToIssuesMap, now));
+      await Promise.all(
+        constructSlackMessage(
+          notificationChannels,
+          productAreaToIssuesMap,
+          channelToIssuesMap,
+          now
+        )
+      );
       expect(postMessageSpy).toHaveBeenCalledTimes(2);
       await Promise.all(
-        constructSlackMessage(channelToIssuesMap, now.add(4, 'hours'))
+        constructSlackMessage(
+          notificationChannels,
+          productAreaToIssuesMap,
+          channelToIssuesMap,
+          now.add(4, 'hours')
+        )
       );
       expect(postMessageSpy).toHaveBeenCalledTimes(4);
     });
     it('should return issues appropriately in different blocks', async function () {
-      const channelToIssuesMap = {
-        channel1: [
+      const notificationChannels = {
+        channel1: ['Product Area: Test'],
+        channel2: ['Product Area: Test', 'Product Area: Other'],
+      };
+      const productAreaToIssuesMap = {
+        'Product Area: Test': [
           {
             url: 'https://test.com/issues/1',
             number: 1,
             title: 'Test Issue',
+            productAreaLabel: 'Product Area: Test',
             triageBy: '2022-12-13T21:00:00.000Z',
             createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel1', isChannelInBusinessHours: true },
-            ],
           },
           {
             url: 'https://test.com/issues/3',
             number: 3,
             title: 'Test Issue 2',
+            productAreaLabel: 'Product Area: Test',
             triageBy: '2022-12-12T19:00:00.000Z',
             createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel1', isChannelInBusinessHours: true },
-            ],
           },
         ],
-        channel2: [
-          {
-            url: 'https://test.com/issues/1',
-            number: 1,
-            title: 'Test Issue',
-            triageBy: '2022-12-13T21:00:00.000Z',
-            createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel2', isChannelInBusinessHours: true },
-            ],
-          },
+        'Product Area: Other': [
           {
             url: 'https://test.com/issues/2',
             number: 2,
             title: 'Open Source Issue',
+            productAreaLabel: 'Product Area: Other',
             triageBy: '2022-12-12T16:00:00.000Z',
             createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel2', isChannelInBusinessHours: true },
-            ],
-          },
-          {
-            url: 'https://test.com/issues/3',
-            number: 3,
-            title: 'Test Issue 2',
-            triageBy: '2022-12-12T19:00:00.000Z',
-            createdAt: '2022-12-10T21:00:00.000Z',
-            channels: [
-              { channelId: 'channel2', isChannelInBusinessHours: true },
-            ],
           },
         ],
       };
+      const channelToIssuesMap = { channel1: [], channel2: [] };
       const now = moment('2022-12-12T16:58:00.000Z');
       const postMessageSpy = jest.spyOn(bolt.client.chat, 'postMessage');
-      await Promise.all(constructSlackMessage(channelToIssuesMap, now));
+      await Promise.all(
+        constructSlackMessage(
+          notificationChannels,
+          productAreaToIssuesMap,
+          channelToIssuesMap,
+          now
+        )
+      );
       expect(postMessageSpy).toHaveBeenCalledTimes(2);
       expect(postMessageSpy).toHaveBeenCalledWith({
         blocks: [
@@ -1236,6 +1288,14 @@ describe('Triage Notification Tests', function () {
       });
     });
     it('should return all issues in overdue if SLA has passed', async function () {
+      const notificationChannels = {
+        channel1: ['Product Area: Test'],
+        channel2: ['Product Area: Test', 'Product Area: Other'],
+      };
+      const productAreaToIssuesMap = {
+        'Product Area: Test': [],
+        'Product Area: Other': [],
+      };
       const channelToIssuesMap = {
         channel1: [
           {
@@ -1251,7 +1311,14 @@ describe('Triage Notification Tests', function () {
       };
       const now = moment('2022-12-12T21:00:00.000Z');
       const postMessageSpy = jest.spyOn(bolt.client.chat, 'postMessage');
-      await Promise.all(constructSlackMessage(channelToIssuesMap, now));
+      await Promise.all(
+        constructSlackMessage(
+          notificationChannels,
+          productAreaToIssuesMap,
+          channelToIssuesMap,
+          now
+        )
+      );
       expect(postMessageSpy).toHaveBeenCalledTimes(1);
       expect(postMessageSpy).toHaveBeenCalledWith({
         blocks: [
@@ -1363,7 +1430,7 @@ describe('Triage Notification Tests', function () {
         .mockReturnValue('2022-12-12T21:00:00.000Z');
       const now = moment('2022-12-12T21:00:00.000Z');
       await notifyProductOwnersForUntriagedIssues(org, now);
-      expect(postMessageSpy).toHaveBeenCalledTimes(2);
+      expect(postMessageSpy).toHaveBeenCalledTimes(3);
       expect(postMessageSpy).toHaveBeenCalledWith({
         blocks: [
           {
@@ -1394,7 +1461,38 @@ describe('Triage Notification Tests', function () {
           {
             fields: [
               {
-                text: '2. <https://test.com/issues/3|#3 Open Source Issue 1>',
+                text: '2. <https://test.com/issues/2|#2 Test Issue 2>',
+                type: 'mrkdwn',
+              },
+              { text: '8 hours overdue', type: 'mrkdwn' },
+            ],
+            type: 'section',
+          },
+        ],
+        channel: 'channel2',
+        text: '👋 Triage Reminder ⏰',
+      });
+      expect(postMessageSpy).toHaveBeenCalledWith({
+        blocks: [
+          {
+            text: {
+              text: 'Hey! You have some tickets to triage:',
+              type: 'plain_text',
+            },
+            type: 'header',
+          },
+          { type: 'divider' },
+          {
+            fields: [
+              { text: '🚨 *Overdue*', type: 'mrkdwn' },
+              { text: '😰', type: 'mrkdwn' },
+            ],
+            type: 'section',
+          },
+          {
+            fields: [
+              {
+                text: '1. <https://test.com/issues/3|#3 Open Source Issue 1>',
                 type: 'mrkdwn',
               },
               { text: '0 minutes overdue', type: 'mrkdwn' },
@@ -1404,7 +1502,7 @@ describe('Triage Notification Tests', function () {
           {
             fields: [
               {
-                text: '3. <https://test.com/issues/4|#4 Open Source Issue 2>',
+                text: '2. <https://test.com/issues/4|#4 Open Source Issue 2>',
                 type: 'mrkdwn',
               },
               { text: '0 minutes overdue', type: 'mrkdwn' },
@@ -1412,7 +1510,7 @@ describe('Triage Notification Tests', function () {
             type: 'section',
           },
         ],
-        channel: 'C05A6BW303Z',
+        channel: 'C05A6BW303Y',
         text: '👋 Triage Reminder ⏰',
       });
       expect(postMessageSpy).toHaveBeenCalledWith({
@@ -1443,14 +1541,15 @@ describe('Triage Notification Tests', function () {
             type: 'section',
           },
         ],
-        channel: 'C05A6BW303Y',
+        channel: 'channel1',
         text: '👋 Triage Reminder ⏰',
       });
     });
 
-    it('should not report issues for codecov repo', async function () {
+    it('should not report issues to slack from codecov repos', async function () {
       org.api.paginate = jest
         .fn()
+        .mockReturnValueOnce([])
         .mockReturnValueOnce([
           {
             html_url: 'https://test.com/issues/1',
@@ -1462,107 +1561,13 @@ describe('Triage Notification Tests', function () {
               { name: 'Product Area: Test' },
             ],
             createdAt: '2022-12-08T21:00:00.000Z',
-            repo: 'routing-repo',
-          },
-          {
-            html_url: 'https://test.com/issues/2',
-            number: 2,
-            title: 'Test Issue 2',
-            node_id: 'node_id',
-            labels: [
-              { name: 'Waiting for: Product Owner' },
-              { name: 'Product Area: Other' },
-            ],
-            createdAt: '2022-12-08T21:00:00.000Z',
-            repo: 'routing-repo',
-          },
-        ])
-        .mockReturnValueOnce([
-          {
-            html_url: 'https://test.com/issues/3',
-            number: 3,
-            title: 'Open Source Issue 1',
-            node_id: 'node_id',
-            labels: [{ name: 'Waiting for: Product Owner' }],
-            createdAt: '2022-12-08T21:00:00.000Z',
-            repo: 'test-ttt-simple',
-          },
-          {
-            html_url: 'https://test.com/issues/4',
-            number: 4,
-            title: 'Open Source Issue 2',
-            node_id: 'node_id',
-            labels: [{ name: 'Waiting for: Product Owner' }],
-            createdAt: '2022-12-08T21:00:00.000Z',
             repo: 'test-ttt-simple',
           },
         ])
         .mockReturnValue([]);
-      getIssueDueDateFromProjectSpy
-        .mockReturnValueOnce('2022-12-09T20:00:00.000Z')
-        .mockReturnValueOnce('2022-12-12T13:00:00.000Z')
-        .mockReturnValue('2022-12-12T21:00:00.000Z');
-      const now = moment('2022-12-12T04:00:00.000Z');
       org.slug = 'codecov';
-      await notifyProductOwnersForUntriagedIssues(org, now);
-      expect(postMessageSpy).toHaveBeenCalledTimes(0);
-    });
-
-    it('should not report issues when out of business hours', async function () {
-      org.api.paginate = jest
-        .fn()
-        .mockReturnValueOnce([
-          {
-            html_url: 'https://test.com/issues/1',
-            number: 1,
-            title: 'Test Issue 1',
-            node_id: 'node_id',
-            labels: [
-              { name: 'Waiting for: Product Owner' },
-              { name: 'Product Area: Test' },
-            ],
-            createdAt: '2022-12-08T21:00:00.000Z',
-            repo: 'routing-repo',
-          },
-          {
-            html_url: 'https://test.com/issues/2',
-            number: 2,
-            title: 'Test Issue 2',
-            node_id: 'node_id',
-            labels: [
-              { name: 'Waiting for: Product Owner' },
-              { name: 'Product Area: Other' },
-            ],
-            createdAt: '2022-12-08T21:00:00.000Z',
-            repo: 'routing-repo',
-          },
-        ])
-        .mockReturnValueOnce([
-          {
-            html_url: 'https://test.com/issues/3',
-            number: 3,
-            title: 'Open Source Issue 1',
-            node_id: 'node_id',
-            labels: [{ name: 'Waiting for: Product Owner' }],
-            createdAt: '2022-12-08T21:00:00.000Z',
-            repo: 'test-ttt-simple',
-          },
-          {
-            html_url: 'https://test.com/issues/4',
-            number: 4,
-            title: 'Open Source Issue 2',
-            node_id: 'node_id',
-            labels: [{ name: 'Waiting for: Product Owner' }],
-            createdAt: '2022-12-08T21:00:00.000Z',
-            repo: 'test-ttt-simple',
-          },
-        ])
-        .mockReturnValue([]);
-      getIssueDueDateFromProjectSpy
-        .mockReturnValueOnce('2022-12-09T20:00:00.000Z')
-        .mockReturnValueOnce('2022-12-12T13:00:00.000Z')
-        .mockReturnValue('2022-12-12T21:00:00.000Z');
-      const now = moment('2022-12-12T04:00:00.000Z');
+      getIssueDueDateFromProjectSpy.mockReturnValue('2022-12-12T21:00:00.000Z');
+      const now = moment('2022-12-12T21:00:00.000Z');
       await notifyProductOwnersForUntriagedIssues(org, now);
       expect(postMessageSpy).toHaveBeenCalledTimes(0);
     });

--- a/src/webhooks/pubsub/slackNotifications.ts
+++ b/src/webhooks/pubsub/slackNotifications.ts
@@ -1,20 +1,24 @@
 import * as Sentry from '@sentry/node';
 import moment from 'moment-timezone';
 
+import { getLabelsTable } from '@/brain/issueNotifier';
 import {
   PRODUCT_AREA_LABEL_PREFIX,
   PRODUCT_OWNERS_INFO,
   WAITING_FOR_PRODUCT_OWNER_LABEL,
 } from '@/config';
 import { Issue } from '@/types';
-import { isTimeInBusinessHours } from '@/utils/businessHours';
+import {
+  isChannelInBusinessHours,
+  isTimeInBusinessHours,
+} from '@/utils/businessHours';
 import { GitHubOrg } from '@api/github/org';
 import { bolt } from '@api/slack';
 import { db } from '@utils/db';
 import { getTeams } from '@utils/getTeams';
 
 const GH_API_PER_PAGE = 100;
-const DEFAULT_PRODUCT_AREA = 'Other';
+const DEFAULT_PRODUCT_AREA_LABEL = 'Product Area: Other';
 const getChannelLastNotifiedTable = () => db('channel_last_notified');
 
 // An item with all of its relevant properties stringified as markdown.
@@ -41,24 +45,22 @@ type SlackMessageOrderedIssueItem = {
   ];
 };
 
+// TODO(team-ospo/issues#198): Clean up undefined types
 type IssueSLOInfo = {
   url: string;
   number: number;
   title: string;
+  productAreaLabel?: string;
   triageBy: string;
   createdAt: string;
-  channels: ChannelItem[];
+  channelId?: string;
+  isChannelInBusinessHours?: boolean;
 };
 
 type SlackMessageBlocks = {
   type: string;
   text?: object;
   fields?: object;
-};
-
-type ChannelItem = {
-  channelId: string;
-  isChannelInBusinessHours: boolean;
 };
 
 export const opts = {
@@ -81,17 +83,14 @@ export const opts = {
   },
 };
 
-const getLabelName = (label?: Issue['labels'][number]): string =>
+const getLabelName = (label?: Issue['labels'][number]) =>
   typeof label === 'string' ? label : label?.name || '';
 
-const getIssueProductAreaLabel = (issue: Issue): string => {
+const getIssueProductAreaLabel = (issue: Issue) => {
   const label = issue.labels.find((label) =>
     getLabelName(label).startsWith(PRODUCT_AREA_LABEL_PREFIX)
   );
-  return (
-    getLabelName(label).slice(PRODUCT_AREA_LABEL_PREFIX.length) ||
-    DEFAULT_PRODUCT_AREA
-  );
+  return getLabelName(label) || DEFAULT_PRODUCT_AREA_LABEL;
 };
 
 // Note that the `ordinal` field is the literal number that will show up, not the index in the
@@ -123,7 +122,7 @@ export const getTriageSLOTimestamp = async (
   repo: string,
   issueNumber: number,
   issueNodeId: string
-): Promise<string> => {
+) => {
   const issueNodeIdInProject = await org.addIssueToGlobalIssuesProject(
     issueNodeId,
     repo,
@@ -143,10 +142,12 @@ export const getTriageSLOTimestamp = async (
 };
 
 export const constructSlackMessage = (
+  notificationChannels: Record<string, string[]>,
+  productAreaToIssuesMap: Record<string, IssueSLOInfo[]>,
   channelToIssuesMap: Record<string, IssueSLOInfo[]>,
   now: moment.Moment
-): Promise<any>[] => {
-  return Object.keys(channelToIssuesMap).flatMap(async (channelId) => {
+) => {
+  return Object.keys(notificationChannels).flatMap(async (channelId) => {
     const overdueIssues: SlackMessageUnorderedIssueItem[] = [];
     const actFastIssues: SlackMessageUnorderedIssueItem[] = [];
     const triageQueueIssues: SlackMessageUnorderedIssueItem[] = [];
@@ -247,154 +248,162 @@ export const constructSlackMessage = (
         }
       }
     };
+    // TODO(team-ospo/issues#198): remove usage of isChannelInBusinessHours
+    if (
+      (channelToIssuesMap[channelId] &&
+        channelToIssuesMap[channelId].length > 0) ||
+      (await isChannelInBusinessHours(channelId, now))
+    ) {
+      notificationChannels[channelId].map((productArea) => {
+        productAreaToIssuesMap[productArea].forEach(addIssueToQueue);
+      });
 
-    channelToIssuesMap[channelId].forEach(addIssueToQueue);
+      if (channelToIssuesMap[channelId]) {
+        channelToIssuesMap[channelId]
+          .filter((issue) => issue.isChannelInBusinessHours)
+          .forEach(addIssueToQueue);
+      }
 
-    const sortAndFlattenIssuesArray = (issues) =>
-      issues
-        .sort(
-          (a, b) => moment(a.triageBy).valueOf() - moment(b.triageBy).valueOf()
-        )
-        .map((item, index) => {
-          return addOrderingToSlackMessageItem(item, index + 1).fields;
-        })
-        .flat();
+      const sortAndFlattenIssuesArray = (issues) =>
+        issues
+          .sort(
+            (a, b) =>
+              moment(a.triageBy).valueOf() - moment(b.triageBy).valueOf()
+          )
+          .map((item, index) => {
+            return addOrderingToSlackMessageItem(item, index + 1).fields;
+          })
+          .flat();
 
-    const messageBlocks: SlackMessageBlocks[] = [
-      {
-        type: 'header',
-        text: {
-          type: 'plain_text',
-          text: 'Hey! You have some tickets to triage:',
+      const messageBlocks: SlackMessageBlocks[] = [
+        {
+          type: 'header',
+          text: {
+            type: 'plain_text',
+            text: 'Hey! You have some tickets to triage:',
+          },
         },
-      },
-      {
-        type: 'divider',
-      },
-    ];
-    if (overdueIssues.length > 0) {
-      const formattedIssues = sortAndFlattenIssuesArray(overdueIssues);
-      messageBlocks.push({
-        type: 'section',
-        fields: [
-          { type: 'mrkdwn', text: `🚨 *Overdue*` },
-          { type: 'mrkdwn', text: `😰` },
-        ],
-      });
-      for (let i = 0; i < formattedIssues.length; i += 2) {
+        {
+          type: 'divider',
+        },
+      ];
+      if (overdueIssues.length > 0) {
+        const formattedIssues = sortAndFlattenIssuesArray(overdueIssues);
         messageBlocks.push({
           type: 'section',
-          fields: [formattedIssues[i], formattedIssues[i + 1]],
+          fields: [
+            { type: 'mrkdwn', text: `🚨 *Overdue*` },
+            { type: 'mrkdwn', text: `😰` },
+          ],
         });
+        for (let i = 0; i < formattedIssues.length; i += 2) {
+          messageBlocks.push({
+            type: 'section',
+            fields: [formattedIssues[i], formattedIssues[i + 1]],
+          });
+        }
       }
-    }
-    if (actFastIssues.length > 0) {
-      const formattedIssues = sortAndFlattenIssuesArray(actFastIssues);
-      messageBlocks.push({
-        type: 'section',
-        fields: [
-          {
-            type: 'mrkdwn',
-            text: `⌛️ *Act fast!*`,
-          },
-          { type: 'mrkdwn', text: `😨` },
-        ],
-      });
-      for (let i = 0; i < formattedIssues.length; i += 2) {
+      if (actFastIssues.length > 0) {
+        const formattedIssues = sortAndFlattenIssuesArray(actFastIssues);
         messageBlocks.push({
           type: 'section',
-          fields: [formattedIssues[i], formattedIssues[i + 1]],
+          fields: [
+            {
+              type: 'mrkdwn',
+              text: `⌛️ *Act fast!*`,
+            },
+            { type: 'mrkdwn', text: `😨` },
+          ],
         });
+        for (let i = 0; i < formattedIssues.length; i += 2) {
+          messageBlocks.push({
+            type: 'section',
+            fields: [formattedIssues[i], formattedIssues[i + 1]],
+          });
+        }
       }
-    }
-    const result = await getChannelLastNotifiedTable()
-      .where({ channel_id: channelId })
-      .select('last_notified_at');
-    const hasEnoughTimePassedSinceLastNotification =
-      result.length > 0
-        ? now.diff(result[0].last_notified_at, 'hours') >= 4
-        : true;
-    const shouldNotifyForOnlyTriagedQueue =
-      hasEnoughTimePassedSinceLastNotification &&
-      hasEnoughTimePassedSinceIssueCreation;
-    const formattedIssues = sortAndFlattenIssuesArray(triageQueueIssues);
-    if (
-      triageQueueIssues.length > 0 &&
-      overdueIssues.length === 0 &&
-      actFastIssues.length === 0
-    ) {
-      messageBlocks.push({
-        type: 'section',
-        fields: [
-          {
-            type: 'mrkdwn',
-            text: `⏳ *Triage Queue*`,
-          },
-          { type: 'mrkdwn', text: `😯` },
-        ],
-      });
-      for (let i = 0; i < formattedIssues.length; i += 2) {
-        messageBlocks.push({
-          type: 'section',
-          fields: [formattedIssues[i], formattedIssues[i + 1]],
-        });
-      }
-    }
-    /*
-      Two cases to skip sending message
-      1. No issues in any queue
-      2. Issues are in triage queue but channel doesn't need to be notified
-    */
-    if (
-      (overdueIssues.length === 0 &&
-        actFastIssues.length === 0 &&
-        triageQueueIssues.length === 0) ||
-      (overdueIssues.length === 0 &&
-        actFastIssues.length === 0 &&
+      const result = await getChannelLastNotifiedTable()
+        .where({ channel_id: channelId })
+        .select('last_notified_at');
+      const hasEnoughTimePassedSinceLastNotification =
+        result.length > 0
+          ? now.diff(result[0].last_notified_at, 'hours') >= 4
+          : true;
+      const shouldNotifyForOnlyTriagedQueue =
+        hasEnoughTimePassedSinceLastNotification &&
+        hasEnoughTimePassedSinceIssueCreation;
+      const formattedIssues = sortAndFlattenIssuesArray(triageQueueIssues);
+      if (
         triageQueueIssues.length > 0 &&
-        !shouldNotifyForOnlyTriagedQueue)
-    ) {
-      return Promise.resolve();
+        overdueIssues.length === 0 &&
+        actFastIssues.length === 0
+      ) {
+        messageBlocks.push({
+          type: 'section',
+          fields: [
+            {
+              type: 'mrkdwn',
+              text: `⏳ *Triage Queue*`,
+            },
+            { type: 'mrkdwn', text: `😯` },
+          ],
+        });
+        for (let i = 0; i < formattedIssues.length; i += 2) {
+          messageBlocks.push({
+            type: 'section',
+            fields: [formattedIssues[i], formattedIssues[i + 1]],
+          });
+        }
+      }
+      /*
+        Two cases to skip sending message
+        1. No issues in any queue
+        2. Issues are in triage queue but channel doesn't need to be notified
+      */
+      if (
+        (overdueIssues.length === 0 &&
+          actFastIssues.length === 0 &&
+          triageQueueIssues.length === 0) ||
+        (overdueIssues.length === 0 &&
+          actFastIssues.length === 0 &&
+          triageQueueIssues.length > 0 &&
+          !shouldNotifyForOnlyTriagedQueue)
+      ) {
+        return Promise.resolve();
+      }
+      return bolt.client.chat
+        .postMessage({
+          channel: channelId,
+          text: '👋 Triage Reminder ⏰',
+          blocks: messageBlocks,
+        })
+        .then(async () => {
+          await getChannelLastNotifiedTable()
+            .insert({ channel_id: channelId, last_notified_at: now })
+            .onConflict('channel_id')
+            .merge();
+        });
     }
-    return bolt.client.chat
-      .postMessage({
-        channel: channelId,
-        text: '👋 Triage Reminder ⏰',
-        blocks: messageBlocks,
-      })
-      .then(async () => {
-        await getChannelLastNotifiedTable()
-          .insert({ channel_id: channelId, last_notified_at: now })
-          .onConflict('channel_id')
-          .merge();
-      });
+    return Promise.resolve();
   });
 };
 
-export const getChannelsForIssue = (
-  repo: string,
-  org: string,
-  productArea: string,
-  now: moment.Moment
-): ChannelItem[] => {
-  const teams = getTeams(repo, org, productArea);
+export const getChannelIdForIssue = (repo: string, org: string) => {
+  const teams = getTeams(repo, org, undefined);
+  // TODO(team-ospo/issues#198): Support multiple teams
+  if (!teams.length) {
+    return null;
+  }
+  return PRODUCT_OWNERS_INFO['teams'][teams[0]]['slack_channel'];
+};
+
+export const getOfficesForRepo = (repo: string, org: string) => {
+  const teams = getTeams(repo, org, undefined);
   if (!teams.length) {
     return [];
   }
-  const channels: ChannelItem[] = teams.reduce(
-    (acc: ChannelItem[], team: string) => {
-      const offices = PRODUCT_OWNERS_INFO['teams'][team]['offices'];
-      acc.push({
-        channelId: PRODUCT_OWNERS_INFO['teams'][team]['slack_channel'],
-        isChannelInBusinessHours: (offices || ['sfo'])
-          .map((office: any) => isTimeInBusinessHours(now, office))
-          .includes(true),
-      });
-      return acc;
-    },
-    []
-  );
-  return channels;
+  // TODO(team-ospo/issues#198): Support multiple teams, default to sfo for now if offices is null
+  return PRODUCT_OWNERS_INFO['teams'][teams[0]]['offices'] || ['sfo'];
 };
 
 export const notifyProductOwnersForUntriagedIssues = async (
@@ -409,22 +418,46 @@ export const notifyProductOwnersForUntriagedIssues = async (
   const getIssueSLOInfoForRepo = async (
     repo: string
   ): Promise<IssueSLOInfo[]> => {
-    // TODO(team-ospo/issues#200): Add codecov support
-    const untriagedIssues =
-      org.slug === 'codecov'
-        ? []
-        : await org.api.paginate(org.api.issues.listForRepo, {
-            owner: org.slug,
+    const untriagedIssues = await org.api.paginate(org.api.issues.listForRepo, {
+      owner: org.slug,
+      repo,
+      state: 'open',
+      labels: WAITING_FOR_PRODUCT_OWNER_LABEL,
+      per_page: GH_API_PER_PAGE,
+    });
+
+    // TODO(team-ospo/issues#198): Consolidate logic between repos with routing and repos without routing
+    if (org.repos.withoutRouting.includes(repo)) {
+      // TODO(team-ospo/issues#200): Add codecov support
+      if (org.slug !== 'codecov') {
+        const issuesWithSLOInfo = untriagedIssues.map(async (issue) => ({
+          url: issue.html_url,
+          number: issue.number,
+          title: issue.title,
+          triageBy: await getTriageSLOTimestamp(
+            org,
             repo,
-            state: 'open',
-            labels: WAITING_FOR_PRODUCT_OWNER_LABEL,
-            per_page: GH_API_PER_PAGE,
-          });
+            issue.number,
+            issue.node_id
+          ),
+          createdAt: issue.created_at,
+          channelId: getChannelIdForIssue(repo, org.slug),
+          isChannelInBusinessHours: getOfficesForRepo(repo, org.slug)
+            .map((office: any) => isTimeInBusinessHours(now, office))
+            .includes(true),
+        }));
+
+        return Promise.all(issuesWithSLOInfo);
+      }
+
+      return Promise.all([]);
+    }
 
     const issuesWithSLOInfo = untriagedIssues.map(async (issue) => ({
       url: issue.html_url,
       number: issue.number,
       title: issue.title,
+      productAreaLabel: getIssueProductAreaLabel(issue),
       triageBy: await getTriageSLOTimestamp(
         org,
         repo,
@@ -432,13 +465,8 @@ export const notifyProductOwnersForUntriagedIssues = async (
         issue.node_id
       ),
       createdAt: issue.created_at,
-      channels: getChannelsForIssue(
-        repo,
-        org.slug,
-        getIssueProductAreaLabel(issue),
-        now
-      ),
     }));
+
     return Promise.all(issuesWithSLOInfo);
   };
 
@@ -451,24 +479,52 @@ export const notifyProductOwnersForUntriagedIssues = async (
   ).flat();
 
   // Get an N-to-N mapping of "Product Area: *" labels to issues
+  const productAreaToIssuesMap: Record<string, IssueSLOInfo[]> = {};
   const channelToIssuesMap: Record<string, IssueSLOInfo[]> = {};
+  const productAreasToNotify = new Set() as Set<string>;
   issuesToNotifyAbout.forEach((data) => {
-    if (data.channels) {
-      data.channels.forEach((channel) => {
-        if (
-          channel.channelId in channelToIssuesMap &&
-          channel.isChannelInBusinessHours
-        ) {
-          channelToIssuesMap[channel.channelId].push(data);
-        } else {
-          channelToIssuesMap[channel.channelId] = [data];
-        }
-      });
+    if (data.channelId) {
+      if (data.channelId in channelToIssuesMap) {
+        channelToIssuesMap[data.channelId].push(data);
+      } else {
+        channelToIssuesMap[data.channelId] = [data];
+      }
+    } else if (data.productAreaLabel) {
+      if (data.productAreaLabel in productAreaToIssuesMap) {
+        productAreaToIssuesMap[data.productAreaLabel].push(data);
+      } else {
+        productAreaToIssuesMap[data.productAreaLabel] = [data];
+        productAreasToNotify.add(data.productAreaLabel);
+      }
+    }
+  });
+  // TODO(team-ospo/issues#198): Remove this once not needed
+  // Get a mapping from Channels to subscribed product areas
+  const notificationChannels: Record<string, string[]> = (
+    await getLabelsTable()
+      .select('label_name', 'channel_id')
+      .whereIn('label_name', Array.from(productAreasToNotify))
+  ).reduce((res, { label_name, channel_id }) => {
+    const productAreas = res[channel_id] || [];
+    productAreas.push(label_name);
+    res[channel_id] = productAreas;
+    return res;
+  }, {});
+
+  // TODO(team-ospo/issues#198): Remove this and completely rework logic
+  Object.keys(channelToIssuesMap).forEach((channelId) => {
+    if (!notificationChannels[channelId]) {
+      notificationChannels[channelId] = [];
     }
   });
 
   // Notify all channels associated with the relevant `Product Area: *` label per issue
-  const notifications = constructSlackMessage(channelToIssuesMap, now);
+  const notifications = constructSlackMessage(
+    notificationChannels,
+    productAreaToIssuesMap,
+    channelToIssuesMap,
+    now
+  );
   // Do all this in parallel and wait till all finish
   await Promise.all(notifications);
 };

--- a/test/product-owners.yml
+++ b/test/product-owners.yml
@@ -5,19 +5,10 @@ product_areas:
     - team-issues
     - team-enterprise
   Test:
-    - team-issues
-  Non-Overlapping Timezone:
-    - team-ingest
-    - team-issues
-  All-Timezones:
-    - team-ingest
-    - team-issues
-    - team-enterprise
-  Overlapping Timezone:
-    - team-issues
-    - team-enterprise
+    - team-ospo
 repos:
-  test-ttt-simple: team-issues
+  test-ttt-simple: team-ospo
+  routing-repo: team-ospo
   vie-repo: team-ingest
   test-null: team-null
 teams:
@@ -25,10 +16,6 @@ teams:
     slack_channel: C05A6BW303Y
     offices:
       - sea
-  team-enterprise:
-    slack_channel: C05A6BW303B
-    offices:
-      - yyz
   team-issues:
     slack_channel: C05A6BW303Z
     offices:


### PR DESCRIPTION
Reverts getsentry/eng-pipes#625

Slack notifications are not sending for #feed-ospo, and I'm not sure why...