### PR TITLE
Datadog tags and events 

### DIFF
--- a/src/webhooks/options-automator/options-automator.test.ts
+++ b/src/webhooks/options-automator/options-automator.test.ts
@@ -280,7 +280,7 @@ describe('options-automator webhook', function () {
   describe('sendOptionAutomatorUpdatesToDataDog tests', function () {
     it('should send the right payload', async function () {
       sendOptionAutomatorUpdatesToDataDog(testpayload, 1699563828);
-      expect(postMessageSpy).toHaveBeenCalledTimes(1);
+      expect(datadogApiInstanceSpy).toHaveBeenCalledTimes(1);
       expect(datadogApiInstanceSpy).toHaveBeenCalledWith({
         body: {
           dateHappened: 1699563828,

--- a/src/webhooks/options-automator/options-automator.test.ts
+++ b/src/webhooks/options-automator/options-automator.test.ts
@@ -280,13 +280,19 @@ describe('options-automator webhook', function () {
   describe('sendOptionAutomatorUpdatesToDataDog tests', function () {
     it('should send the right payload', async function () {
       sendOptionAutomatorUpdatesToDataDog(testpayload, 1699563828);
+      expect(postMessageSpy).toHaveBeenCalledTimes(1);
       expect(datadogApiInstanceSpy).toHaveBeenCalledWith({
         body: {
           dateHappened: 1699563828,
-          text: '{"region":"test_region","drifted_options":[{"option_name":"drifted_option_1","option_value":"value_1"},{"option_name":"drifted_option_2","option_value":"value_2"}],"updated_options":[{"option_name":"updated_option_1","db_value":"db_value_1","value":"new_value_1"}],"set_options":[{"option_name":"set_option_1","option_value":"set_value_1"},{"option_name":"set_option_2","option_value":"set_value_2"}],"unset_options":["unset_option_1","unset_option_2"],"not_writable_options":[{"option_name":"error_option_1","error_msg":"Error occurred for option 1"},{"option_name":"error_option_2","error_msg":"Error occurred for option 2"}],"unregistered_options":["unregisterd_option_1","unregisterd_option_2"],"invalid_type_options":[{"option_name":"invalid_type_option_1","got_type":"string","expected_type":"float"},{"option_name":"invalid_type_option_2","got_type":"float","expected_type":"int"}]}',
+          text: '"{"change":"region","option":"t"}"',
           title: 'Options Automator Update',
           alertType: 'info',
-          tags: ['sentry_region:test_region'],
+          tags: [
+            'sentry_region:st-test_region',
+            'source_tool:options-automator',
+            'source:options-automator',
+            'source_category:infra-tools',
+          ],
         },
       });
     });

--- a/src/webhooks/options-automator/options-automator.test.ts
+++ b/src/webhooks/options-automator/options-automator.test.ts
@@ -1,5 +1,5 @@
 import testEmptyPayload from '@test/payloads/options-automator/testEmptyPayload';
-import testParitalPayload from '@test/payloads/options-automator/testPartialPayload.json';
+import testPartialPayload from '@test/payloads/options-automator/testPartialPayload.json';
 import testPayload from '@test/payloads/options-automator/testPayload.json';
 import testSaasPayload from '@test/payloads/options-automator/testSaasPayload.json';
 
@@ -235,7 +235,7 @@ describe('options-automator webhook', function () {
     });
     it('writes drift only', async function () {
       const postMessageSpy = jest.spyOn(bolt.client.chat, 'postMessage');
-      await messageSlack(testParitalPayload);
+      await messageSlack(testPartialPayload);
       expect(postMessageSpy).toHaveBeenCalledTimes(1);
       const message = postMessageSpy.mock.calls[0][0];
       expect(message).toEqual({
@@ -280,7 +280,7 @@ describe('options-automator webhook', function () {
 
   describe('sendOptionAutomatorUpdatesToDataDog tests', function () {
     it('should send the right payload', async function () {
-      await sendOptionAutomatorUpdatesToDataDog(testParitalPayload, 1699563828);
+      await sendOptionAutomatorUpdatesToDataDog(testPartialPayload, 1699563828);
       expect(datadogApiInstanceSpy).toHaveBeenCalledTimes(2);
       const message = datadogApiInstanceSpy.mock.calls[0][0];
       expect(message).toEqual({

--- a/src/webhooks/options-automator/options-automator.test.ts
+++ b/src/webhooks/options-automator/options-automator.test.ts
@@ -290,9 +290,9 @@ describe('options-automator webhook', function () {
           alertType: 'error',
           tags: [
             'sentry_region:st-test_region',
-            'source_tool:"options-automator"',
-            'source:"options-automator"',
-            'source_category:"infra-tools"',
+            'source_tool:options-automator',
+            'source:options-automator',
+            'source_category:infra-tools',
           ],
         },
       });
@@ -305,9 +305,9 @@ describe('options-automator webhook', function () {
           alertType: 'error',
           tags: [
             'sentry_region:st-test_region',
-            'source_tool:"options-automator"',
-            'source:"options-automator"',
-            'source_category:"infra-tools"',
+            'source_tool:options-automator',
+            'source:options-automator',
+            'source_category:infra-tools',
           ],
         },
       });

--- a/src/webhooks/options-automator/options-automator.test.ts
+++ b/src/webhooks/options-automator/options-automator.test.ts
@@ -313,4 +313,8 @@ describe('options-automator webhook', function () {
       });
     });
   });
+  it('should send multiple messages', async function () {
+    await sendOptionAutomatorUpdatesToDataDog(testpayload, 1699563828);
+    expect(datadogApiInstanceSpy).toHaveBeenCalledTimes(13);
+  });
 });

--- a/src/webhooks/options-automator/options-automator.test.ts
+++ b/src/webhooks/options-automator/options-automator.test.ts
@@ -279,19 +279,35 @@ describe('options-automator webhook', function () {
 
   describe('sendOptionAutomatorUpdatesToDataDog tests', function () {
     it('should send the right payload', async function () {
-      sendOptionAutomatorUpdatesToDataDog(testpayload, 1699563828);
-      expect(datadogApiInstanceSpy).toHaveBeenCalledTimes(1);
-      expect(datadogApiInstanceSpy).toHaveBeenCalledWith({
+      await sendOptionAutomatorUpdatesToDataDog(testparitalpayload, 1699563828);
+      expect(datadogApiInstanceSpy).toHaveBeenCalledTimes(2);
+      const message = datadogApiInstanceSpy.mock.calls[0][0];
+      expect(message).toEqual({
         body: {
           dateHappened: 1699563828,
-          text: '"{"change":"region","option":"t"}"',
+          text: '{"change":"drifted_options","option":{"option_name":"drifted_option_1","option_value":"value_1"}}',
           title: 'Options Automator Update',
-          alertType: 'info',
+          alertType: 'error',
           tags: [
             'sentry_region:st-test_region',
-            'source_tool:options-automator',
-            'source:options-automator',
-            'source_category:infra-tools',
+            'source_tool:"options-automator"',
+            'source:"options-automator"',
+            'source_category:"infra-tools"',
+          ],
+        },
+      });
+      const secondMessage = datadogApiInstanceSpy.mock.calls[1][0];
+      expect(secondMessage).toEqual({
+        body: {
+          dateHappened: 1699563828,
+          text: '{"change":"drifted_options","option":{"option_name":"drifted_option_2","option_value":"value_2"}}',
+          title: 'Options Automator Update',
+          alertType: 'error',
+          tags: [
+            'sentry_region:st-test_region',
+            'source_tool:"options-automator"',
+            'source:"options-automator"',
+            'source_category:"infra-tools"',
           ],
         },
       });

--- a/src/webhooks/options-automator/options-automator.ts
+++ b/src/webhooks/options-automator/options-automator.ts
@@ -27,7 +27,9 @@ export async function sendOptionAutomatorUpdatesToDataDog(
   timestamp: number
 ) {
   const formatRegionTag = (region: string): string => {
-    if (region === 'us' || region === 'de') {
+    const SAAS_REGIONS = ['us', 'de'];
+
+    if (SAAS_REGIONS.includes(region)) {
       return `sentry_region:${region}`;
     } else {
       return `sentry_region:st-${region}`;
@@ -64,6 +66,7 @@ export async function sendOptionAutomatorUpdatesToDataDog(
           `source_tool:options-automator`,
           `source:options-automator`,
           `source_category:infra-tools`,
+          `option_name:${option.option_name}`,
         ],
       };
       await DATADOG_API_INSTANCE.createEvent({ body: params });

--- a/src/webhooks/options-automator/options-automator.ts
+++ b/src/webhooks/options-automator/options-automator.ts
@@ -58,6 +58,7 @@ export async function sendOptionAutomatorUpdatesToDataDog(
 
       const params: v1.EventCreateRequest = {
         title: 'Options Automator Update',
+        // TODO(getsentry/eng-pipes#144): Refactor Text Message
         text: JSON.stringify(text),
         alertType: alertType,
         dateHappened: timestamp,

--- a/src/webhooks/options-automator/options-automator.ts
+++ b/src/webhooks/options-automator/options-automator.ts
@@ -43,6 +43,7 @@ export async function sendOptionAutomatorUpdatesToDataDog(
   };
 
   for (const optionType in message) {
+    if (optionType === 'region') continue;
     for (const option of message[optionType]) {
       const text = {
         change: optionType,

--- a/src/webhooks/options-automator/options-automator.ts
+++ b/src/webhooks/options-automator/options-automator.ts
@@ -61,9 +61,9 @@ export async function sendOptionAutomatorUpdatesToDataDog(
         dateHappened: timestamp,
         tags: [
           region,
-          `source_tool:"options-automator"`,
-          `source:"options-automator"`,
-          `source_category:"infra-tools"`,
+          `source_tool:options-automator`,
+          `source:options-automator`,
+          `source_category:infra-tools`,
         ],
       };
       await DATADOG_API_INSTANCE.createEvent({ body: params });

--- a/src/webhooks/options-automator/options-automator.ts
+++ b/src/webhooks/options-automator/options-automator.ts
@@ -58,7 +58,7 @@ export async function sendOptionAutomatorUpdatesToDataDog(
 
       const params: v1.EventCreateRequest = {
         title: 'Options Automator Update',
-        // TODO(getsentry/eng-pipes#144): Refactor Text Message
+        // TODO(getsentry/eng-pipes#706): Refactor Text Message
         text: JSON.stringify(text),
         alertType: alertType,
         dateHappened: timestamp,

--- a/test/payloads/options-automator/testEmptyPayload.json
+++ b/test/payloads/options-automator/testEmptyPayload.json
@@ -1,0 +1,10 @@
+{
+    "region": "",
+    "drifted_options": [],
+    "updated_options": [],
+    "set_options": [],
+    "unset_options": [],
+    "not_writable_options": [],
+    "unregistered_options": [],
+    "invalid_type_options": []
+}

--- a/test/payloads/options-automator/testPartialPayload.json
+++ b/test/payloads/options-automator/testPartialPayload.json
@@ -1,0 +1,13 @@
+{
+    "region": "test_region",
+    "drifted_options": [
+        {"option_name": "drifted_option_1", "option_value": "value_1"},
+        {"option_name": "drifted_option_2", "option_value": "value_2"}
+    ],
+    "updated_options": [],
+    "set_options": [],
+    "unset_options": [],
+    "not_writable_options": [],
+    "unregistered_options": [],
+    "invalid_type_options": []
+}

--- a/test/payloads/options-automator/testPayload.json
+++ b/test/payloads/options-automator/testPayload.json
@@ -1,0 +1,30 @@
+{
+    "region": "test_region",
+    "drifted_options": [
+        {"option_name": "drifted_option_1", "option_value": "value_1"},
+        {"option_name": "drifted_option_2", "option_value": "value_2"}
+    ],
+    "updated_options": [
+        {
+            "option_name": "updated_option_1",
+            "db_value": "db_value_1",
+            "value": "new_value_1"
+        }
+    ],
+    "set_options": [
+        {"option_name": "set_option_1", "option_value": "set_value_1"},
+        {"option_name": "set_option_2", "option_value": "set_value_2"}
+    ],
+    "unset_options": ["unset_option_1", "unset_option_2"],
+    "not_writable_options": [
+        {"option_name": "error_option_1", "error_msg": "Error occurred for option 1"},
+        {"option_name": "error_option_2", "error_msg": "Error occurred for option 2"}
+    ],
+    "unregistered_options": [
+        "unregisterd_option_1", "unregisterd_option_2"
+    ],
+    "invalid_type_options": [
+        {"option_name": "invalid_type_option_1", "got_type": "string", "expected_type": "float"},
+        {"option_name": "invalid_type_option_2", "got_type": "float", "expected_type": "int"}
+    ]
+}

--- a/test/payloads/options-automator/testSaasPayload.json
+++ b/test/payloads/options-automator/testSaasPayload.json
@@ -1,0 +1,16 @@
+{
+    "region": "us",
+    "drifted_options": [],
+    "updated_options": [
+        {
+            "option_name": "updated_option_1",
+            "db_value": "db_value_1",
+            "value": "new_value_1"
+        }
+    ],
+    "set_options": [],
+    "unset_options": [],
+    "not_writable_options": [],
+    "unregistered_options": [],
+    "invalid_type_options": []
+}


### PR DESCRIPTION
This PR does a couple things: 

- for each option changed, send an event to datadog 
- report as `success` or `error` depending on the option 
- adds the correct tags for datadog dashboard purposes and for tracking infra changes 
