### PR TITLE
Fix some bugs with ttr

### DIFF
--- a/src/utils/scores.test.ts
+++ b/src/utils/scores.test.ts
@@ -67,7 +67,7 @@ describe('score tests', () => {
       labelings.repository as repository,
       IF(
         unlabelings.dt IS NULL,
-        CURRENT_TIMESTAMP(),
+        NULL,
         unlabelings.dt
       ) AS triaged_dt,
       labelings.dt AS routed_dt,
@@ -82,7 +82,7 @@ describe('score tests', () => {
       OR unlabelings.dt IS NULL)
       AND timestamp_diff(
         CURRENT_TIMESTAMP(),
-        labelings.dt,
+        labelings.dt_triage_by,
         day
       ) <= 7
   )

--- a/src/utils/scores.ts
+++ b/src/utils/scores.ts
@@ -47,7 +47,7 @@ export async function getIssueEventsForTeam(team) {
       labelings.repository as repository,
       IF(
         unlabelings.dt IS NULL,
-        CURRENT_TIMESTAMP(),
+        NULL,
         unlabelings.dt
       ) AS triaged_dt,
       labelings.dt AS routed_dt,
@@ -62,7 +62,7 @@ export async function getIssueEventsForTeam(team) {
       OR unlabelings.dt IS NULL)
       AND timestamp_diff(
         CURRENT_TIMESTAMP(),
-        labelings.dt,
+        labelings.dt_triage_by,
         day
       ) <= 7
   )

--- a/src/webhooks/pubsub/slackScores.test.ts
+++ b/src/webhooks/pubsub/slackScores.test.ts
@@ -119,7 +119,7 @@ describe('slackScores tests', function () {
             issue_id: 4,
             repository: 'routing-repo',
             product_area: 'Test',
-            triaged_dt: { value: '2023-10-13T16:53:15.000Z' },
+            triaged_dt: null,
             triage_by_dt: { value: '2023-10-12T21:52:14.223Z' },
           },
         ])
@@ -186,14 +186,14 @@ describe('slackScores tests', function () {
       });
     });
 
-    it('should ignore issue if it is not due yet', async () => {
+    it('should ignore issue if it is not due yet and not triaged', async () => {
       getIssueEventsForTeamSpy
         .mockReturnValueOnce([
           {
             issue_id: 1,
             repository: 'routing-repo',
             product_area: 'One-Team',
-            triaged_dt: { value: '2023-10-11T16:53:15.000Z' },
+            triaged_dt: null,
             triage_by_dt: { value: '9999-10-12T21:52:14.223Z' },
           },
         ])
@@ -222,6 +222,56 @@ describe('slackScores tests', function () {
 | issues                        |   - (0/0)      |
 | null                          |   - (0/0)      |
 | ospo                          |   - (0/0)      |
+└────────────────────────────────────────────────┘\`\`\``,
+              type: 'mrkdwn',
+            },
+            type: 'section',
+          },
+        ],
+        channel: TEAM_PRODUCT_OWNERS_CHANNEL_ID,
+        text: 'Weekly GitHub Team Scores',
+      });
+    });
+
+    it('should count issue if it is not due yet and already triaged', async () => {
+      getIssueEventsForTeamSpy
+        .mockReturnValueOnce([
+          {
+            issue_id: 1,
+            repository: 'routing-repo',
+            product_area: 'One-Team',
+            triaged_dt: { value: '2023-10-12T21:52:14.223Z' },
+            triage_by_dt: { value: '9999-10-12T21:52:14.223Z' },
+          },
+        ])
+        .mockReturnValue([]);
+      await sendGitHubEngagementMetrics();
+      expect(postMessageSpy).toHaveBeenCalledWith({
+        blocks: [
+          {
+            text: {
+              emoji: true,
+              text: '🗓️ Weekly GitHub Response Times by Team 🗓️',
+              type: 'plain_text',
+            },
+            type: 'header',
+          },
+          {
+            text: {
+              text: `\`\`\`
+┌────────────────────────────────────────────────┐
+| Team                          │ % on Time      |
+├────────────────────────────────────────────────┤
+| Low Volume                                     |
+├────────────────────────────────────────────────┤
+| ospo                          | 100 (1/1)      |
+├────────────────────────────────────────────────┤
+| No Volume                                      |
+├────────────────────────────────────────────────┤
+| enterprise                    |   - (0/0)      |
+| ingest                        |   - (0/0)      |
+| issues                        |   - (0/0)      |
+| null                          |   - (0/0)      |
 └────────────────────────────────────────────────┘\`\`\``,
               type: 'mrkdwn',
             },

--- a/src/webhooks/pubsub/slackScores.ts
+++ b/src/webhooks/pubsub/slackScores.ts
@@ -44,12 +44,16 @@ export const sendGitHubEngagementMetrics = async (
 ) => {
   const teamScores: teamScoreInfo[] = await Promise.all(
     Object.keys(PRODUCT_OWNERS_INFO['teams']).map(async (team: string) => {
-      // Filter out issues that are not yet due
+      // Filter for issues that have been due in the past week unless they have been triaged
       const issueTriageEvents = (await getIssueEventsForTeam(team)).filter(
-        (issue) => moment(issue.triage_by_dt.value) <= moment()
+        (issue) =>
+          moment(issue.triage_by_dt.value) <= moment() ||
+          issue.triaged_dt !== null
       );
       const triagedOnTimeEvents = issueTriageEvents.filter(
-        (issue) => issue.triaged_dt.value <= issue.triage_by_dt.value
+        (issue) =>
+          issue.triaged_dt !== null &&
+          issue.triaged_dt.value <= issue.triage_by_dt.value
       );
       // For teams with 0 events, set the score to 0 instead of NaN to ensure those teams
       // end up on the bottom of the scoreboard automatically.


### PR DESCRIPTION
1. Makes it more obvious when an issue is not yet triaged, `triaged_dt` will be null
2. Count issues immediately if they are triaged early
3. Use the issue due date (`triage_by_dt`) as a basis for finding issues to count in slack message, instead of the labeling of `Waiting for: Product Owner`