### PR TITLE
feat(apis): schedule weekly slack message

### DIFF
--- a/src/brain/apis/getStatsMessage.test.ts
+++ b/src/brain/apis/getStatsMessage.test.ts
@@ -1,4 +1,4 @@
-import getStatsMessage from './getStatsMessage';
+import { getStatsMessage } from './getStatsMessage';
 
 jest.mock('./getOwnershipData', () =>
   jest.fn(() => ({

--- a/src/brain/apis/getStatsMessage.ts
+++ b/src/brain/apis/getStatsMessage.ts
@@ -149,7 +149,7 @@ function getOverallStats(ownership_data) {
   return { messages, goal };
 }
 
-export default async function getStatsMessage(team: string) {
+export default async function getStatsMessage(team: string = '') {
   const ownership_data = await getOwnershipData();
   // If team is not mentioned return stats for all
   if (team === '') {

--- a/src/brain/apis/getStatsMessage.ts
+++ b/src/brain/apis/getStatsMessage.ts
@@ -149,7 +149,7 @@ function getOverallStats(ownership_data) {
   return { messages, goal };
 }
 
-export default async function getStatsMessage(team: string = '') {
+export async function getStatsMessage(team: string = '') {
   const ownership_data = await getOwnershipData();
   // If team is not mentioned return stats for all
   if (team === '') {

--- a/src/brain/apis/index.ts
+++ b/src/brain/apis/index.ts
@@ -13,6 +13,45 @@ type SlackBlock = {
     text: string;
   };
 };
+
+export function getMessageBlocks(response, team = ''): Array<SlackBlock> {
+  const blocks: Array<SlackBlock> = [];
+    response.messages.forEach((message) => {
+      blocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: team === '' ? '```' + message + '```' : message,
+        },
+      });
+    });
+
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text:
+          (response.goal === 0
+            ? ':bufo-party:'
+            : response.goal > 50
+            ? ':bufo-cry:'
+            : ':bufo-silly-goose-dance:') +
+          ' ' +
+          response.goal.toString() +
+          '% far from the goal of having no unknown APIs.',
+      },
+    });
+    if (response.should_show_docs === true) {
+      blocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `Please <${response.review_link}|review> unknown and experimental APIs and <https://develop.sentry.dev/api/public/#1-declaring-owner-for-the-endpoint|update the endpoints> as either public or private.`,
+        },
+      });
+    }
+    return blocks;
+}
 export function apis() {
   bolt.event(
     'app_mention',
@@ -58,47 +97,11 @@ export function apis() {
           return;
         }
 
-        const blocks: Array<SlackBlock> = [];
-        response.messages.forEach((message) => {
-          blocks.push({
-            type: 'section',
-            text: {
-              type: 'mrkdwn',
-              text: team === '' ? '```' + message + '```' : message,
-            },
-          });
-        });
-
-        blocks.push({
-          type: 'section',
-          text: {
-            type: 'mrkdwn',
-            text:
-              (response.goal === 0
-                ? ':bufo-party:'
-                : response.goal > 50
-                ? ':bufo-cry:'
-                : ':bufo-silly-goose-dance:') +
-              ' ' +
-              response.goal.toString() +
-              '% far from the goal of having no unknown APIs.',
-          },
-        });
-        if (response.should_show_docs === true) {
-          blocks.push({
-            type: 'section',
-            text: {
-              type: 'mrkdwn',
-              text: `Please <${response.review_link}|review> unknown and experimental APIs and <https://develop.sentry.dev/api/public/#1-declaring-owner-for-the-endpoint|update the endpoints> as either public or private.`,
-            },
-          });
-        }
-
         await client.chat.update({
           channel: String(message.channel),
           ts: String(message.ts),
           text: 'API Ownership Stats',
-          blocks,
+          blocks: getMessageBlocks(response, team),
         });
       } catch (ex) {
         await client.chat.update({

--- a/src/brain/apis/index.ts
+++ b/src/brain/apis/index.ts
@@ -16,41 +16,41 @@ type SlackBlock = {
 
 export function getMessageBlocks(response, team = ''): Array<SlackBlock> {
   const blocks: Array<SlackBlock> = [];
-    response.messages.forEach((message) => {
-      blocks.push({
-        type: 'section',
-        text: {
-          type: 'mrkdwn',
-          text: team === '' ? '```' + message + '```' : message,
-        },
-      });
-    });
-
+  response.messages.forEach((message) => {
     blocks.push({
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text:
-          (response.goal === 0
-            ? ':bufo-party:'
-            : response.goal > 50
-            ? ':bufo-cry:'
-            : ':bufo-silly-goose-dance:') +
-          ' ' +
-          response.goal.toString() +
-          '% far from the goal of having no unknown APIs.',
+        text: team === '' ? '```' + message + '```' : message,
       },
     });
-    if (response.should_show_docs === true) {
-      blocks.push({
-        type: 'section',
-        text: {
-          type: 'mrkdwn',
-          text: `Please <${response.review_link}|review> unknown and experimental APIs and <https://develop.sentry.dev/api/public/#1-declaring-owner-for-the-endpoint|update the endpoints> as either public or private.`,
-        },
-      });
-    }
-    return blocks;
+  });
+
+  blocks.push({
+    type: 'section',
+    text: {
+      type: 'mrkdwn',
+      text:
+        (response.goal === 0
+          ? ':bufo-party:'
+          : response.goal > 50
+          ? ':bufo-cry:'
+          : ':bufo-silly-goose-dance:') +
+        ' ' +
+        response.goal.toString() +
+        '% far from the goal of having no unknown APIs.',
+    },
+  });
+  if (response.should_show_docs === true) {
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `Please <${response.review_link}|review> unknown and experimental APIs and <https://develop.sentry.dev/api/public/#1-declaring-owner-for-the-endpoint|update the endpoints> as either public or private.`,
+      },
+    });
+  }
+  return blocks;
 }
 export function apis() {
   bolt.event(

--- a/src/brain/apis/index.ts
+++ b/src/brain/apis/index.ts
@@ -1,7 +1,8 @@
 import { bolt } from '@api/slack';
 import { wrapHandler } from '@utils/wrapHandler';
 
-import getStatsMessage, {
+import {
+  getStatsMessage,
   INVALID_TEAM_ERROR,
   OWNERSHIP_FILE_LINK,
 } from './getStatsMessage';

--- a/src/brain/apis/indext.test.ts
+++ b/src/brain/apis/indext.test.ts
@@ -3,23 +3,27 @@ import { createSlackAppMention } from '@test/utils/createSlackAppMention';
 import { buildServer } from '@/buildServer';
 import { bolt } from '@api/slack';
 
-import getStatsMessage, { OWNERSHIP_FILE_LINK } from './getStatsMessage';
+import * as getAPIsStatsMessage from './getStatsMessage';
 import { apis } from '.';
 
 const STATS_TEXT = 'Some random team stats';
 jest.mock('@api/slack');
 
-jest.mock('./getStatsMessage', () =>
-  jest.fn(() => ({
-    messages: [STATS_TEXT],
-    should_show_docs: false,
-    goal: 50,
-    review_link: OWNERSHIP_FILE_LINK,
-  }))
-);
-
 describe('slack app', function () {
-  let fastify;
+  let fastify, getStatsMessageSpy, postMessageSpy;
+
+  beforeAll(() => {
+    getStatsMessageSpy = jest.spyOn(getAPIsStatsMessage, 'getStatsMessage');
+    getStatsMessageSpy.mockImplementation(() => {
+      return {
+        messages: [STATS_TEXT],
+        should_show_docs: false,
+        goal: 50,
+        review_link: getAPIsStatsMessage.OWNERSHIP_FILE_LINK,
+      };
+    });
+    postMessageSpy = jest.spyOn(bolt.client.chat, 'postMessage');
+  });
 
   beforeEach(async function () {
     fastify = await buildServer(false);
@@ -36,8 +40,8 @@ describe('slack app', function () {
       '<@U018UAXJVG8> apis enterprise'
     );
     expect(response.statusCode).toBe(200);
-    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(1);
-    expect(getStatsMessage).toHaveBeenCalledWith('enterprise');
+    expect(postMessageSpy).toHaveBeenCalledTimes(1);
+    expect(getStatsMessageSpy).toHaveBeenCalledWith('enterprise');
 
     expect(bolt.client.chat.update).toHaveBeenCalledTimes(1);
     expect(bolt.client.chat.update.mock.calls[0][0].blocks[0].text.text).toBe(

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -47,6 +47,8 @@ export const TEAM_PRODUCT_OWNERS_CHANNEL_ID =
   process.env.TEAM_PRODUCT_OWNERS_CHANNEL_ID || 'C063DCB4PGF';
 export const DISCUSS_PRODUCT_CHANNEL_ID = // #discuss-product
   process.env.DISCUSS_PRODUCT_CHANNEL_ID || 'CDXAKMGTU';
+export const TEAM_ENGINEERING_CHANNEL_ID = // #team-engineering
+  process.env.TEAM_ENGINEERING_CHANNEL_ID || 'C1B4LB39D';
 export const DISABLE_GITHUB_METRICS =
   process.env.DISABLE_GITHUB_METRICS === 'true' ||
   process.env.DISABLE_GITHUB_METRICS === '1';
@@ -159,6 +161,7 @@ export const GH_ORGS: GitHubOrgs = loadGitHubOrgs(process.env);
 export const GETSENTRY_ORG = GH_ORGS.get(
   process.env.GETSENTRY_ORG_SLUG || 'getsentry'
 );
+
 
 // TODO(eng-pipes/issues#610): Clean up this hacky workaround
 export const PRODUCT_OWNERS_YML = process.cwd().endsWith('/src')

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -162,7 +162,6 @@ export const GETSENTRY_ORG = GH_ORGS.get(
   process.env.GETSENTRY_ORG_SLUG || 'getsentry'
 );
 
-
 // TODO(eng-pipes/issues#610): Clean up this hacky workaround
 export const PRODUCT_OWNERS_YML = process.cwd().endsWith('/src')
   ? `../${process.env.PRODUCT_OWNERS_YML || 'product-owners.yml'}`

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -47,8 +47,6 @@ export const TEAM_PRODUCT_OWNERS_CHANNEL_ID =
   process.env.TEAM_PRODUCT_OWNERS_CHANNEL_ID || 'C063DCB4PGF';
 export const DISCUSS_PRODUCT_CHANNEL_ID = // #discuss-product
   process.env.DISCUSS_PRODUCT_CHANNEL_ID || 'CDXAKMGTU';
-export const TEAM_ENGINEERING_CHANNEL_ID = // #team-engineering
-  process.env.TEAM_ENGINEERING_CHANNEL_ID || 'C1B4LB39D';
 export const DISABLE_GITHUB_METRICS =
   process.env.DISABLE_GITHUB_METRICS === 'true' ||
   process.env.DISABLE_GITHUB_METRICS === '1';

--- a/src/webhooks/pubsub/slackScores.test.ts
+++ b/src/webhooks/pubsub/slackScores.test.ts
@@ -13,11 +13,11 @@ import {
   sendGitHubEngagementMetrics,
   triggerSlackScores,
 } from './slackScores';
-import { OWNERSHIP_FILE_LINK} from '../../brain/apis/getStatsMessage';
+import { OWNERSHIP_FILE_LINK } from '../../brain/apis/getStatsMessage';
 
 jest.mock('../../brain/apis/getStatsMessage', () =>
   jest.fn(() => ({
-    messages: ["Some random message"],
+    messages: ['Some random message'],
     should_show_docs: false,
     goal: 50,
     review_link: OWNERSHIP_FILE_LINK,

--- a/src/webhooks/pubsub/slackScores.test.ts
+++ b/src/webhooks/pubsub/slackScores.test.ts
@@ -13,6 +13,16 @@ import {
   sendGitHubEngagementMetrics,
   triggerSlackScores,
 } from './slackScores';
+import { OWNERSHIP_FILE_LINK} from '../../brain/apis/getStatsMessage';
+
+jest.mock('../../brain/apis/getStatsMessage', () =>
+  jest.fn(() => ({
+    messages: ["Some random message"],
+    should_show_docs: false,
+    goal: 50,
+    review_link: OWNERSHIP_FILE_LINK,
+  }))
+);
 
 describe('slackScores tests', function () {
   let getIssueEventsForTeamSpy, getDiscussionEventsSpy, postMessageSpy;

--- a/src/webhooks/pubsub/slackScores.test.ts
+++ b/src/webhooks/pubsub/slackScores.test.ts
@@ -8,12 +8,12 @@ import {
   TEAM_PRODUCT_OWNERS_CHANNEL_ID,
 } from '../../config';
 
+import { OWNERSHIP_FILE_LINK } from '../../brain/apis/getStatsMessage';
 import {
   sendDiscussionMetrics,
   sendGitHubEngagementMetrics,
   triggerSlackScores,
 } from './slackScores';
-import { OWNERSHIP_FILE_LINK } from '../../brain/apis/getStatsMessage';
 
 jest.mock('../../brain/apis/getStatsMessage', () =>
   jest.fn(() => ({

--- a/src/webhooks/pubsub/slackScores.test.ts
+++ b/src/webhooks/pubsub/slackScores.test.ts
@@ -2,13 +2,13 @@ import { GETSENTRY_ORG, GH_ORGS } from '@/config';
 import { bolt } from '@api/slack';
 import * as scoresUtils from '@utils/scores';
 
+import { OWNERSHIP_FILE_LINK } from '../../brain/apis/getStatsMessage';
 import {
   DISCUSS_PRODUCT_CHANNEL_ID,
   TEAM_OSPO_CHANNEL_ID,
   TEAM_PRODUCT_OWNERS_CHANNEL_ID,
 } from '../../config';
 
-import { OWNERSHIP_FILE_LINK } from '../../brain/apis/getStatsMessage';
 import {
   sendDiscussionMetrics,
   sendGitHubEngagementMetrics,

--- a/src/webhooks/pubsub/slackScores.ts
+++ b/src/webhooks/pubsub/slackScores.ts
@@ -1,5 +1,7 @@
 import moment from 'moment-timezone';
 
+import { getMessageBlocks } from '@/brain/apis';
+import getStatsMessage from '@/brain/apis/getStatsMessage';
 import {
   DISCUSS_PRODUCT_CHANNEL_ID,
   GETSENTRY_ORG,
@@ -11,8 +13,6 @@ import {
 import { getDiscussionEvents, getIssueEventsForTeam } from '@/utils/scores';
 import { GitHubOrg } from '@api/github/org';
 import { bolt } from '@api/slack';
-import getStatsMessage from '@/brain/apis/getStatsMessage';
-import { getMessageBlocks } from '@/brain/apis';
 
 type teamScoreInfo = {
   team: string;
@@ -45,6 +45,9 @@ const TEAM_PREFIX = 'team-';
 
 export const sendApisPublishStatus = async (ospo_internal: boolean = false) => {
   const message = await getStatsMessage();
+  const channelToPost = ospo_internal
+    ? TEAM_OSPO_CHANNEL_ID
+    : TEAM_ENGINEERING_CHANNEL_ID;
   let messageBlocks = [
     {
       type: 'section',
@@ -56,7 +59,7 @@ export const sendApisPublishStatus = async (ospo_internal: boolean = false) => {
   ];
   messageBlocks = messageBlocks.concat(getMessageBlocks(message));
   await bolt.client.chat.postMessage({
-    channel: TEAM_ENGINEERING_CHANNEL_ID,
+    channel: channelToPost,
     text: 'API Publish Stats By Team',
     blocks: messageBlocks,
   });

--- a/src/webhooks/pubsub/slackScores.ts
+++ b/src/webhooks/pubsub/slackScores.ts
@@ -43,9 +43,7 @@ const SPACE_LENGTH = 1;
 const NUM_DISCUSSION_SCOREBOARD_ELEMENTS = 5;
 const TEAM_PREFIX = 'team-';
 
-export const sendApisPublishStatus = async (
-  ospo_internal: boolean = false
-) => {
+export const sendApisPublishStatus = async (ospo_internal: boolean = false) => {
   const message = await getStatsMessage();
   let messageBlocks = [
     {
@@ -55,14 +53,14 @@ export const sendApisPublishStatus = async (
         text: 'API Publish Stats By Team',
       },
     },
-  ]
-  messageBlocks = messageBlocks.concat(getMessageBlocks(message))
+  ];
+  messageBlocks = messageBlocks.concat(getMessageBlocks(message));
   await bolt.client.chat.postMessage({
     channel: TEAM_ENGINEERING_CHANNEL_ID,
     text: 'API Publish Stats By Team',
     blocks: messageBlocks,
   });
-}
+};
 
 export const sendGitHubEngagementMetrics = async (
   ospo_internal: boolean = false

--- a/src/webhooks/pubsub/slackScores.ts
+++ b/src/webhooks/pubsub/slackScores.ts
@@ -319,7 +319,7 @@ export const triggerSlackScores = async (
   if (org !== GETSENTRY_ORG) {
     return;
   }
-  // await sendGitHubEngagementMetrics();
-  // await sendDiscussionMetrics();
+  await sendGitHubEngagementMetrics();
+  await sendDiscussionMetrics();
   await sendApisPublishStatus();
 };

--- a/src/webhooks/pubsub/slackScores.ts
+++ b/src/webhooks/pubsub/slackScores.ts
@@ -1,12 +1,12 @@
 import moment from 'moment-timezone';
 
 import { getMessageBlocks } from '@/brain/apis';
-import getStatsMessage from '@/brain/apis/getStatsMessage';
+import { getStatsMessage } from '@/brain/apis/getStatsMessage';
 import {
   DISCUSS_PRODUCT_CHANNEL_ID,
+  FEED_ENGINEERING_CHANNEL_ID,
   GETSENTRY_ORG,
   PRODUCT_OWNERS_INFO,
-  TEAM_ENGINEERING_CHANNEL_ID,
   TEAM_OSPO_CHANNEL_ID,
   TEAM_PRODUCT_OWNERS_CHANNEL_ID,
 } from '@/config';
@@ -43,11 +43,8 @@ const SPACE_LENGTH = 1;
 const NUM_DISCUSSION_SCOREBOARD_ELEMENTS = 5;
 const TEAM_PREFIX = 'team-';
 
-export const sendApisPublishStatus = async (ospo_internal: boolean = false) => {
+export const sendApisPublishStatus = async () => {
   const message = await getStatsMessage();
-  const channelToPost = ospo_internal
-    ? TEAM_OSPO_CHANNEL_ID
-    : TEAM_ENGINEERING_CHANNEL_ID;
   let messageBlocks = [
     {
       type: 'section',
@@ -59,7 +56,7 @@ export const sendApisPublishStatus = async (ospo_internal: boolean = false) => {
   ];
   messageBlocks = messageBlocks.concat(getMessageBlocks(message));
   await bolt.client.chat.postMessage({
-    channel: channelToPost,
+    channel: FEED_ENGINEERING_CHANNEL_ID,
     text: 'API Publish Stats By Team',
     blocks: messageBlocks,
   });


### PR DESCRIPTION
We want to send API stats to team-engineering every week for better visibility.

Testing using:
```
curl -X POST 'http://127.0.0.1:3000/webhooks/pubsub' -H "Content-Type: application/json" -d '{"message": {"data": "eyJuYW1lIjoic2xhY2stc2NvcmVzIn0="}}'
```

I can see the message in my test org:
![Screenshot 2023-12-06 at 5 54 10 PM](https://github.com/getsentry/eng-pipes/assets/132939361/dd4a7d48-6a3a-4dca-a876-7c0b6f4788ff)
