### PR TITLE
fix(apis): Improve Slack message for APIs

### DIFF
--- a/src/brain/apis/getStatsMessage.test.ts
+++ b/src/brain/apis/getStatsMessage.test.ts
@@ -21,21 +21,21 @@ jest.mock('./getOwnershipData', () =>
 describe('api stats', function () {
   it('calculates team stats', async function () {
     const response = await getStatsMessage('team1');
-    expect(response.message).toBe(
+    expect(response.messages[0]).toBe(
       'Publish status for team1 APIs:\n' +
-        '• public: 1 (100%) :party-sunglasses-blob: \n' +
+        '• public: 1 (100%) :bufo-silly-goose-dance: \n' +
         '• private: 0 (0%)  \n' +
-        '• experimental: 0 (0%) :party-sunglasses-blob: \n' +
-        '• unknown: 0 (0%) :party-sunglasses-blob: \n'
+        '• experimental: 0 (0%) :bufo-party: \n' +
+        '• unknown: 0 (0%) :bufo-party: \n'
     );
   });
 
   it('calculates overall stats', async function () {
     const response = await getStatsMessage('');
-    expect(response.message).toBe(
+    expect(response.messages[0]).toBe(
       'Team Name            | Public(%) | Private(%) | Experimental(%) | Unknown(%)\n' +
-        '<https://github.com/getsentry/sentry/blob/master/src/sentry/apidocs/api_ownership_stats_dont_modify.json#L1|team1>                | 100       | 0          | 0               | 0         \n' +
-        '<https://github.com/getsentry/sentry/blob/master/src/sentry/apidocs/api_ownership_stats_dont_modify.json#L7|team2>                | 0   ☒     | 0          | 33  ☒           | 67  ☒     \n'
+        '<https://github.com/getsentry/sentry-api-schema/blob/main/api_ownership_stats_dont_modify.json#L1|team1>                | 100       | 0          | 0               | 0         \n' +
+        '<https://github.com/getsentry/sentry-api-schema/blob/main/api_ownership_stats_dont_modify.json#L7|team2>                | 0         | 0          | 33              | 67        \n'
     );
   });
 });

--- a/src/brain/apis/getStatsMessage.ts
+++ b/src/brain/apis/getStatsMessage.ts
@@ -1,48 +1,41 @@
 import getOwnershipData from './getOwnershipData';
 
 export const OWNERSHIP_FILE_LINK =
-  'https://github.com/getsentry/sentry/blob/master/src/sentry/apidocs/api_ownership_stats_dont_modify.json';
+  'https://github.com/getsentry/sentry-api-schema/blob/main/api_ownership_stats_dont_modify.json';
 export const INVALID_TEAM_ERROR = 'INVALID_TEAM_ERROR';
+const SLACK_MESSAGE_LIMIT = 3000;
+
+type TeamData = {
+  blockStart: number,
+  public: Array<String>,
+  private: Array<String>,
+  experimental: Array<String>,
+  unknown: Array<String>,
+}
 
 const COLUMN_WIDTH = 21;
 function getEmojiForType(
   type: string,
-  api_rate: number,
-  is_short_message: boolean
+  api_rate: number
 ) {
-  if (is_short_message) {
-    switch (type) {
-      case 'public':
-        return api_rate < 10 ? '☒' : '';
-      case 'private':
-        return '';
-      case 'unknown':
-        return api_rate > 0 ? '☒' : '';
-      case 'experimental':
-        return api_rate > 0 ? '☒' : '';
-      default:
-        return '';
-    }
-  }
-
   switch (type) {
     case 'public':
       return api_rate === 0
-        ? ':sad_blob:'
+        ? ':bufo-sad:'
         : api_rate < 20
-        ? ':blob-unamused:'
+        ? ':bufo-facepalm:'
         : api_rate > 50
-        ? ':party-sunglasses-blob:'
+        ? ':bufo-silly-goose-dance:'
         : '';
     case 'private':
       return '';
     case 'unknown':
     case 'experimental':
       return api_rate === 0
-        ? ':party-sunglasses-blob:'
+        ? ':bufo-party:'
         : api_rate > 50
-        ? ':sad_blob:'
-        : ':blob-unamused:';
+        ? ':bufo-sad:'
+        : ':bufo-facepalm:';
     default:
       return '';
   }
@@ -50,18 +43,17 @@ function getEmojiForType(
 
 function getShortMessageForType(team_data, type, total) {
   const api_rate = Math.round((team_data[type].length * 100) / total);
-  const emoji = getEmojiForType(type, api_rate, true);
   const rate_string = strAdjustLength(api_rate.toString(), 3);
-  return strAdjustLength(`${rate_string} ${emoji}`, type.length + 3);
+  return strAdjustLength(`${rate_string}`, type.length + 3);
 }
 
 function getMessageLineForType(team_data, type, total) {
   const api_rate = Math.round((team_data[type].length * 100) / total);
-  const emoji = getEmojiForType(type, api_rate, false);
+  const emoji = getEmojiForType(type, api_rate);
   return `• ${type}: ${team_data[type].length} (${api_rate}%) ${emoji} \n`;
 }
 
-function getTotalApisForTeam(team_data) {
+function getTotalApisForTeam(team_data): number {
   return (
     team_data['public'].length +
     team_data['private'].length +
@@ -74,12 +66,13 @@ function getMessageForTeam(ownership_data, team) {
   const team_data = ownership_data[team];
   const total = getTotalApisForTeam(team_data);
   return {
-    message:
+    messages: [ 
       `Publish status for ${team} APIs:\n` +
       getMessageLineForType(team_data, 'public', total) +
       getMessageLineForType(team_data, 'private', total) +
       getMessageLineForType(team_data, 'experimental', total) +
-      getMessageLineForType(team_data, 'unknown', total),
+      getMessageLineForType(team_data, 'unknown', total)],
+    goal: Math.round(team_data["unknown"].length * 100 / total),
     should_show_docs:
       team_data['unknown'].length + team_data['experimental'].length > 0,
     review_link: `${OWNERSHIP_FILE_LINK}#L${team_data['block_start']}`,
@@ -94,14 +87,36 @@ function strAdjustLength(word: string, target: number) {
 }
 
 function getOverallStats(ownership_data) {
-  let response =
+  const response_lines: Array<string> = []
+  let total_apis: number = 0;
+  let unknown_apis: number = 0;
+  response_lines.push(
     strAdjustLength('Team Name', COLUMN_WIDTH) +
-    '| Public(%) | Private(%) | Experimental(%) | Unknown(%)\n';
-  ownership_data.forEach((team_data, team) => {
+    '| Public(%) | Private(%) | Experimental(%) | Unknown(%)\n');
+
+  const typed_ownership_data: Map<string, TeamData> = new Map()
+  ownership_data.forEach((value, key) => {
+      const teamData: TeamData = 
+      {
+          blockStart: value['block_start'], 
+          public: value['public'], 
+          private: value['private'], 
+          unknown: value['unknown'],
+          experimental: value['experimental']
+      }
+      typed_ownership_data.set(key, teamData);
+    }
+  )
+  const sorted_data = new Map([...typed_ownership_data.entries()].sort((a, b) => {
+    return a[0].localeCompare(b[0])
+  }));
+
+  sorted_data.forEach((team_data, team) => {
     const total = getTotalApisForTeam(team_data);
-    response =
-      response +
-      `<${OWNERSHIP_FILE_LINK}#L${team_data['block_start']}|${team}>` +
+    total_apis += total;
+    unknown_apis += team_data["unknown"].length
+    response_lines.push(
+      `<${OWNERSHIP_FILE_LINK}#L${team_data.blockStart}|${team}>` +
       strAdjustLength('', COLUMN_WIDTH - team.length) +
       '| ' +
       getShortMessageForType(team_data, 'public', total) +
@@ -111,17 +126,37 @@ function getOverallStats(ownership_data) {
       getShortMessageForType(team_data, 'experimental', total) +
       ' | ' +
       getShortMessageForType(team_data, 'unknown', total) +
-      '\n';
+      '\n');
   });
-  return response;
+  // Slack messages can't be longer than 3000 characters so splitting the message into
+  // multiple ones
+  const messages: Array<string> = []
+  let message: string = '';
+  response_lines.forEach((line, index) => {
+    const result = message + line;
+    if (result.length <= SLACK_MESSAGE_LIMIT) {
+      message = result;
+      if (index == response_lines.length - 1) {
+        messages.push(message)
+      }
+    } else {
+      messages.push(message);
+      message = line;
+    }
+  });
+
+  const goal = Math.round(unknown_apis * 100 / total_apis);
+  return {messages, goal};
 }
 
 export default async function getStatsMessage(team: string) {
   const ownership_data = await getOwnershipData();
   // If team is not mentioned return stats for all
   if (team === '') {
+    const {messages, goal} = getOverallStats(new Map(Object.entries(ownership_data)));
     return {
-      message: getOverallStats(new Map(Object.entries(ownership_data))),
+      messages: messages,
+      goal: goal,
       should_show_docs: true,
       review_link: OWNERSHIP_FILE_LINK,
     };
@@ -132,7 +167,8 @@ export default async function getStatsMessage(team: string) {
   }
 
   return {
-    message: INVALID_TEAM_ERROR,
+    messages: [INVALID_TEAM_ERROR],
+    goal: -1,
     should_show_docs: false,
     review_link: OWNERSHIP_FILE_LINK,
   };

--- a/src/brain/apis/getStatsMessage.ts
+++ b/src/brain/apis/getStatsMessage.ts
@@ -6,18 +6,15 @@ export const INVALID_TEAM_ERROR = 'INVALID_TEAM_ERROR';
 const SLACK_MESSAGE_LIMIT = 3000;
 
 type TeamData = {
-  blockStart: number,
-  public: Array<String>,
-  private: Array<String>,
-  experimental: Array<String>,
-  unknown: Array<String>,
-}
+  blockStart: number;
+  public: Array<String>;
+  private: Array<String>;
+  experimental: Array<String>;
+  unknown: Array<String>;
+};
 
 const COLUMN_WIDTH = 21;
-function getEmojiForType(
-  type: string,
-  api_rate: number
-) {
+function getEmojiForType(type: string, api_rate: number) {
   switch (type) {
     case 'public':
       return api_rate === 0
@@ -66,13 +63,14 @@ function getMessageForTeam(ownership_data, team) {
   const team_data = ownership_data[team];
   const total = getTotalApisForTeam(team_data);
   return {
-    messages: [ 
+    messages: [
       `Publish status for ${team} APIs:\n` +
-      getMessageLineForType(team_data, 'public', total) +
-      getMessageLineForType(team_data, 'private', total) +
-      getMessageLineForType(team_data, 'experimental', total) +
-      getMessageLineForType(team_data, 'unknown', total)],
-    goal: Math.round(team_data["unknown"].length * 100 / total),
+        getMessageLineForType(team_data, 'public', total) +
+        getMessageLineForType(team_data, 'private', total) +
+        getMessageLineForType(team_data, 'experimental', total) +
+        getMessageLineForType(team_data, 'unknown', total),
+    ],
+    goal: Math.round((team_data['unknown'].length * 100) / total),
     should_show_docs:
       team_data['unknown'].length + team_data['experimental'].length > 0,
     review_link: `${OWNERSHIP_FILE_LINK}#L${team_data['block_start']}`,
@@ -87,57 +85,59 @@ function strAdjustLength(word: string, target: number) {
 }
 
 function getOverallStats(ownership_data) {
-  const response_lines: Array<string> = []
+  const response_lines: Array<string> = [];
   let total_apis: number = 0;
   let unknown_apis: number = 0;
   response_lines.push(
     strAdjustLength('Team Name', COLUMN_WIDTH) +
-    '| Public(%) | Private(%) | Experimental(%) | Unknown(%)\n');
+      '| Public(%) | Private(%) | Experimental(%) | Unknown(%)\n'
+  );
 
-  const typed_ownership_data: Map<string, TeamData> = new Map()
+  const typed_ownership_data: Map<string, TeamData> = new Map();
   ownership_data.forEach((value, key) => {
-      const teamData: TeamData = 
-      {
-          blockStart: value['block_start'], 
-          public: value['public'], 
-          private: value['private'], 
-          unknown: value['unknown'],
-          experimental: value['experimental']
-      }
-      typed_ownership_data.set(key, teamData);
-    }
-  )
-  const sorted_data = new Map([...typed_ownership_data.entries()].sort((a, b) => {
-    return a[0].localeCompare(b[0])
-  }));
+    const teamData: TeamData = {
+      blockStart: value['block_start'],
+      public: value['public'],
+      private: value['private'],
+      unknown: value['unknown'],
+      experimental: value['experimental'],
+    };
+    typed_ownership_data.set(key, teamData);
+  });
+  const sorted_data = new Map(
+    [...typed_ownership_data.entries()].sort((a, b) => {
+      return a[0].localeCompare(b[0]);
+    })
+  );
 
   sorted_data.forEach((team_data, team) => {
     const total = getTotalApisForTeam(team_data);
     total_apis += total;
-    unknown_apis += team_data["unknown"].length
+    unknown_apis += team_data['unknown'].length;
     response_lines.push(
       `<${OWNERSHIP_FILE_LINK}#L${team_data.blockStart}|${team}>` +
-      strAdjustLength('', COLUMN_WIDTH - team.length) +
-      '| ' +
-      getShortMessageForType(team_data, 'public', total) +
-      ' | ' +
-      getShortMessageForType(team_data, 'private', total) +
-      ' | ' +
-      getShortMessageForType(team_data, 'experimental', total) +
-      ' | ' +
-      getShortMessageForType(team_data, 'unknown', total) +
-      '\n');
+        strAdjustLength('', COLUMN_WIDTH - team.length) +
+        '| ' +
+        getShortMessageForType(team_data, 'public', total) +
+        ' | ' +
+        getShortMessageForType(team_data, 'private', total) +
+        ' | ' +
+        getShortMessageForType(team_data, 'experimental', total) +
+        ' | ' +
+        getShortMessageForType(team_data, 'unknown', total) +
+        '\n'
+    );
   });
   // Slack messages can't be longer than 3000 characters so splitting the message into
   // multiple ones
-  const messages: Array<string> = []
+  const messages: Array<string> = [];
   let message: string = '';
   response_lines.forEach((line, index) => {
     const result = message + line;
     if (result.length <= SLACK_MESSAGE_LIMIT) {
       message = result;
-      if (index == response_lines.length - 1) {
-        messages.push(message)
+      if (index === response_lines.length - 1) {
+        messages.push(message);
       }
     } else {
       messages.push(message);
@@ -145,15 +145,17 @@ function getOverallStats(ownership_data) {
     }
   });
 
-  const goal = Math.round(unknown_apis * 100 / total_apis);
-  return {messages, goal};
+  const goal = Math.round((unknown_apis * 100) / total_apis);
+  return { messages, goal };
 }
 
 export default async function getStatsMessage(team: string) {
   const ownership_data = await getOwnershipData();
   // If team is not mentioned return stats for all
   if (team === '') {
-    const {messages, goal} = getOverallStats(new Map(Object.entries(ownership_data)));
+    const { messages, goal } = getOverallStats(
+      new Map(Object.entries(ownership_data))
+    );
     return {
       messages: messages,
       goal: goal,

--- a/src/brain/apis/index.ts
+++ b/src/brain/apis/index.ts
@@ -7,12 +7,12 @@ import getStatsMessage, {
 } from './getStatsMessage';
 
 type SlackBlock = {
-  type: string,
+  type: string;
   text: {
-    type: string,
-    text: string,
-  }
-}
+    type: string;
+    text: string;
+  };
+};
 export function apis() {
   bolt.event(
     'app_mention',
@@ -58,32 +58,32 @@ export function apis() {
           return;
         }
 
-    
         const blocks: Array<SlackBlock> = [];
         response.messages.forEach((message) => {
-          blocks.push(
-          {
+          blocks.push({
             type: 'section',
             text: {
               type: 'mrkdwn',
-              text:
-                team === ''
-                  ? '```' + message + '```'
-                  : message,
+              text: team === '' ? '```' + message + '```' : message,
             },
           });
         });
 
-        blocks.push(
-            {
-              type: 'section',
-              text: {
-                type: 'mrkdwn',
-                text: (response.goal == 0 ? ":bufo-party:" : response.goal > 50 ?  ":bufo-cry:" : ":bufo-silly-goose-dance:") +
-                  " " + response.goal.toString() + "% far from the goal of having no unknown APIs.",
-              },
-            }
-        );
+        blocks.push({
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text:
+              (response.goal === 0
+                ? ':bufo-party:'
+                : response.goal > 50
+                ? ':bufo-cry:'
+                : ':bufo-silly-goose-dance:') +
+              ' ' +
+              response.goal.toString() +
+              '% far from the goal of having no unknown APIs.',
+          },
+        });
         if (response.should_show_docs === true) {
           blocks.push({
             type: 'section',

--- a/src/brain/apis/index.ts
+++ b/src/brain/apis/index.ts
@@ -6,6 +6,13 @@ import getStatsMessage, {
   OWNERSHIP_FILE_LINK,
 } from './getStatsMessage';
 
+type SlackBlock = {
+  type: string,
+  text: {
+    type: string,
+    text: string,
+  }
+}
 export function apis() {
   bolt.event(
     'app_mention',
@@ -33,7 +40,7 @@ export function apis() {
 
       try {
         const response = await getStatsMessage(team);
-        if (response.message === INVALID_TEAM_ERROR) {
+        if (response.messages[0] === INVALID_TEAM_ERROR) {
           await client.chat.update({
             channel: String(message.channel),
             ts: String(message.ts),
@@ -51,19 +58,32 @@ export function apis() {
           return;
         }
 
-        const blocks = [
+    
+        const blocks: Array<SlackBlock> = [];
+        response.messages.forEach((message) => {
+          blocks.push(
           {
             type: 'section',
             text: {
               type: 'mrkdwn',
               text:
                 team === ''
-                  ? '```' + response.message + '```'
-                  : response.message,
+                  ? '```' + message + '```'
+                  : message,
             },
-          },
-        ];
+          });
+        });
 
+        blocks.push(
+            {
+              type: 'section',
+              text: {
+                type: 'mrkdwn',
+                text: (response.goal == 0 ? ":bufo-party:" : response.goal > 50 ?  ":bufo-cry:" : ":bufo-silly-goose-dance:") +
+                  " " + response.goal.toString() + "% far from the goal of having no unknown APIs.",
+              },
+            }
+        );
         if (response.should_show_docs === true) {
           blocks.push({
             type: 'section',

--- a/src/brain/apis/indext.test.ts
+++ b/src/brain/apis/indext.test.ts
@@ -11,8 +11,9 @@ jest.mock('@api/slack');
 
 jest.mock('./getStatsMessage', () =>
   jest.fn(() => ({
-    message: STATS_TEXT,
+    messages: [STATS_TEXT],
     should_show_docs: false,
+    goal: 50,
     review_link: OWNERSHIP_FILE_LINK,
   }))
 );


### PR DESCRIPTION
Our slack bot is failing because now we have too many teams and slack message has to be less than 3001 character. So in this PR:
1.  I'm breaking one message into multiple messages
2. I'm adding a sentence to say how far the team is from the goal of 0 unknown apis
3. Replace the emojis with :bufo: because why not 🐸 

Overall stats:
![Screenshot 2023-12-05 at 11 30 43 AM](https://github.com/getsentry/eng-pipes/assets/132939361/51610b30-2e61-4a06-9f62-f10271c3f833)


Team stats:
![Screenshot 2023-12-05 at 11 29 52 AM](https://github.com/getsentry/eng-pipes/assets/132939361/b01acda3-7e3d-462d-8241-dde141b54fec)

