### PR TITLE
fix(scoreboard): Don't show issues that are not yet due on weekly scores

### DIFF
--- a/src/webhooks/pubsub/slackScores.test.ts
+++ b/src/webhooks/pubsub/slackScores.test.ts
@@ -117,4 +117,49 @@ describe('slackScores Tests', function () {
       text: 'Weekly GitHub Team Scores',
     });
   });
+
+  it('should ignore issue if it is not due yet', async () => {
+    getIssueEventsForTeamSpy
+      .mockReturnValueOnce([
+        {
+          issue_id: 1,
+          repository: 'routing-repo',
+          product_area: 'One-Team',
+          triaged_dt: { value: '2023-10-11T16:53:15.000Z' },
+          triage_by_dt: { value: '9999-10-12T21:52:14.223Z' },
+        },
+      ])
+      .mockReturnValue([]);
+    await triggerSlackScores(null, null);
+    expect(postMessageSpy).toHaveBeenCalledWith({
+      blocks: [
+        {
+          text: {
+            emoji: true,
+            text: '🗓️ Weekly GitHub Response Times by Team 🗓️',
+            type: 'plain_text',
+          },
+          type: 'header',
+        },
+        {
+          text: {
+            text: `\`\`\`
+┌────────────────────────────────────────────────┐
+| Team                          │ % on Time      |
+├────────────────────────────────────────────────┤
+| enterprise                    | -   (0/0)      |
+| ingest                        | -   (0/0)      |
+| issues                        | -   (0/0)      |
+| null                          | -   (0/0)      |
+| ospo                          | -   (0/0)      |
+└────────────────────────────────────────────────┘\`\`\``,
+            type: 'mrkdwn',
+          },
+          type: 'section',
+        },
+      ],
+      channel: 'G01F3FQ0T41',
+      text: 'Weekly GitHub Team Scores',
+    });
+  });
 });

--- a/src/webhooks/pubsub/slackScores.ts
+++ b/src/webhooks/pubsub/slackScores.ts
@@ -23,7 +23,10 @@ export const triggerSlackScores = async (
 ) => {
   const teamScores: teamScoreInfo[] = await Promise.all(
     Object.keys(PRODUCT_OWNERS_INFO['teams']).map(async (team: string) => {
-      const issueTriageEvents = await getIssueEventsForTeam(team);
+      // Filter out issues that are not yet due
+      const issueTriageEvents = (await getIssueEventsForTeam(team)).filter(
+        (issue) => moment(issue.triage_by_dt.value) <= moment()
+      );
       const triagedOnTimeEvents = issueTriageEvents.filter(
         (issue) => issue.triaged_dt.value <= issue.triage_by_dt.value
       );


### PR DESCRIPTION
Noticed there seemed to be a lot of events on our scoreboard, I think this is the reason why