### PR TITLE
Only reply on canary failure when deploy-backend fails

### DIFF
--- a/src/brain/gocdSlackFeeds/index.test.ts
+++ b/src/brain/gocdSlackFeeds/index.test.ts
@@ -74,6 +74,12 @@ describe('gocdSlackFeeds', function () {
           stage: {
             name: 'deploy-canary',
             result: 'Failed',
+            jobs: [
+              {
+                name: 'deploy-backend',
+                result: 'Failed',
+              },
+            ],
           },
         },
       },
@@ -228,6 +234,178 @@ describe('gocdSlackFeeds', function () {
     expect(slackMessages).toHaveLength(3);
   });
 
+  it('do not reply to canary if deploy-backend job is not failed', async function () {
+    org.api.repos.compareCommits.mockImplementation((args) => {
+      if (args.owner !== GETSENTRY_ORG.slug) {
+        throw new Error(`Unexpected compareCommits() owner: ${args.owner}`);
+      }
+      if (args.repo !== 'getsentry') {
+        throw new Error(`Unexpected compareCommits() repo: ${args.repo}`);
+      }
+      return {
+        status: 200,
+        data: {
+          commits: [
+            {
+              commit: {},
+              author: {
+                login: 'githubUser',
+              },
+            },
+          ],
+        },
+      };
+    });
+    const gocdPayload = merge({}, payload, {
+      data: {
+        pipeline: {
+          name: GOCD_SENTRYIO_BE_PIPELINE_NAME,
+          stage: {
+            name: 'deploy-canary',
+            result: 'Failed',
+            jobs: [
+              {
+                name: 'deploy-backend',
+                result: 'Passed',
+              },
+              {
+                name: 'another-job',
+                result: 'Failed',
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    // First Event
+    await handler(gocdPayload);
+
+    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(3);
+
+    const wantPostMsg = {
+      text: 'GoCD deployment started',
+      attachments: [
+        {
+          color: Color.DANGER,
+          blocks: [
+            slackblocks.section(
+              slackblocks.markdown('*sentryio/getsentry-backend*')
+            ),
+            {
+              elements: [
+                slackblocks.markdown('Deploying'),
+                slackblocks.markdown(
+                  '<https://github.com/getsentry/getsentry/commits/2b0034becc4ab26b985f4c1a08ab068f153c274c|getsentry@2b0034becc4a>'
+                ),
+              ],
+            },
+            slackblocks.divider(),
+            {
+              elements: [
+                slackblocks.markdown('❌ *deploy-canary*'),
+                slackblocks.markdown(
+                  '<https://deploy.getsentry.net/go/pipelines/getsentry-backend/20/deploy-canary/1|Failed>'
+                ),
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(3);
+
+    const postCalls = bolt.client.chat.postMessage.mock.calls;
+    postCalls.sort(sortMessages);
+    expect(postCalls[0][0]).toMatchObject(
+      merge({}, wantPostMsg, { channel: FEED_DEPLOY_CHANNEL_ID })
+    );
+    expect(postCalls[1][0]).toMatchObject(
+      merge({}, wantPostMsg, { channel: FEED_ENGINEERING_CHANNEL_ID })
+    );
+    expect(postCalls[2][0]).toMatchObject(
+      merge({}, wantPostMsg, { channel: FEED_DEV_INFRA_CHANNEL_ID })
+    );
+
+    let slackMessages = await db('slack_messages').select('*');
+    expect(slackMessages).toHaveLength(3);
+
+    const wantSlack = {
+      refId: `sentryio-${gocdPayload.data.pipeline.name}/20@2b0034becc4ab26b985f4c1a08ab068f153c274c`,
+      channel: 'channel_id',
+      ts: '1234123.123',
+      context: {
+        text: 'GoCD deployment started',
+      },
+    };
+    expect(slackMessages[0]).toMatchObject(wantSlack);
+    expect(slackMessages[1]).toMatchObject(wantSlack);
+    expect(slackMessages[2]).toMatchObject(wantSlack);
+
+    // Second Event
+    await handler(
+      merge({}, gocdPayload, {
+        data: {
+          pipeline: {
+            stage: {
+              'approved-by': 'changes',
+              result: 'Passed',
+            },
+          },
+        },
+      })
+    );
+
+    const wantUpdate = {
+      ts: '1234123.123',
+      text: 'GoCD deployment started',
+      attachments: [
+        {
+          color: Color.OFF_WHITE_TOO,
+          blocks: [
+            slackblocks.section(
+              slackblocks.markdown('*sentryio/getsentry-backend*')
+            ),
+            {
+              elements: [
+                slackblocks.markdown('Deploying'),
+                slackblocks.markdown(
+                  '<https://github.com/getsentry/getsentry/commits/2b0034becc4ab26b985f4c1a08ab068f153c274c|getsentry@2b0034becc4a>'
+                ),
+              ],
+            },
+            slackblocks.divider(),
+            {
+              elements: [
+                slackblocks.markdown('✅ *deploy-canary*'),
+                slackblocks.markdown(
+                  '<https://deploy.getsentry.net/go/pipelines/getsentry-backend/20/deploy-canary/1|Passed>'
+                ),
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(3);
+    // The reply message is not updated
+    expect(bolt.client.chat.update).toHaveBeenCalledTimes(3);
+    const updateCalls = bolt.client.chat.update.mock.calls;
+    updateCalls.sort(sortMessages);
+    expect(updateCalls[0][0]).toMatchObject(
+      merge({}, wantUpdate, { channel: FEED_DEPLOY_CHANNEL_ID })
+    );
+    expect(updateCalls[1][0]).toMatchObject(
+      merge({}, wantUpdate, { channel: FEED_ENGINEERING_CHANNEL_ID })
+    );
+    expect(updateCalls[2][0]).toMatchObject(
+      merge({}, wantUpdate, { channel: FEED_DEV_INFRA_CHANNEL_ID })
+    );
+
+    slackMessages = await db('slack_messages').select('*');
+    expect(slackMessages).toHaveLength(3);
+  });
+
   it('post and update message to all feeds without author', async function () {
     org.api.repos.compareCommits.mockImplementation((args) => {
       if (args.owner !== GETSENTRY_ORG.slug) {
@@ -257,6 +435,12 @@ describe('gocdSlackFeeds', function () {
           stage: {
             name: 'deploy-canary',
             result: 'Failed',
+            jobs: [
+              {
+                name: 'deploy-backend',
+                result: 'Failed',
+              },
+            ],
           },
         },
       },
@@ -453,6 +637,12 @@ describe('gocdSlackFeeds', function () {
           stage: {
             name: 'deploy-canary',
             result: 'Failed',
+            jobs: [
+              {
+                name: 'deploy-backend',
+                result: 'Failed',
+              },
+            ],
           },
         },
       },
@@ -702,6 +892,12 @@ describe('gocdSlackFeeds', function () {
           stage: {
             name: 'deploy-canary',
             result: 'Failed',
+            jobs: [
+              {
+                name: 'deploy-backend',
+                result: 'Failed',
+              },
+            ],
           },
         },
       },

--- a/src/brain/gocdSlackFeeds/index.ts
+++ b/src/brain/gocdSlackFeeds/index.ts
@@ -123,7 +123,10 @@ const engineeringFeed = new DeployFeed({
   replyCallback: async (pipeline) => {
     const hasFailedCanary =
       pipeline.stage.name.includes('canary') &&
-      pipeline.stage.result.toLowerCase() === 'failed';
+      pipeline.stage.result.toLowerCase() === 'failed' &&
+      pipeline.stage.jobs
+        .find((job) => job.name === 'deploy-backend')
+        ?.result.toLowerCase() === 'failed';
     if (!hasFailedCanary) return [];
     const [base, head] = await getBaseAndHeadCommit(pipeline);
     const authors = head ? await getAuthors('getsentry', base, head) : [];


### PR DESCRIPTION
Fixing a bug which caused the "Canary is paused" message to be sent out even when canary was not paused. This happened because we only checked if the deploy-canary stage failed, but didn't check which job caused it to fail.