### PR TITLE
Ignore ` char in discussion titles

### DIFF
--- a/src/webhooks/pubsub/slackScores.test.ts
+++ b/src/webhooks/pubsub/slackScores.test.ts
@@ -254,17 +254,17 @@ describe('slackScores tests', function () {
             text: {
               text: `\`\`\`
 ┌────────────────────────────────────────────────────────────────────┐
-| Most Active Discussions this Week                 │ # comments     |
+| Most Active Discussions this Week                 │     # comments |
 ├────────────────────────────────────────────────────────────────────┤
-| <https://github.com/routing-repo/discussions/001|Discussion 1>                                      | 3              |
-| <https://github.com/routing-repo/discussions/002|Discussion 2>                                      | 2              |
-| <https://github.com/test-ttt-simple/discussions/003|Overflowing Discussion Title blahblahblahblahbl...>| 1              |
+| <https://github.com/routing-repo/discussions/001|Discussion 1>                                      |              3 |
+| <https://github.com/routing-repo/discussions/002|Discussion 2>                                      |              2 |
+| <https://github.com/test-ttt-simple/discussions/003|Overflowing Discussion Title blahblahblahblahb...> |              1 |
 └────────────────────────────────────────────────────────────────────┘
 ┌────────────────────────────────────────────────────────────────────┐
-| Most Active Sentaurs this Week                    │ # comments     |
+| Most Active Sentaurs this Week                    │     # comments |
 ├────────────────────────────────────────────────────────────────────┤
-| luke_skywalker                                    | 2              |
-| han_solo                                          | 1              |
+| luke_skywalker                                    |              2 |
+| han_solo                                          |              1 |
 └────────────────────────────────────────────────────────────────────┘\`\`\``,
               type: 'mrkdwn',
             },
@@ -275,6 +275,66 @@ describe('slackScores tests', function () {
         text: 'Weekly Discussion Metrics',
       });
     });
+
+    it('should properly ignore ` character in discussion title', async () => {
+      const discussions = [
+        {
+          title: 'Discussion with `markdown`',
+          repository: 'routing-repo',
+          discussion_number: '001',
+          num_comments: 3,
+        },
+      ];
+      const discussionCommenters = [
+        {
+          username: 'luke_skywalker',
+          num_comments: 2,
+        },
+        {
+          username: 'han_solo',
+          num_comments: 1,
+        },
+      ];
+      getDiscussionEventsSpy.mockReturnValue({
+        discussions,
+        discussionCommenters,
+      });
+      await sendDiscussionMetrics();
+      // Columns with links in them may seem a bit off, because the links won't actually appear in slack
+      expect(postMessageSpy).toHaveBeenCalledWith({
+        blocks: [
+          {
+            text: {
+              emoji: true,
+              text: '🗓️ Weekly Discussion Metrics 🗓️',
+              type: 'plain_text',
+            },
+            type: 'header',
+          },
+          {
+            text: {
+              text: `\`\`\`
+┌────────────────────────────────────────────────────────────────────┐
+| Most Active Discussions this Week                 │     # comments |
+├────────────────────────────────────────────────────────────────────┤
+| <https://github.com/routing-repo/discussions/001|Discussion with markdown>                          |              3 |
+└────────────────────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────────────┐
+| Most Active Sentaurs this Week                    │     # comments |
+├────────────────────────────────────────────────────────────────────┤
+| luke_skywalker                                    |              2 |
+| han_solo                                          |              1 |
+└────────────────────────────────────────────────────────────────────┘\`\`\``,
+              type: 'mrkdwn',
+            },
+            type: 'section',
+          },
+        ],
+        channel: 'G01F3FQ0T41',
+        text: 'Weekly Discussion Metrics',
+      });
+    });
+
     it('should send discussion metrics properly for over 5 discussions/users commented', async () => {
       const discussions = [
         {
@@ -360,22 +420,22 @@ describe('slackScores tests', function () {
             text: {
               text: `\`\`\`
 ┌────────────────────────────────────────────────────────────────────┐
-| Most Active Discussions this Week                 │ # comments     |
+| Most Active Discussions this Week                 │     # comments |
 ├────────────────────────────────────────────────────────────────────┤
-| <https://github.com/routing-repo/discussions/001|Discussion 1>                                      | 6              |
-| <https://github.com/routing-repo/discussions/002|Discussion 2>                                      | 5              |
-| <https://github.com/test-ttt-simple/discussions/003|Discussion 3>                                      | 4              |
-| <https://github.com/test-ttt-simple/discussions/004|Discussion 4>                                      | 3              |
-| <https://github.com/test-ttt-simple/discussions/005|Discussion 5>                                      | 2              |
+| <https://github.com/routing-repo/discussions/001|Discussion 1>                                      |              6 |
+| <https://github.com/routing-repo/discussions/002|Discussion 2>                                      |              5 |
+| <https://github.com/test-ttt-simple/discussions/003|Discussion 3>                                      |              4 |
+| <https://github.com/test-ttt-simple/discussions/004|Discussion 4>                                      |              3 |
+| <https://github.com/test-ttt-simple/discussions/005|Discussion 5>                                      |              2 |
 └────────────────────────────────────────────────────────────────────┘
 ┌────────────────────────────────────────────────────────────────────┐
-| Most Active Sentaurs this Week                    │ # comments     |
+| Most Active Sentaurs this Week                    │     # comments |
 ├────────────────────────────────────────────────────────────────────┤
-| luke_skywalker                                    | 10             |
-| han_solo                                          | 5              |
-| boba_fett                                         | 4              |
-| darth_vader                                       | 3              |
-| yoda                                              | 2              |
+| luke_skywalker                                    |             10 |
+| han_solo                                          |              5 |
+| boba_fett                                         |              4 |
+| darth_vader                                       |              3 |
+| yoda                                              |              2 |
 └────────────────────────────────────────────────────────────────────┘\`\`\``,
               type: 'mrkdwn',
             },

--- a/src/webhooks/pubsub/slackScores.ts
+++ b/src/webhooks/pubsub/slackScores.ts
@@ -34,6 +34,7 @@ const DISCUSSION_COLUMN_WIDTH = 50;
 const NUM_COMMENTS_COLUMN_WIDTH = 15;
 const NUM_ROW_SPACES = 3;
 const LESS_THAN_SIGN_LENGTH = 1;
+const SPACE_LENGTH = 1;
 const NUM_DISCUSSION_SCOREBOARD_ELEMENTS = 5;
 const TEAM_PREFIX = 'team-';
 
@@ -157,7 +158,11 @@ export const sendDiscussionMetrics = async () => {
     } else if (column === 'firstColumnItem') {
       return entry + ' '.repeat(DISCUSSION_COLUMN_WIDTH - entry.length);
     }
-    return entry + ' '.repeat(NUM_COMMENTS_COLUMN_WIDTH - entry.length);
+    return (
+      ' '.repeat(NUM_COMMENTS_COLUMN_WIDTH - entry.length - SPACE_LENGTH) +
+      entry +
+      ' '
+    );
   };
   let firstColumnName = 'Most Active Discussions this Week';
   const secondColumnName = '# comments';
@@ -176,9 +181,13 @@ export const sendDiscussionMetrics = async () => {
       const truncatedDiscussionTitle =
         discussionInfo.title.length <= DISCUSSION_COLUMN_WIDTH
           ? discussionInfo.title + '>'
-          : `${discussionInfo.title.slice(0, DISCUSSION_COLUMN_WIDTH - 3)}...>`;
+          : `${discussionInfo.title.slice(
+              0,
+              DISCUSSION_COLUMN_WIDTH - 4
+            )}...> `;
       const truncatedDiscussionTitleWithSpaces = addSpaces(
-        truncatedDiscussionTitle,
+        // Remove all instances of ` char from string
+        truncatedDiscussionTitle.replace(/`/g, ''),
         'discussion'
       );
       const discussionText = `<https://github.com/${discussionInfo.repository}/discussions/${discussionInfo.discussion_number}|${truncatedDiscussionTitleWithSpaces}`;


### PR DESCRIPTION
fixes a bug seen in scoreboard

<img width="655" alt="Screenshot 2023-10-31 at 3 53 54 PM" src="https://github.com/getsentry/eng-pipes/assets/25517925/8b551b57-d732-4aa9-953a-2f2c99b78778">
