### PR TITLE
Adding no deploys alert for s4s

### DIFF
--- a/src/brain/gocdNoDeploysAlert/index.ts
+++ b/src/brain/gocdNoDeploysAlert/index.ts
@@ -20,6 +20,7 @@ import { getLastGetSentryGoCDDeploy } from '@/utils/db/getLatestDeploy';
 const PIPELINE_FILTER = [
   GOCD_SENTRYIO_BE_PIPELINE_NAME,
   GOCD_SENTRYIO_FE_PIPELINE_NAME,
+  'deploy-getsentry-backend-s4s',
 ];
 const DEPLOYS_FAILING_HOURS = 2;
 export const DEPLOYS_FAILING_LIMIT_MS = DEPLOYS_FAILING_HOURS * 60 * 60 * 1000;

--- a/src/brain/gocdNoDeploysAlert/index.ts
+++ b/src/brain/gocdNoDeploysAlert/index.ts
@@ -18,9 +18,9 @@ import {
 import { getLastGetSentryGoCDDeploy } from '@/utils/db/getLatestDeploy';
 
 const PIPELINE_FILTER = [
+  'deploy-getsentry-backend-s4s',
   GOCD_SENTRYIO_BE_PIPELINE_NAME,
   GOCD_SENTRYIO_FE_PIPELINE_NAME,
-  'deploy-getsentry-backend-s4s',
 ];
 const DEPLOYS_FAILING_HOURS = 2;
 export const DEPLOYS_FAILING_LIMIT_MS = DEPLOYS_FAILING_HOURS * 60 * 60 * 1000;


### PR DESCRIPTION
Will hopefully help improve visibility around s4s failing to deploy (messages will only be sent in feed-dev-infra for now).