### PR TITLE
For slack triage notifications, use business hours left to notify hourly

### DIFF
--- a/src/brain/issueLabelHandler/followups.ts
+++ b/src/brain/issueLabelHandler/followups.ts
@@ -234,12 +234,12 @@ export async function ensureOneWaitingForLabel({
   let timeToRespondBy;
   if (labelName === WAITING_FOR_PRODUCT_OWNER_LABEL) {
     timeToRespondBy =
-      (await calculateSLOViolationTriage(
+      calculateSLOViolationTriage(
         WAITING_FOR_PRODUCT_OWNER_LABEL,
         issue.labels,
         repo,
         org.slug
-      )) || moment().toISOString();
+      ) || moment().toISOString();
   } else if (labelName === WAITING_FOR_SUPPORT_LABEL) {
     timeToRespondBy =
       (await calculateSLOViolationRoute(

--- a/src/utils/businessHours.test.ts
+++ b/src/utils/businessHours.test.ts
@@ -493,66 +493,61 @@ describe('businessHours tests', function () {
     it('should correctly calculate business hours left overnight', function () {
       const triageBy = '2023-12-22T18:00:00.000Z';
       const now = moment('2023-12-22T01:00:00.000Z');
+      const repo = 'test-ttt-simple';
+      const org = 'getsentry';
+      const productArea = 'Other';
       expect(
-        getBusinessHoursLeft(
-          triageBy,
-          now,
-          'test-ttt-simple',
-          'getsentry',
-          'Other'
-        )
+        getBusinessHoursLeft(triageBy, now, repo, org, productArea)
       ).toEqual(1);
     });
     it('should correctly calculate business hours over multiple days', function () {
       const triageBy = '2023-12-22T18:00:00.000Z';
       const now = moment('2023-12-21T01:00:00.000Z');
+      const repo = 'test-ttt-simple';
+      const org = 'getsentry';
+      const productArea = 'Other';
       expect(
-        getBusinessHoursLeft(
-          triageBy,
-          now,
-          'test-ttt-simple',
-          'getsentry',
-          'Other'
-        )
+        getBusinessHoursLeft(triageBy, now, repo, org, productArea)
       ).toEqual(9);
+    });
+    it('should correctly calculate business hours over holiday', function () {
+      const triageBy = '2024-01-02T17:00:00.000Z';
+      const now = moment('2023-12-23T00:00:00.000Z');
+      const repo = 'test-ttt-simple';
+      const org = 'getsentry';
+      const productArea = 'Other';
+      expect(
+        getBusinessHoursLeft(triageBy, now, repo, org, productArea)
+      ).toEqual(1);
     });
     it('should correctly account for weekends when calculating business hours', function () {
       const triageBy = '2023-01-17T18:00:00.000Z';
       const now = moment('2023-01-14T00:00:00.000Z');
+      const repo = 'test-ttt-simple';
+      const org = 'getsentry';
+      const productArea = 'Other';
       expect(
-        getBusinessHoursLeft(
-          triageBy,
-          now,
-          'test-ttt-simple',
-          'getsentry',
-          'Other'
-        )
+        getBusinessHoursLeft(triageBy, now, repo, org, productArea)
       ).toEqual(2);
     });
     it('should correctly calculate business hours for issues with non overlapping timezones', function () {
       const triageBy = '2023-12-22T18:00:00.000Z';
       const now = moment('2023-12-21T01:00:00.000Z');
+      const repo = 'routing-repo';
+      const org = 'getsentry';
+      const productArea = 'Non-Overlapping Timezone';
       expect(
-        getBusinessHoursLeft(
-          triageBy,
-          now,
-          'routing-repo',
-          'getsentry',
-          'Non-Overlapping Timezone'
-        )
+        getBusinessHoursLeft(triageBy, now, repo, org, productArea)
       ).toEqual(25);
     });
     it('should correctly calculate business hours for issues with overlapping timezones', function () {
       const triageBy = '2023-12-22T18:00:00.000Z';
       const now = moment('2023-12-21T01:00:00.000Z');
+      const repo = 'routing-repo';
+      const org = 'getsentry';
+      const productArea = 'Overlapping Timezone';
       expect(
-        getBusinessHoursLeft(
-          triageBy,
-          now,
-          'routing-repo',
-          'getsentry',
-          'Overlapping Timezone'
-        )
+        getBusinessHoursLeft(triageBy, now, repo, org, productArea)
       ).toEqual(15);
     });
   });

--- a/src/utils/businessHours.test.ts
+++ b/src/utils/businessHours.test.ts
@@ -32,6 +32,7 @@ import {
   calculateSLOViolationRoute,
   calculateSLOViolationTriage,
   calculateTimeToRespondBy,
+  getBusinessHoursLeft,
   getNextAvailableBusinessHourWindow,
 } from './businessHours';
 
@@ -285,8 +286,8 @@ describe('businessHours tests', function () {
   });
 
   describe('calculateSLOViolationTriage', function () {
-    it('should calculate SLO violation when product area is not defined', async function () {
-      const result = await calculateSLOViolationTriage(
+    it('should calculate SLO violation when product area is not defined', function () {
+      const result = calculateSLOViolationTriage(
         WAITING_FOR_PRODUCT_OWNER_LABEL,
         [{ name: 'Test' }],
         'routing-repo',
@@ -295,8 +296,8 @@ describe('businessHours tests', function () {
       expect(result).not.toEqual(null);
     });
 
-    it('should not calculate SLO violation if label is not untriaged', async function () {
-      const result = await calculateSLOViolationTriage(
+    it('should not calculate SLO violation if label is not untriaged', function () {
+      const result = calculateSLOViolationTriage(
         'Status: Test',
         [{ name: 'Product Area: Test' }],
         'routing-repo',
@@ -305,8 +306,8 @@ describe('businessHours tests', function () {
       expect(result).toEqual(null);
     });
 
-    it('should not calculate SLO violation if label is unrouted', async function () {
-      const result = await calculateSLOViolationTriage(
+    it('should not calculate SLO violation if label is unrouted', function () {
+      const result = calculateSLOViolationTriage(
         WAITING_FOR_SUPPORT_LABEL,
         [{ name: 'Product Area: Test' }],
         'routing-repo',
@@ -315,8 +316,8 @@ describe('businessHours tests', function () {
       expect(result).toEqual(null);
     });
 
-    it('should calculate SLO violation if label is untriaged', async function () {
-      const result = await calculateSLOViolationTriage(
+    it('should calculate SLO violation if label is untriaged', function () {
+      const result = calculateSLOViolationTriage(
         WAITING_FOR_PRODUCT_OWNER_LABEL,
         [{ name: 'Product Area: Test' }],
         'routing-repo',
@@ -325,8 +326,8 @@ describe('businessHours tests', function () {
       expect(result).not.toEqual(null);
     });
 
-    it('should calculate SLO violation if label is waiting for product owner', async function () {
-      const result = await calculateSLOViolationTriage(
+    it('should calculate SLO violation if label is waiting for product owner', function () {
+      const result = calculateSLOViolationTriage(
         WAITING_FOR_PRODUCT_OWNER_LABEL,
         [{ name: 'Product Area: Test' }],
         'routing-repo',
@@ -337,8 +338,8 @@ describe('businessHours tests', function () {
   });
 
   describe('getNextAvailableBusinessHourWindow', function () {
-    it('should get open source product area timezones if product area does not have offices', async function () {
-      const { start, end } = await getNextAvailableBusinessHourWindow(
+    it('should get open source product area timezones if product area does not have offices', function () {
+      const { start, end } = getNextAvailableBusinessHourWindow(
         'Does not exist',
         moment('2022-12-08T12:00:00.000Z').utc(),
         'routing-repo',
@@ -352,8 +353,8 @@ describe('businessHours tests', function () {
       );
     });
 
-    it('should get sfo timezones for repo with no offices defined', async function () {
-      const { start, end } = await getNextAvailableBusinessHourWindow(
+    it('should get sfo timezones for repo with no offices defined', function () {
+      const { start, end } = getNextAvailableBusinessHourWindow(
         '',
         moment('2022-12-08T12:00:00.000Z').utc(),
         'test-null',
@@ -367,8 +368,8 @@ describe('businessHours tests', function () {
       );
     });
 
-    it('should get sfo timezones for Test', async function () {
-      const { start, end } = await getNextAvailableBusinessHourWindow(
+    it('should get sfo timezones for Test', function () {
+      const { start, end } = getNextAvailableBusinessHourWindow(
         'Test',
         moment('2022-12-08T12:00:00.000Z').utc(),
         'routing-repo',
@@ -382,8 +383,8 @@ describe('businessHours tests', function () {
       );
     });
 
-    it('should get vie timezone for Test if it has the closest business hours available', async function () {
-      const { start, end } = await getNextAvailableBusinessHourWindow(
+    it('should get vie timezone for Test if it has the closest business hours available', function () {
+      const { start, end } = getNextAvailableBusinessHourWindow(
         'Non-Overlapping Timezone',
         moment('2022-12-08T12:00:00.000Z').utc(),
         'routing-repo',
@@ -397,8 +398,8 @@ describe('businessHours tests', function () {
       );
     });
 
-    it('should get sfo timezone for Test if it has the closest business hours available', async function () {
-      const { start, end } = await getNextAvailableBusinessHourWindow(
+    it('should get sfo timezone for Test if it has the closest business hours available', function () {
+      const { start, end } = getNextAvailableBusinessHourWindow(
         'Non-Overlapping Timezone',
         moment('2022-12-08T16:30:00.000Z').utc(),
         'routing-repo',
@@ -412,8 +413,8 @@ describe('businessHours tests', function () {
       );
     });
 
-    it('should get yyz timezone for Test if it has the closest business hours available', async function () {
-      const { start, end } = await getNextAvailableBusinessHourWindow(
+    it('should get yyz timezone for Test if it has the closest business hours available', function () {
+      const { start, end } = getNextAvailableBusinessHourWindow(
         'All-Timezones',
         moment('2022-12-08T16:30:00.000Z').utc(),
         'routing-repo',
@@ -427,8 +428,8 @@ describe('businessHours tests', function () {
       );
     });
 
-    it('should return vie hours for Christmas for product area subscribed to vie, yyz, sfo', async function () {
-      const { start, end } = await getNextAvailableBusinessHourWindow(
+    it('should return vie hours for Christmas for product area subscribed to vie, yyz, sfo', function () {
+      const { start, end } = getNextAvailableBusinessHourWindow(
         'All-Timezones',
         moment('2023-12-23T12:00:00.000Z').utc(),
         'routing-repo',
@@ -442,8 +443,8 @@ describe('businessHours tests', function () {
       );
     });
 
-    it('should return vie hours for Saturday for product area subscribed to vie, yyz, sfo', async function () {
-      const { start, end } = await getNextAvailableBusinessHourWindow(
+    it('should return vie hours for Saturday for product area subscribed to vie, yyz, sfo', function () {
+      const { start, end } = getNextAvailableBusinessHourWindow(
         'All-Timezones',
         moment('2022-12-17T12:00:00.000Z').utc(),
         'routing-repo',
@@ -457,8 +458,8 @@ describe('businessHours tests', function () {
       );
     });
 
-    it('should return vie hours for Sunday for product area subscribed to vie, yyz, sfo', async function () {
-      const { start, end } = await getNextAvailableBusinessHourWindow(
+    it('should return vie hours for Sunday for product area subscribed to vie, yyz, sfo', function () {
+      const { start, end } = getNextAvailableBusinessHourWindow(
         'All-Timezones',
         moment('2022-12-18T12:00:00.000Z').utc(),
         'routing-repo',
@@ -472,8 +473,8 @@ describe('businessHours tests', function () {
       );
     });
 
-    it('should return yyz hours for Saturday for product area subscribed to yyz, sfo', async function () {
-      const { start, end } = await getNextAvailableBusinessHourWindow(
+    it('should return yyz hours for Saturday for product area subscribed to yyz, sfo', function () {
+      const { start, end } = getNextAvailableBusinessHourWindow(
         'Overlapping Timezone',
         moment('2022-12-17T12:00:00.000Z').utc(),
         'routing-repo',
@@ -485,6 +486,74 @@ describe('businessHours tests', function () {
       expect(end.valueOf()).toEqual(
         moment('2022-12-19T22:00:00.000Z').valueOf()
       );
+    });
+  });
+
+  describe('getBusinessHoursLeft', function () {
+    it('should correctly calculate business hours left overnight', function () {
+      const triageBy = '2023-12-22T18:00:00.000Z';
+      const now = moment('2023-12-22T01:00:00.000Z');
+      expect(
+        getBusinessHoursLeft(
+          triageBy,
+          now,
+          'test-ttt-simple',
+          'getsentry',
+          'Other'
+        )
+      ).toEqual(1);
+    });
+    it('should correctly calculate business hours over multiple days', function () {
+      const triageBy = '2023-12-22T18:00:00.000Z';
+      const now = moment('2023-12-21T01:00:00.000Z');
+      expect(
+        getBusinessHoursLeft(
+          triageBy,
+          now,
+          'test-ttt-simple',
+          'getsentry',
+          'Other'
+        )
+      ).toEqual(9);
+    });
+    it('should correctly account for weekends when calculating business hours', function () {
+      const triageBy = '2023-01-17T18:00:00.000Z';
+      const now = moment('2023-01-14T00:00:00.000Z');
+      expect(
+        getBusinessHoursLeft(
+          triageBy,
+          now,
+          'test-ttt-simple',
+          'getsentry',
+          'Other'
+        )
+      ).toEqual(2);
+    });
+    it('should correctly calculate business hours for issues with non overlapping timezones', function () {
+      const triageBy = '2023-12-22T18:00:00.000Z';
+      const now = moment('2023-12-21T01:00:00.000Z');
+      expect(
+        getBusinessHoursLeft(
+          triageBy,
+          now,
+          'routing-repo',
+          'getsentry',
+          'Non-Overlapping Timezone'
+        )
+      ).toEqual(25);
+    });
+    it('should correctly calculate business hours for issues with overlapping timezones', function () {
+      const triageBy = '2023-12-22T18:00:00.000Z';
+      const now = moment('2023-12-21T01:00:00.000Z');
+      expect(
+        getBusinessHoursLeft(
+          triageBy,
+          now,
+          'routing-repo',
+          'getsentry',
+          'Overlapping Timezone'
+        )
+      ).toEqual(15);
     });
   });
 });

--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -288,12 +288,12 @@ export async function insertOss(
           data.product_area &&
           data.product_area.slice(PRODUCT_AREA_LABEL_PREFIX.length);
         if (data.action === 'labeled') {
-          data.timeToRouteBy = await calculateSLOViolationRoute(
+          data.timeToRouteBy = calculateSLOViolationRoute(
             data.target_name,
             payload.repository.name,
             payload.organization.login
           );
-          data.timeToTriageBy = await calculateSLOViolationTriage(
+          data.timeToTriageBy = calculateSLOViolationTriage(
             data.target_name,
             issue.labels,
             payload.repository.name,

--- a/src/webhooks/pubsub/slackNotifications.test.ts
+++ b/src/webhooks/pubsub/slackNotifications.test.ts
@@ -147,6 +147,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel1', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
         ],
         channel2: [
@@ -159,6 +162,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel2', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
           {
             url: 'https://test.com/issues/2',
@@ -169,6 +175,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel2', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
         ],
       };
@@ -274,6 +283,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel1', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
           {
             url: 'https://test.com/issues/1',
@@ -284,6 +296,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel1', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
         ],
       };
@@ -353,6 +368,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel1', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
           {
             url: 'https://test.com/issues/1',
@@ -363,6 +381,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel1', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
           {
             url: 'https://test.com/issues/2',
@@ -373,6 +394,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel1', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
           {
             url: 'https://test.com/issues/4',
@@ -383,6 +407,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel1', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
         ],
       };
@@ -482,6 +509,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel1', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
           {
             url: 'https://test.com/issues/2',
@@ -492,6 +522,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel1', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
           {
             url: 'https://test.com/issues/3',
@@ -502,6 +535,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel1', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
         ],
       };
@@ -578,6 +614,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel1', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
         ],
         channel2: [
@@ -590,6 +629,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel2', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
           {
             url: 'https://test.com/issues/2',
@@ -600,6 +642,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel2', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
         ],
       };
@@ -624,6 +669,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel1', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
         ],
         channel2: [
@@ -636,6 +684,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel2', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
           {
             url: 'https://test.com/issues/2',
@@ -646,6 +697,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel2', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
         ],
       };
@@ -742,6 +796,68 @@ describe('Triage Notification Tests', function () {
         text: '👋 Triage Reminder ⏰',
       });
     });
+    it('should return issue in act fast queue if SLA is within than 4 business hours away', async function () {
+      const channelToIssuesMap = {
+        channel1: [
+          {
+            url: 'https://test.com/issues/1',
+            number: 1,
+            title: 'Test Issue',
+            triageBy: '2022-12-12T18:00:00.000Z',
+            createdAt: '2022-12-10T18:00:00.000Z',
+            channels: [
+              { channelId: 'channel1', isChannelInBusinessHours: true },
+            ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
+          },
+        ],
+      };
+      const now = moment('2022-12-12T00:30:00.000Z');
+      const postMessageSpy = jest.spyOn(bolt.client.chat, 'postMessage');
+      await Promise.all(constructSlackMessage(channelToIssuesMap, now));
+      expect(postMessageSpy).toHaveBeenCalledTimes(1);
+      expect(postMessageSpy).toHaveBeenCalledWith({
+        blocks: [
+          {
+            text: {
+              text: 'Hey! You have some tickets to triage:',
+              type: 'plain_text',
+            },
+            type: 'header',
+          },
+          {
+            type: 'divider',
+          },
+          {
+            fields: [
+              {
+                text: '⌛️ *Act fast!*',
+                type: 'mrkdwn',
+              },
+              {
+                text: '😨',
+                type: 'mrkdwn',
+              },
+            ],
+            type: 'section',
+          },
+          {
+            fields: [
+              {
+                text: '1. <https://test.com/issues/1|#1 Test Issue>',
+                type: 'mrkdwn',
+              },
+              { text: '17 hours 30 minutes left', type: 'mrkdwn' },
+            ],
+            type: 'section',
+          },
+        ],
+        channel: 'channel1',
+        text: '👋 Triage Reminder ⏰',
+      });
+    });
     it('should always notify if issue SLA is in the act fast queue on every hour', async function () {
       const channelToIssuesMap = {
         channel1: [
@@ -754,6 +870,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel1', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
         ],
         channel2: [
@@ -766,6 +885,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel2', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
           {
             url: 'https://test.com/issues/2',
@@ -776,6 +898,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel2', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
         ],
       };
@@ -800,6 +925,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel1', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
         ],
         channel2: [
@@ -812,6 +940,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel2', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
           {
             url: 'https://test.com/issues/2',
@@ -822,6 +953,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel2', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
         ],
       };
@@ -842,6 +976,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel1', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
         ],
         channel2: [
@@ -854,6 +991,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel2', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
           {
             url: 'https://test.com/issues/2',
@@ -864,6 +1004,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel2', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
         ],
       };
@@ -969,6 +1112,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel1', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
         ],
         channel2: [
@@ -981,6 +1127,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel2', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
           {
             url: 'https://test.com/issues/2',
@@ -991,6 +1140,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel2', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
         ],
       };
@@ -1015,6 +1167,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel1', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
         ],
         channel2: [
@@ -1027,6 +1182,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel2', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
           {
             url: 'https://test.com/issues/2',
@@ -1037,6 +1195,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel2', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
         ],
       };
@@ -1061,6 +1222,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel1', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
           {
             url: 'https://test.com/issues/3',
@@ -1071,6 +1235,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel1', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
         ],
         channel2: [
@@ -1083,6 +1250,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel2', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
           {
             url: 'https://test.com/issues/2',
@@ -1093,6 +1263,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel2', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
           {
             url: 'https://test.com/issues/3',
@@ -1103,6 +1276,9 @@ describe('Triage Notification Tests', function () {
             channels: [
               { channelId: 'channel2', isChannelInBusinessHours: true },
             ],
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
         ],
       };
@@ -1220,6 +1396,9 @@ describe('Triage Notification Tests', function () {
             createdAt: '2022-12-08T21:00:00.000Z',
             isChannelInBusinessHours: true,
             channelId: 'channel1',
+            repo: 'routing-repo',
+            productArea: 'One-Team',
+            org: 'getsentry',
           },
         ],
       };


### PR DESCRIPTION
It's a bit annoying when in the morning, a team gets surprised with a slack notification of an issue that is due in 24 minutes. This is because at the end of the day, we're not necessarily notifying teams of issues due the next morning since it is technically over 12 hours away. 

Also cleans up some unneeded async/await declarations

Closes this: https://github.com/getsentry/eng-pipes/issues/719

