### PR TITLE
Add an alert for consecutive unsuccessful GoCD deploys

### DIFF
--- a/src/brain/gocdConsecutiveUnsuccessfulAlert/consecutiveUnsuccessfulDeploysAlert.ts
+++ b/src/brain/gocdConsecutiveUnsuccessfulAlert/consecutiveUnsuccessfulDeploysAlert.ts
@@ -1,0 +1,106 @@
+import { KnownBlock } from '@slack/types';
+
+import { bolt } from '@/api/slack';
+import * as slackblocks from '@/blocks/slackBlocks';
+import { GOCD_ORIGIN } from '@/config';
+import {
+  DBGoCDDeployment,
+  GoCDPipeline,
+  GoCDResponse,
+  GoCDStageResponse,
+} from '@/types';
+import { getLastGetSentryGoCDDeploy } from '@/utils/db/getLatestDeploy';
+
+export const CONSECUTIVE_UNSUCCESSFUL_DEPLOYS_LIMIT = 3;
+
+export class ConsecutiveUnsuccessfulDeploysAlert {
+  private slackChannelID: string;
+  private consecutiveUnsuccessfulLimit: number;
+  private pipelineFilter: PipelineFilterCallback | undefined;
+
+  constructor({
+    slackChannelID,
+    consecutiveUnsuccessfulLimit,
+    pipelineFilter,
+  }: ConsecutiveUnsuccessfulDeploysAlertArgs) {
+    this.slackChannelID = slackChannelID;
+    this.consecutiveUnsuccessfulLimit =
+      consecutiveUnsuccessfulLimit || CONSECUTIVE_UNSUCCESSFUL_DEPLOYS_LIMIT;
+    this.pipelineFilter = pipelineFilter;
+  }
+
+  async handle(body: GoCDResponse) {
+    const { pipeline } = (body as GoCDStageResponse).data;
+
+    if (this.pipelineFilter && !this.pipelineFilter(pipeline)) {
+      return;
+    }
+
+    // If everything is passing, we don't need to check or do anything
+    if (pipeline.stage.result.toLowerCase() === 'passed') {
+      return;
+    }
+
+    const lastDeploy = await getLastGetSentryGoCDDeploy(
+      pipeline.group,
+      pipeline.name
+    );
+
+    if (!lastDeploy) {
+      // Do nothing until we have at least one deploy
+      return;
+    }
+
+    const numConsecutiveUnsuccessfulDeploys =
+      Number(pipeline.counter) - Number(lastDeploy.pipeline_counter);
+
+    if (
+      numConsecutiveUnsuccessfulDeploys >= this.consecutiveUnsuccessfulLimit
+    ) {
+      const blocks = this.getMessageBlocks(
+        pipeline,
+        lastDeploy,
+        numConsecutiveUnsuccessfulDeploys
+      );
+      await bolt.client.chat.postMessage({
+        channel: this.slackChannelID,
+        text: this.getBodyText(pipeline, numConsecutiveUnsuccessfulDeploys),
+        blocks,
+        unfurl_links: false,
+      });
+    }
+  }
+
+  private getBodyText(pipeline: GoCDPipeline, numConsecutiveFailures: number) {
+    return `❗️ *${pipeline.name}* has had ${numConsecutiveFailures} consecutive unsuccessful deploys.`;
+  }
+
+  private getMessageBlocks(
+    pipeline: GoCDPipeline,
+    lastDeploy: DBGoCDDeployment,
+    numConsecutiveFailures: number
+  ): Array<KnownBlock> {
+    const prevDeployVSMURL = `${GOCD_ORIGIN}/go/pipelines/value_stream_map/${lastDeploy.pipeline_name}/${lastDeploy.pipeline_counter}`;
+    const currentOverviewURL = `${GOCD_ORIGIN}/go/pipelines/${pipeline.name}/${pipeline.counter}/${pipeline.stage.name}/${pipeline.stage.counter}`;
+    const deployToolsURL = `https://deploy-tools.getsentry.net/services/${pipeline.group}`;
+
+    return [
+      slackblocks.section(
+        slackblocks.markdown(this.getBodyText(pipeline, numConsecutiveFailures))
+      ),
+      slackblocks.section(
+        slackblocks.markdown(
+          `<${currentOverviewURL}|Latest failure> | <${prevDeployVSMURL}|Last good deploy> | <${deployToolsURL}|Deploy Tools>`
+        )
+      ),
+    ];
+  }
+}
+
+type ConsecutiveUnsuccessfulDeploysAlertArgs = {
+  slackChannelID: string;
+  consecutiveUnsuccessfulLimit?: number;
+  pipelineFilter?: PipelineFilterCallback;
+};
+
+type PipelineFilterCallback = (pipeline: GoCDPipeline) => boolean;

--- a/src/brain/gocdConsecutiveUnsuccessfulAlert/index.test.ts
+++ b/src/brain/gocdConsecutiveUnsuccessfulAlert/index.test.ts
@@ -136,7 +136,7 @@ describe('gocdConsecutiveUnsuccessfulAlerts', function () {
       stage_state: 'Passed',
       stage_result: 'unknown',
       stage_create_time: new Date('2022-10-26T17:57:53.000Z'),
-      stage_last_transition_time: new Date(),
+      stage_last_transition_time: new Date('2022-10-26T17:57:53.000Z'),
       stage_jobs: '{}',
     });
 

--- a/src/brain/gocdConsecutiveUnsuccessfulAlert/index.test.ts
+++ b/src/brain/gocdConsecutiveUnsuccessfulAlert/index.test.ts
@@ -1,0 +1,235 @@
+import merge from 'lodash.merge';
+
+import payload from '@test/payloads/gocd/gocd-stage-building.json';
+
+import * as slackblocks from '@/blocks/slackBlocks';
+import { DB_TABLE_STAGES } from '@/brain/saveGoCDStageEvents';
+import { buildServer } from '@/buildServer';
+import {
+  FEED_DEV_INFRA_CHANNEL_ID,
+  GOCD_SENTRYIO_BE_PIPELINE_GROUP,
+  GOCD_SENTRYIO_BE_PIPELINE_NAME,
+} from '@/config';
+import { Fastify } from '@/types';
+import { bolt } from '@api/slack';
+import { db } from '@utils/db';
+
+import { CONSECUTIVE_UNSUCCESSFUL_DEPLOYS_LIMIT } from './consecutiveUnsuccessfulDeploysAlert';
+import { gocdConsecutiveUnsuccessfulAlert, handler } from '.';
+
+jest.mock('@api/getUser');
+
+describe('gocdConsecutiveUnsuccessfulAlerts', function () {
+  let fastify: Fastify;
+
+  beforeAll(async function () {
+    await db.migrate.latest();
+  });
+
+  afterAll(async function () {
+    await db.destroy();
+  });
+
+  beforeEach(async function () {
+    fastify = await buildServer(false);
+    await gocdConsecutiveUnsuccessfulAlert();
+    await db(DB_TABLE_STAGES).delete();
+    await db('slack_messages').delete();
+  });
+
+  afterEach(async function () {
+    fastify.close();
+    jest.clearAllMocks();
+    await db(DB_TABLE_STAGES).delete();
+    await db('slack_messages').delete();
+  });
+
+  it('do nothing for non-getsentry pipeline', async function () {
+    const gocdPayload = merge({}, payload, {
+      data: {
+        pipeline: {
+          name: 'deploy-example-service',
+          stage: {
+            name: 'deploy-canary',
+            result: 'Failed',
+          },
+        },
+      },
+    });
+
+    // First Event
+    await handler(gocdPayload);
+
+    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(0);
+  });
+
+  it('do nothing for passing getsentry stage', async function () {
+    const gocdPayload = merge({}, payload, {
+      data: {
+        pipeline: {
+          name: GOCD_SENTRYIO_BE_PIPELINE_NAME,
+          stage: {
+            name: 'deploy-canary',
+            result: 'Passed',
+          },
+        },
+      },
+    });
+
+    // First Event
+    await handler(gocdPayload);
+
+    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(0);
+  });
+
+  it('do nothing if there is no previous deploy', async function () {
+    const gocdPayload = merge({}, payload, {
+      data: {
+        pipeline: {
+          name: GOCD_SENTRYIO_BE_PIPELINE_NAME,
+          stage: {
+            name: 'deploy-canary',
+            result: 'Failed',
+          },
+        },
+      },
+    });
+
+    // First Event
+    await handler(gocdPayload);
+
+    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(0);
+  });
+
+  it('do nothing if the number of consecutive unsuccessful deploys is within the limit', async function () {
+    await db(DB_TABLE_STAGES).insert({
+      pipeline_id: 'pipeline-id-123',
+
+      pipeline_name: GOCD_SENTRYIO_BE_PIPELINE_NAME,
+      pipeline_counter: 19,
+      pipeline_group: GOCD_SENTRYIO_BE_PIPELINE_GROUP,
+      pipeline_build_cause: JSON.stringify([
+        {
+          material: {
+            'git-configuration': {
+              'shallow-clone': false,
+              branch: 'master',
+              url: 'git@github.com:getsentry/getsentry.git',
+            },
+            type: 'git',
+          },
+          changed: false,
+          modifications: [
+            {
+              revision: '333333',
+              'modified-time': 'Oct 26, 2022, 5:05:17 PM',
+              data: {},
+            },
+          ],
+        },
+      ]),
+
+      stage_name: 'deploy-primary',
+      stage_counter: 1,
+      stage_approval_type: '',
+      stage_approved_by: '',
+      stage_state: 'Passed',
+      stage_result: 'unknown',
+      stage_create_time: new Date('2022-10-26T17:57:53.000Z'),
+      stage_last_transition_time: new Date(),
+      stage_jobs: '{}',
+    });
+
+    const gocdPayload = merge({}, payload, {
+      data: {
+        pipeline: {
+          group: GOCD_SENTRYIO_BE_PIPELINE_GROUP,
+          name: GOCD_SENTRYIO_BE_PIPELINE_NAME,
+          stage: {
+            name: 'deploy-canary',
+            result: 'Failed',
+          },
+        },
+      },
+    });
+
+    // First Event
+    await handler(gocdPayload);
+
+    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(0);
+  });
+
+  it('post to feed-dev-infra if the number of consecutive unsuccessful deploys is over the limit', async function () {
+    await db(DB_TABLE_STAGES).insert({
+      pipeline_id: 'pipeline-id-123',
+
+      pipeline_name: GOCD_SENTRYIO_BE_PIPELINE_NAME,
+      pipeline_counter: 20 - CONSECUTIVE_UNSUCCESSFUL_DEPLOYS_LIMIT,
+      pipeline_group: GOCD_SENTRYIO_BE_PIPELINE_GROUP,
+      pipeline_build_cause: JSON.stringify([
+        {
+          material: {
+            'git-configuration': {
+              'shallow-clone': false,
+              branch: 'master',
+              url: 'git@github.com:getsentry/getsentry.git',
+            },
+            type: 'git',
+          },
+          changed: false,
+          modifications: [
+            {
+              revision: '333333',
+              'modified-time': 'Oct 26, 2022, 5:05:17 PM',
+              data: {},
+            },
+          ],
+        },
+      ]),
+
+      stage_name: 'deploy-primary',
+      stage_counter: 1,
+      stage_approval_type: '',
+      stage_approved_by: '',
+      stage_state: 'Passed',
+      stage_result: 'unknown',
+      stage_create_time: new Date('2022-10-26T17:57:53.000Z'),
+      stage_last_transition_time: new Date('2022-10-26T17:57:53.000Z'),
+      stage_jobs: '{}',
+    });
+
+    const gocdPayload = merge({}, payload, {
+      data: {
+        pipeline: {
+          name: GOCD_SENTRYIO_BE_PIPELINE_NAME,
+          group: GOCD_SENTRYIO_BE_PIPELINE_GROUP,
+          stage: {
+            name: 'deploy-canary',
+            result: 'Failed',
+          },
+        },
+      },
+    });
+
+    // First Event
+    await handler(gocdPayload);
+
+    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(1);
+    expect(bolt.client.chat.postMessage.mock.calls[0][0]).toMatchObject({
+      text: `❗️ *getsentry-backend* has had ${CONSECUTIVE_UNSUCCESSFUL_DEPLOYS_LIMIT} consecutive unsuccessful deploys.`,
+      channel: FEED_DEV_INFRA_CHANNEL_ID,
+      blocks: [
+        slackblocks.section(
+          slackblocks.markdown(
+            `❗️ *getsentry-backend* has had ${CONSECUTIVE_UNSUCCESSFUL_DEPLOYS_LIMIT} consecutive unsuccessful deploys.`
+          )
+        ),
+        slackblocks.section(
+          slackblocks.markdown(
+            `<https://deploy.getsentry.net/go/pipelines/getsentry-backend/20/deploy-canary/1|Latest failure> | <https://deploy.getsentry.net/go/pipelines/value_stream_map/getsentry-backend/17|Last good deploy> | <https://deploy-tools.getsentry.net/services/getsentry-backend|Deploy Tools>`
+          )
+        ),
+      ],
+    });
+  });
+});

--- a/src/brain/gocdConsecutiveUnsuccessfulAlert/index.ts
+++ b/src/brain/gocdConsecutiveUnsuccessfulAlert/index.ts
@@ -1,0 +1,30 @@
+import { gocdevents } from '@/api/gocdevents';
+import {
+  FEED_DEV_INFRA_CHANNEL_ID,
+  GOCD_SENTRYIO_BE_PIPELINE_NAME,
+  GOCD_SENTRYIO_FE_PIPELINE_NAME,
+} from '@/config';
+import { GoCDResponse } from '@/types';
+
+import { ConsecutiveUnsuccessfulDeploysAlert } from './consecutiveUnsuccessfulDeploysAlert';
+
+const PIPELINE_FILTER = [
+  GOCD_SENTRYIO_BE_PIPELINE_NAME,
+  GOCD_SENTRYIO_FE_PIPELINE_NAME,
+];
+
+const devinfraAlert = new ConsecutiveUnsuccessfulDeploysAlert({
+  slackChannelID: FEED_DEV_INFRA_CHANNEL_ID,
+  consecutiveUnsuccessfulLimit: 3,
+  pipelineFilter: (pipeline) => {
+    return PIPELINE_FILTER.includes(pipeline.name);
+  },
+});
+
+export async function handler(body: GoCDResponse) {
+  await devinfraAlert.handle(body);
+}
+
+export async function gocdConsecutiveUnsuccessfulAlert() {
+  gocdevents.on('stage', handler);
+}


### PR DESCRIPTION
This should be a low risk change as it will only message #feed-dev-infra for now. This is similar to #616 but takes a slightly different approach which may prove to be more effective. In the future, if this proves useful, we could add it to other channels such as discuss-frontend and team-engineering.