### PR TITLE
Filling in sentry User

### DIFF
--- a/src/webhooks/sentry-options/sentry-options.test.ts
+++ b/src/webhooks/sentry-options/sentry-options.test.ts
@@ -302,6 +302,7 @@ describe('sentry-options webhook', function () {
             'source:options-automator',
             'source_category:infra-tools',
             'option_name:drifted_option_1',
+            `sentry_user:options-automator`,
           ],
         },
       });
@@ -318,6 +319,7 @@ describe('sentry-options webhook', function () {
             'source:options-automator',
             'source_category:infra-tools',
             'option_name:drifted_option_2',
+            `sentry_user:options-automator`,
           ],
         },
       });
@@ -345,6 +347,7 @@ describe('sentry-options webhook', function () {
           'source:options-automator',
           'source_category:infra-tools',
           'option_name:updated_option_1',
+          `sentry_user:options-automator`,
         ],
       },
     });

--- a/src/webhooks/sentry-options/sentry-options.ts
+++ b/src/webhooks/sentry-options/sentry-options.ts
@@ -68,6 +68,7 @@ export async function sendSentryOptionsUpdatesToDatadog(
           `source:${message.source}`,
           `source_category:infra-tools`,
           `option_name:${option.option_name}`,
+          `sentry_user::${message.source}`,
         ],
       };
       await DATADOG_API_INSTANCE.createEvent({ body: params });


### PR DESCRIPTION
Adding in a `sentry_user` tag, this will eventually be replaced with the actual user who made the change. For now, adding in the same as source tool so datadog can group better. 