### PR TITLE
Use new GitHub project to track `Waiting for: Foo` labels

### DIFF
--- a/github-orgs.yml
+++ b/github-orgs.yml
@@ -4,11 +4,17 @@ getsentry:
     privateKey: 'GH_APP_PRIVATE_KEY_FOR_GETSENTRY'
     installationId: 9303463
   project:
-    nodeId: 'PVT_kwDOABVQ184AOGW8'
+    nodeId: 'PVT_kwDOABVQ184AZ4Df'
     fieldIds:
-      productArea: 'PVTSSF_lADOABVQ184AOGW8zgJEBno'
-      status: 'PVTSSF_lADOABVQ184AOGW8zgI_7g0'
-      responseDue: 'PVTF_lADOABVQ184AOGW8zgLLxGg'
+      productArea: 'PVTSSF_lADOABVQ184AZ4DfzgQkiSc'
+      status: 'PVTSSF_lADOABVQ184AZ4DfzgQkiPA'
+      responseDue: 'PVTF_lADOABVQ184AZ4DfzgQkiSs'
+    # Old GH project: https://github.com/orgs/getsentry/projects/76
+    # nodeId: 'PVT_kwDOABVQ184AOGW8'
+    # fieldIds:
+    #   productArea: 'PVTSSF_lADOABVQ184AOGW8zgJEBno'
+    #   status: 'PVTSSF_lADOABVQ184AOGW8zgI_7g0'
+    #   responseDue: 'PVTF_lADOABVQ184AOGW8zgLLxGg'
   repos:
     withRouting:
       - 'sentry'


### PR DESCRIPTION
Our old project has ~1200 items and is at the limit, triggering [issues](https://sentry.sentry.io/issues/4550453765/?project=5246761&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=4&utc=true). Let's use a new one until GitHub supports unlimited items in a project.