### PR TITLE
fix: update region naming to be the same as sentry-kube

### DIFF
--- a/src/brain/gocdDataDog/deployDatadogEvents.ts
+++ b/src/brain/gocdDataDog/deployDatadogEvents.ts
@@ -226,7 +226,7 @@ export class DeployDatadogEvents {
   getFormattedRegion(pipeline: GoCDPipeline) {
     const pipeline_name = pipeline.name;
     const sentry_region_mappings = {
-      s4s: 's4s',
+      s4s: 'st-sentry4sentry',
       us: 'us',
       de: 'de',
       'customer-1': 'st-goldmansachs',


### PR DESCRIPTION
just so you can filter easier in datadog. because sentry-kube uses `st-sentry4sentry` this currently uses `s4s`