### PR TITLE
Trigger slack scores from ospo channel

### DIFF
--- a/src/brain/triggerPubSub/index.test.ts
+++ b/src/brain/triggerPubSub/index.test.ts
@@ -1,0 +1,65 @@
+import { createSlackAppMention } from '@test/utils/createSlackAppMention';
+
+import { buildServer } from '@/buildServer';
+import * as slackScoresFunctions from '@/webhooks/pubsub/slackScores';
+
+import { TEAM_OSPO_CHANNEL_ID } from '../../config';
+
+import { triggerPubSub } from '.';
+
+jest.mock('@api/slack');
+
+describe('slack app', function () {
+  let fastify, sendGitHubEngagementMetricsSpy, sendDiscussionMetricsSpy;
+
+  beforeEach(async function () {
+    fastify = await buildServer(false);
+    sendGitHubEngagementMetricsSpy = jest.spyOn(
+      slackScoresFunctions,
+      'sendGitHubEngagementMetrics'
+    );
+    sendDiscussionMetricsSpy = jest.spyOn(
+      slackScoresFunctions,
+      'sendDiscussionMetrics'
+    );
+    triggerPubSub();
+  });
+
+  afterEach(function () {
+    fastify.close();
+    jest.clearAllMocks();
+  });
+
+  it('does not do anything if channel is not ospo team channel', async function () {
+    const response = await createSlackAppMention(
+      fastify,
+      '<@U018UAXJVG8> ttr',
+      'channel1'
+    );
+    expect(response.statusCode).toBe(200);
+    expect(sendGitHubEngagementMetricsSpy).not.toHaveBeenCalled();
+    expect(sendDiscussionMetricsSpy).not.toHaveBeenCalled();
+  });
+
+  it('fetches github ttr', async function () {
+    const response = await createSlackAppMention(
+      fastify,
+      '<@U018UAXJVG8> ttr',
+      TEAM_OSPO_CHANNEL_ID
+    );
+    expect(response.statusCode).toBe(200);
+    expect(sendGitHubEngagementMetricsSpy).toHaveBeenCalledWith(true);
+    expect(sendDiscussionMetricsSpy).not.toHaveBeenCalled();
+  });
+
+  it('fetches github activity', async function () {
+    const response = await createSlackAppMention(
+      fastify,
+      '<@U018UAXJVG8> activity',
+      TEAM_OSPO_CHANNEL_ID
+    );
+    expect(response.statusCode).toBe(200);
+    expect(sendGitHubEngagementMetricsSpy).not.toHaveBeenCalled();
+    expect(sendDiscussionMetricsSpy).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/brain/triggerPubSub/index.ts
+++ b/src/brain/triggerPubSub/index.ts
@@ -1,0 +1,23 @@
+import { TEAM_OSPO_CHANNEL_ID } from '@/config';
+import {
+  sendDiscussionMetrics,
+  sendGitHubEngagementMetrics,
+} from '@/webhooks/pubsub/slackScores';
+import { bolt } from '@api/slack';
+import { wrapHandler } from '@utils/wrapHandler';
+
+export const slackHandler = async ({ event }) => {
+  const { channel, text } = event;
+  if (channel !== TEAM_OSPO_CHANNEL_ID) {
+    return;
+  }
+  if (text.includes('ttr')) {
+    await sendGitHubEngagementMetrics(true);
+  } else if (text.includes('activity')) {
+    await sendDiscussionMetrics(true);
+  }
+};
+
+export async function triggerPubSub() {
+  bolt.event('app_mention', wrapHandler('slack-scores', slackHandler));
+}

--- a/src/webhooks/pubsub/slackScores.test.ts
+++ b/src/webhooks/pubsub/slackScores.test.ts
@@ -4,6 +4,7 @@ import * as scoresUtils from '@utils/scores';
 
 import {
   EPD_LEADERSHIP_CHANNEL_ID,
+  TEAM_OSPO_CHANNEL_ID,
   TEAM_PRODUCT_OWNERS_CHANNEL_ID,
 } from '../../config';
 
@@ -58,6 +59,16 @@ describe('slackScores tests', function () {
       expect(postMessageSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           channel: TEAM_PRODUCT_OWNERS_CHANNEL_ID,
+        })
+      );
+    });
+
+    it('should send slack notifications to correct channels if test is passed in', async () => {
+      getIssueEventsForTeamSpy.mockReturnValue([]);
+      await sendGitHubEngagementMetrics(true);
+      expect(postMessageSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: TEAM_OSPO_CHANNEL_ID,
         })
       );
     });

--- a/src/webhooks/pubsub/slackScores.ts
+++ b/src/webhooks/pubsub/slackScores.ts
@@ -39,7 +39,7 @@ const SPACE_LENGTH = 1;
 const NUM_DISCUSSION_SCOREBOARD_ELEMENTS = 5;
 const TEAM_PREFIX = 'team-';
 
-export const sendGitHubEngagementMetrics = async () => {
+export const sendGitHubEngagementMetrics = async (test: boolean = false) => {
   const teamScores: teamScoreInfo[] = await Promise.all(
     Object.keys(PRODUCT_OWNERS_INFO['teams']).map(async (team: string) => {
       // Filter out issues that are not yet due
@@ -126,10 +126,9 @@ export const sendGitHubEngagementMetrics = async () => {
       text: '```' + scoreBoard + '```',
     },
   });
-  const channelsToPost = [
-    EPD_LEADERSHIP_CHANNEL_ID,
-    TEAM_PRODUCT_OWNERS_CHANNEL_ID,
-  ];
+  const channelsToPost = test
+    ? [TEAM_OSPO_CHANNEL_ID]
+    : [EPD_LEADERSHIP_CHANNEL_ID, TEAM_PRODUCT_OWNERS_CHANNEL_ID];
   const slackNotifications = channelsToPost.map((channelId: string) => {
     return bolt.client.chat.postMessage({
       channel: channelId,
@@ -140,7 +139,7 @@ export const sendGitHubEngagementMetrics = async () => {
   await Promise.all(slackNotifications);
 };
 
-export const sendDiscussionMetrics = async () => {
+export const sendDiscussionMetrics = async (__test: boolean = false) => {
   const { discussions, discussionCommenters } = await getDiscussionEvents();
   if (discussions.length === 0 && discussionCommenters.length === 0) {
     return;

--- a/test/utils/createSlackAppMention.ts
+++ b/test/utils/createSlackAppMention.ts
@@ -1,7 +1,12 @@
 import { createSlackEvent } from './createSlackEvent';
 
-export async function createSlackAppMention(fastify, text: string) {
+export async function createSlackAppMention(
+  fastify,
+  text: string,
+  channel?: string
+) {
   return await createSlackEvent(fastify, 'app_mention', {
     text,
+    channel,
   });
 }


### PR DESCRIPTION
done by typing this in OSPO channel:

@Sentaur ttr
@Sentaur activity

I opted for not adding a slack bot command since it doesnt seem useful to add a highly visible command if it should only be used by our team in our private channel. Also, it requires elevated user permissions to add a new command and I just didn't want to jump through those hoops