### PR TITLE
Link to canary logs in pause message

### DIFF
--- a/src/brain/gocdSlackFeeds/index.test.ts
+++ b/src/brain/gocdSlackFeeds/index.test.ts
@@ -99,7 +99,7 @@ describe('gocdSlackFeeds', function () {
         ),
         slackblocks.section(
           slackblocks.markdown(
-            'Please check the errors in the canary logs, take appropriate rollback actions if needed and unpause the pipeline once it is safe to do so.'
+            'Please check the errors in the <https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-us/20/deploy-canary/1/deploy-backend|canary logs>, take appropriate rollback actions if needed and unpause the pipeline once it is safe to do so.'
           )
         ),
         slackblocks.context(
@@ -460,7 +460,7 @@ describe('gocdSlackFeeds', function () {
         ),
         slackblocks.section(
           slackblocks.markdown(
-            'Please check the errors in the canary logs, take appropriate rollback actions if needed and unpause the pipeline once it is safe to do so.'
+            'Please check the errors in the <https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-us/20/deploy-canary/1/deploy-backend|canary logs>, take appropriate rollback actions if needed and unpause the pipeline once it is safe to do so.'
           )
         ),
       ],
@@ -662,7 +662,7 @@ describe('gocdSlackFeeds', function () {
         ),
         slackblocks.section(
           slackblocks.markdown(
-            'Please check the errors in the canary logs, take appropriate rollback actions if needed and unpause the pipeline once it is safe to do so.'
+            'Please check the errors in the <https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-us/20/deploy-canary/1/deploy-backend|canary logs>, take appropriate rollback actions if needed and unpause the pipeline once it is safe to do so.'
           )
         ),
         slackblocks.context(
@@ -917,7 +917,7 @@ describe('gocdSlackFeeds', function () {
         ),
         slackblocks.section(
           slackblocks.markdown(
-            'Please check the errors in the canary logs, take appropriate rollback actions if needed and unpause the pipeline once it is safe to do so.'
+            'Please check the errors in the <https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-us/20/deploy-canary/1/deploy-backend|canary logs>, take appropriate rollback actions if needed and unpause the pipeline once it is safe to do so.'
           )
         ),
         slackblocks.context(

--- a/src/brain/gocdSlackFeeds/index.ts
+++ b/src/brain/gocdSlackFeeds/index.ts
@@ -150,11 +150,12 @@ const engineeringFeed = new DeployFeed({
         return `<@${user.slackUser}>`;
       })
       .join(' ');
+    const gocdLogsLink = `https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-us/${pipeline.counter}/deploy-canary/${pipeline.stage.counter}/deploy-backend`;
     const blocks = [
       header(plaintext(':double_vertical_bar: Canary has been paused')),
       section(
         markdown(
-          'Please check the errors in the canary logs, take appropriate rollback actions if needed and unpause the pipeline once it is safe to do so.'
+          `Please check the errors in the <${gocdLogsLink}|canary logs>, take appropriate rollback actions if needed and unpause the pipeline once it is safe to do so.`
         )
       ),
     ];


### PR DESCRIPTION
Upon request, I added a link to the canary logs so that users can more easily navigate to them upon canary pausing.