### PR TITLE
Updating the message sent on canary failure

### DIFF
--- a/src/brain/gocdSlackFeeds/index.test.ts
+++ b/src/brain/gocdSlackFeeds/index.test.ts
@@ -106,12 +106,12 @@ describe('gocdSlackFeeds', function () {
         slackblocks.section(
           slackblocks.markdown(
             `The deployment pipeline has been paused due to detected issues in canary.
-            Here are the steps you should follow to address the situation:\n\n
-            :mag_right: *Step 1: Review the Errors*\n Review the errors in the *<https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-us/20/deploy-canary/1/deploy-backend|Canary Logs>*.\n
-            :sentry: *Step 2: Check Sentry Release*\n Check the *<https://sentry.sentry.io/releases/backend@2b0034becc4ab26b985f4c1a08ab068f153c274c/?project=|Sentry Release>* for any related issues.\n
-            :thinking_face: *Step 3: Is a Rollback Necessary?*\nDetermine if a rollback is necessary by reviewing our *<${IS_ROLLBACK_NECESSARY_LINK}|Guidelines>*.\n
-            :arrow_backward: *Step 4: Rollback Procedure*\nIf a rollback is necessary, use the *<${ROLLBACK_PLAYBOOK_LINK}|GoCD Playbook>* or *<${GOCD_USER_GUIDE_LINK}|GoCD User Guide>* to guide you.\n
-            :arrow_forward: *Step 5: Unpause the Pipeline*\nWhether or not a rollback was necessary, make sure to unpause the pipeline once it is safe to do so.`
+          Here are the steps you should follow to address the situation:\n\n
+          :mag_right: *Step 1: Review the Errors*\n Review the errors in the *<https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-us/20/deploy-canary/1/deploy-backend|Canary Logs>*.\n
+          :sentry: *Step 2: Check Sentry Release*\n Check the *<https://sentry.sentry.io/releases/backend@2b0034becc4ab26b985f4c1a08ab068f153c274c/?project=|Sentry Release>* for any related issues.\n
+          :thinking_face: *Step 3: Is a Rollback Necessary?*\nDetermine if a rollback is necessary by reviewing our *<${IS_ROLLBACK_NECESSARY_LINK}|Guidelines>*.\n
+          :arrow_backward: *Step 4: Rollback Procedure*\nIf a rollback is necessary, use the *<${ROLLBACK_PLAYBOOK_LINK}|GoCD Playbook>* or *<${GOCD_USER_GUIDE_LINK}|GoCD User Guide>* to guide you.\n
+          :arrow_forward: *Step 5: Unpause the Pipeline*\nWhether or not a rollback was necessary, make sure to unpause the pipeline once it is safe to do so.`
           )
         ),
         slackblocks.context(
@@ -473,12 +473,12 @@ describe('gocdSlackFeeds', function () {
         slackblocks.section(
           slackblocks.markdown(
             `The deployment pipeline has been paused due to detected issues in canary.
-            Here are the steps you should follow to address the situation:\n\n
-            :mag_right: *Step 1: Review the Errors*\n Review the errors in the *<https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-us/20/deploy-canary/1/deploy-backend|Canary Logs>*.\n
-            :sentry: *Step 2: Check Sentry Release*\n Check the *<https://sentry.sentry.io/releases/backend@2b0034becc4ab26b985f4c1a08ab068f153c274c/?project=|Sentry Release>* for any related issues.\n
-            :thinking_face: *Step 3: Is a Rollback Necessary?*\nDetermine if a rollback is necessary by reviewing our *<${IS_ROLLBACK_NECESSARY_LINK}|Guidelines>*.\n
-            :arrow_backward: *Step 4: Rollback Procedure*\nIf a rollback is necessary, use the *<${ROLLBACK_PLAYBOOK_LINK}|GoCD Playbook>* or *<${GOCD_USER_GUIDE_LINK}|GoCD User Guide>* to guide you.\n
-            :arrow_forward: *Step 5: Unpause the Pipeline*\nWhether or not a rollback was necessary, make sure to unpause the pipeline once it is safe to do so.`
+          Here are the steps you should follow to address the situation:\n\n
+          :mag_right: *Step 1: Review the Errors*\n Review the errors in the *<https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-us/20/deploy-canary/1/deploy-backend|Canary Logs>*.\n
+          :sentry: *Step 2: Check Sentry Release*\n Check the *<https://sentry.sentry.io/releases/backend@2b0034becc4ab26b985f4c1a08ab068f153c274c/?project=|Sentry Release>* for any related issues.\n
+          :thinking_face: *Step 3: Is a Rollback Necessary?*\nDetermine if a rollback is necessary by reviewing our *<${IS_ROLLBACK_NECESSARY_LINK}|Guidelines>*.\n
+          :arrow_backward: *Step 4: Rollback Procedure*\nIf a rollback is necessary, use the *<${ROLLBACK_PLAYBOOK_LINK}|GoCD Playbook>* or *<${GOCD_USER_GUIDE_LINK}|GoCD User Guide>* to guide you.\n
+          :arrow_forward: *Step 5: Unpause the Pipeline*\nWhether or not a rollback was necessary, make sure to unpause the pipeline once it is safe to do so.`
           )
         ),
       ],
@@ -681,12 +681,12 @@ describe('gocdSlackFeeds', function () {
         slackblocks.section(
           slackblocks.markdown(
             `The deployment pipeline has been paused due to detected issues in canary.
-            Here are the steps you should follow to address the situation:\n\n
-            :mag_right: *Step 1: Review the Errors*\n Review the errors in the *<https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-us/20/deploy-canary/1/deploy-backend|Canary Logs>*.\n
-            :sentry: *Step 2: Check Sentry Release*\n Check the *<https://sentry.sentry.io/releases/backend@2b0034becc4ab26b985f4c1a08ab068f153c274c/?project=|Sentry Release>* for any related issues.\n
-            :thinking_face: *Step 3: Is a Rollback Necessary?*\nDetermine if a rollback is necessary by reviewing our *<${IS_ROLLBACK_NECESSARY_LINK}|Guidelines>*.\n
-            :arrow_backward: *Step 4: Rollback Procedure*\nIf a rollback is necessary, use the *<${ROLLBACK_PLAYBOOK_LINK}|GoCD Playbook>* or *<${GOCD_USER_GUIDE_LINK}|GoCD User Guide>* to guide you.\n
-            :arrow_forward: *Step 5: Unpause the Pipeline*\nWhether or not a rollback was necessary, make sure to unpause the pipeline once it is safe to do so.`
+          Here are the steps you should follow to address the situation:\n\n
+          :mag_right: *Step 1: Review the Errors*\n Review the errors in the *<https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-us/20/deploy-canary/1/deploy-backend|Canary Logs>*.\n
+          :sentry: *Step 2: Check Sentry Release*\n Check the *<https://sentry.sentry.io/releases/backend@2b0034becc4ab26b985f4c1a08ab068f153c274c/?project=|Sentry Release>* for any related issues.\n
+          :thinking_face: *Step 3: Is a Rollback Necessary?*\nDetermine if a rollback is necessary by reviewing our *<${IS_ROLLBACK_NECESSARY_LINK}|Guidelines>*.\n
+          :arrow_backward: *Step 4: Rollback Procedure*\nIf a rollback is necessary, use the *<${ROLLBACK_PLAYBOOK_LINK}|GoCD Playbook>* or *<${GOCD_USER_GUIDE_LINK}|GoCD User Guide>* to guide you.\n
+          :arrow_forward: *Step 5: Unpause the Pipeline*\nWhether or not a rollback was necessary, make sure to unpause the pipeline once it is safe to do so.`
           )
         ),
         slackblocks.context(
@@ -942,12 +942,12 @@ describe('gocdSlackFeeds', function () {
         slackblocks.section(
           slackblocks.markdown(
             `The deployment pipeline has been paused due to detected issues in canary.
-            Here are the steps you should follow to address the situation:\n\n
-            :mag_right: *Step 1: Review the Errors*\n Review the errors in the *<https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-us/20/deploy-canary/1/deploy-backend|Canary Logs>*.\n
-            :sentry: *Step 2: Check Sentry Release*\n Check the *<https://sentry.sentry.io/releases/backend@2b0034becc4ab26b985f4c1a08ab068f153c274c/?project=|Sentry Release>* for any related issues.\n
-            :thinking_face: *Step 3: Is a Rollback Necessary?*\nDetermine if a rollback is necessary by reviewing our *<${IS_ROLLBACK_NECESSARY_LINK}|Guidelines>*.\n
-            :arrow_backward: *Step 4: Rollback Procedure*\nIf a rollback is necessary, use the *<${ROLLBACK_PLAYBOOK_LINK}|GoCD Playbook>* or *<${GOCD_USER_GUIDE_LINK}|GoCD User Guide>* to guide you.\n
-            :arrow_forward: *Step 5: Unpause the Pipeline*\nWhether or not a rollback was necessary, make sure to unpause the pipeline once it is safe to do so.`
+          Here are the steps you should follow to address the situation:\n\n
+          :mag_right: *Step 1: Review the Errors*\n Review the errors in the *<https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-us/20/deploy-canary/1/deploy-backend|Canary Logs>*.\n
+          :sentry: *Step 2: Check Sentry Release*\n Check the *<https://sentry.sentry.io/releases/backend@2b0034becc4ab26b985f4c1a08ab068f153c274c/?project=|Sentry Release>* for any related issues.\n
+          :thinking_face: *Step 3: Is a Rollback Necessary?*\nDetermine if a rollback is necessary by reviewing our *<${IS_ROLLBACK_NECESSARY_LINK}|Guidelines>*.\n
+          :arrow_backward: *Step 4: Rollback Procedure*\nIf a rollback is necessary, use the *<${ROLLBACK_PLAYBOOK_LINK}|GoCD Playbook>* or *<${GOCD_USER_GUIDE_LINK}|GoCD User Guide>* to guide you.\n
+          :arrow_forward: *Step 5: Unpause the Pipeline*\nWhether or not a rollback was necessary, make sure to unpause the pipeline once it is safe to do so.`
           )
         ),
         slackblocks.context(

--- a/src/brain/gocdSlackFeeds/index.test.ts
+++ b/src/brain/gocdSlackFeeds/index.test.ts
@@ -108,7 +108,7 @@ describe('gocdSlackFeeds', function () {
             `The deployment pipeline has been paused due to detected issues in canary.
           Here are the steps you should follow to address the situation:\n\n
           :mag_right: *Step 1: Review the Errors*\n Review the errors in the *<https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-us/20/deploy-canary/1/deploy-backend|Canary Logs>*.\n
-          :sentry: *Step 2: Check Sentry Release*\n Check the *<https://sentry.sentry.io/releases/backend@2b0034becc4ab26b985f4c1a08ab068f153c274c/?project=|Sentry Release>* for any related issues.\n
+          :sentry: *Step 2: Check Sentry Release*\n Check the *<https://sentry.sentry.io/releases/backend@2b0034becc4ab26b985f4c1a08ab068f153c274c/?project=1|Sentry Release>* for any related issues.\n
           :thinking_face: *Step 3: Is a Rollback Necessary?*\nDetermine if a rollback is necessary by reviewing our *<${IS_ROLLBACK_NECESSARY_LINK}|Guidelines>*.\n
           :arrow_backward: *Step 4: Rollback Procedure*\nIf a rollback is necessary, use the *<${ROLLBACK_PLAYBOOK_LINK}|GoCD Playbook>* or *<${GOCD_USER_GUIDE_LINK}|GoCD User Guide>* to guide you.\n
           :arrow_forward: *Step 5: Unpause the Pipeline*\nWhether or not a rollback was necessary, make sure to unpause the pipeline once it is safe to do so.`
@@ -475,7 +475,7 @@ describe('gocdSlackFeeds', function () {
             `The deployment pipeline has been paused due to detected issues in canary.
           Here are the steps you should follow to address the situation:\n\n
           :mag_right: *Step 1: Review the Errors*\n Review the errors in the *<https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-us/20/deploy-canary/1/deploy-backend|Canary Logs>*.\n
-          :sentry: *Step 2: Check Sentry Release*\n Check the *<https://sentry.sentry.io/releases/backend@2b0034becc4ab26b985f4c1a08ab068f153c274c/?project=|Sentry Release>* for any related issues.\n
+          :sentry: *Step 2: Check Sentry Release*\n Check the *<https://sentry.sentry.io/releases/backend@2b0034becc4ab26b985f4c1a08ab068f153c274c/?project=1|Sentry Release>* for any related issues.\n
           :thinking_face: *Step 3: Is a Rollback Necessary?*\nDetermine if a rollback is necessary by reviewing our *<${IS_ROLLBACK_NECESSARY_LINK}|Guidelines>*.\n
           :arrow_backward: *Step 4: Rollback Procedure*\nIf a rollback is necessary, use the *<${ROLLBACK_PLAYBOOK_LINK}|GoCD Playbook>* or *<${GOCD_USER_GUIDE_LINK}|GoCD User Guide>* to guide you.\n
           :arrow_forward: *Step 5: Unpause the Pipeline*\nWhether or not a rollback was necessary, make sure to unpause the pipeline once it is safe to do so.`
@@ -683,7 +683,7 @@ describe('gocdSlackFeeds', function () {
             `The deployment pipeline has been paused due to detected issues in canary.
           Here are the steps you should follow to address the situation:\n\n
           :mag_right: *Step 1: Review the Errors*\n Review the errors in the *<https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-us/20/deploy-canary/1/deploy-backend|Canary Logs>*.\n
-          :sentry: *Step 2: Check Sentry Release*\n Check the *<https://sentry.sentry.io/releases/backend@2b0034becc4ab26b985f4c1a08ab068f153c274c/?project=|Sentry Release>* for any related issues.\n
+          :sentry: *Step 2: Check Sentry Release*\n Check the *<https://sentry.sentry.io/releases/backend@2b0034becc4ab26b985f4c1a08ab068f153c274c/?project=1|Sentry Release>* for any related issues.\n
           :thinking_face: *Step 3: Is a Rollback Necessary?*\nDetermine if a rollback is necessary by reviewing our *<${IS_ROLLBACK_NECESSARY_LINK}|Guidelines>*.\n
           :arrow_backward: *Step 4: Rollback Procedure*\nIf a rollback is necessary, use the *<${ROLLBACK_PLAYBOOK_LINK}|GoCD Playbook>* or *<${GOCD_USER_GUIDE_LINK}|GoCD User Guide>* to guide you.\n
           :arrow_forward: *Step 5: Unpause the Pipeline*\nWhether or not a rollback was necessary, make sure to unpause the pipeline once it is safe to do so.`
@@ -944,7 +944,7 @@ describe('gocdSlackFeeds', function () {
             `The deployment pipeline has been paused due to detected issues in canary.
           Here are the steps you should follow to address the situation:\n\n
           :mag_right: *Step 1: Review the Errors*\n Review the errors in the *<https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-us/20/deploy-canary/1/deploy-backend|Canary Logs>*.\n
-          :sentry: *Step 2: Check Sentry Release*\n Check the *<https://sentry.sentry.io/releases/backend@2b0034becc4ab26b985f4c1a08ab068f153c274c/?project=|Sentry Release>* for any related issues.\n
+          :sentry: *Step 2: Check Sentry Release*\n Check the *<https://sentry.sentry.io/releases/backend@2b0034becc4ab26b985f4c1a08ab068f153c274c/?project=1|Sentry Release>* for any related issues.\n
           :thinking_face: *Step 3: Is a Rollback Necessary?*\nDetermine if a rollback is necessary by reviewing our *<${IS_ROLLBACK_NECESSARY_LINK}|Guidelines>*.\n
           :arrow_backward: *Step 4: Rollback Procedure*\nIf a rollback is necessary, use the *<${ROLLBACK_PLAYBOOK_LINK}|GoCD Playbook>* or *<${GOCD_USER_GUIDE_LINK}|GoCD User Guide>* to guide you.\n
           :arrow_forward: *Step 5: Unpause the Pipeline*\nWhether or not a rollback was necessary, make sure to unpause the pipeline once it is safe to do so.`

--- a/src/brain/gocdSlackFeeds/index.test.ts
+++ b/src/brain/gocdSlackFeeds/index.test.ts
@@ -17,7 +17,13 @@ import { getUser } from '@api/getUser';
 import { bolt } from '@api/slack';
 import { db } from '@utils/db';
 
-import { gocdSlackFeeds, handler } from '.';
+import {
+  GOCD_USER_GUIDE_LINK,
+  gocdSlackFeeds,
+  handler,
+  IS_ROLLBACK_NECESSARY_LINK,
+  ROLLBACK_PLAYBOOK_LINK,
+} from '.';
 
 jest.mock('@api/getUser');
 
@@ -99,7 +105,13 @@ describe('gocdSlackFeeds', function () {
         ),
         slackblocks.section(
           slackblocks.markdown(
-            'Please check the errors in the *<https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-us/20/deploy-canary/1/deploy-backend|Canary Logs>* and the *<https://sentry.sentry.io/releases/backend@2b0034becc4ab26b985f4c1a08ab068f153c274c/?project=1|Sentry Release>*, take appropriate rollback actions if needed and unpause the pipeline once it is safe to do so.'
+            `The deployment pipeline has been paused due to detected issues in canary.
+            Here are the steps you should follow to address the situation:\n\n
+            :mag_right: *Step 1: Review the Errors*\n Review the errors in the *<https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-us/20/deploy-canary/1/deploy-backend|Canary Logs>*.\n
+            :sentry: *Step 2: Check Sentry Release*\n Check the *<https://sentry.sentry.io/releases/backend@2b0034becc4ab26b985f4c1a08ab068f153c274c/?project=|Sentry Release>* for any related issues.\n
+            :thinking_face: *Step 3: Is a Rollback Necessary?*\nDetermine if a rollback is necessary by reviewing our *<${IS_ROLLBACK_NECESSARY_LINK}|Guidelines>*.\n
+            :arrow_backward: *Step 4: Rollback Procedure*\nIf a rollback is necessary, use the *<${ROLLBACK_PLAYBOOK_LINK}|GoCD Playbook>* or *<${GOCD_USER_GUIDE_LINK}|GoCD User Guide>* to guide you.\n
+            :arrow_forward: *Step 5: Unpause the Pipeline*\nWhether or not a rollback was necessary, make sure to unpause the pipeline once it is safe to do so.`
           )
         ),
         slackblocks.context(
@@ -460,7 +472,13 @@ describe('gocdSlackFeeds', function () {
         ),
         slackblocks.section(
           slackblocks.markdown(
-            'Please check the errors in the *<https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-us/20/deploy-canary/1/deploy-backend|Canary Logs>* and the *<https://sentry.sentry.io/releases/backend@2b0034becc4ab26b985f4c1a08ab068f153c274c/?project=1|Sentry Release>*, take appropriate rollback actions if needed and unpause the pipeline once it is safe to do so.'
+            `The deployment pipeline has been paused due to detected issues in canary.
+            Here are the steps you should follow to address the situation:\n\n
+            :mag_right: *Step 1: Review the Errors*\n Review the errors in the *<https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-us/20/deploy-canary/1/deploy-backend|Canary Logs>*.\n
+            :sentry: *Step 2: Check Sentry Release*\n Check the *<https://sentry.sentry.io/releases/backend@2b0034becc4ab26b985f4c1a08ab068f153c274c/?project=|Sentry Release>* for any related issues.\n
+            :thinking_face: *Step 3: Is a Rollback Necessary?*\nDetermine if a rollback is necessary by reviewing our *<${IS_ROLLBACK_NECESSARY_LINK}|Guidelines>*.\n
+            :arrow_backward: *Step 4: Rollback Procedure*\nIf a rollback is necessary, use the *<${ROLLBACK_PLAYBOOK_LINK}|GoCD Playbook>* or *<${GOCD_USER_GUIDE_LINK}|GoCD User Guide>* to guide you.\n
+            :arrow_forward: *Step 5: Unpause the Pipeline*\nWhether or not a rollback was necessary, make sure to unpause the pipeline once it is safe to do so.`
           )
         ),
       ],
@@ -662,7 +680,13 @@ describe('gocdSlackFeeds', function () {
         ),
         slackblocks.section(
           slackblocks.markdown(
-            'Please check the errors in the *<https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-us/20/deploy-canary/1/deploy-backend|Canary Logs>* and the *<https://sentry.sentry.io/releases/backend@2b0034becc4ab26b985f4c1a08ab068f153c274c/?project=1|Sentry Release>*, take appropriate rollback actions if needed and unpause the pipeline once it is safe to do so.'
+            `The deployment pipeline has been paused due to detected issues in canary.
+            Here are the steps you should follow to address the situation:\n\n
+            :mag_right: *Step 1: Review the Errors*\n Review the errors in the *<https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-us/20/deploy-canary/1/deploy-backend|Canary Logs>*.\n
+            :sentry: *Step 2: Check Sentry Release*\n Check the *<https://sentry.sentry.io/releases/backend@2b0034becc4ab26b985f4c1a08ab068f153c274c/?project=|Sentry Release>* for any related issues.\n
+            :thinking_face: *Step 3: Is a Rollback Necessary?*\nDetermine if a rollback is necessary by reviewing our *<${IS_ROLLBACK_NECESSARY_LINK}|Guidelines>*.\n
+            :arrow_backward: *Step 4: Rollback Procedure*\nIf a rollback is necessary, use the *<${ROLLBACK_PLAYBOOK_LINK}|GoCD Playbook>* or *<${GOCD_USER_GUIDE_LINK}|GoCD User Guide>* to guide you.\n
+            :arrow_forward: *Step 5: Unpause the Pipeline*\nWhether or not a rollback was necessary, make sure to unpause the pipeline once it is safe to do so.`
           )
         ),
         slackblocks.context(
@@ -917,7 +941,13 @@ describe('gocdSlackFeeds', function () {
         ),
         slackblocks.section(
           slackblocks.markdown(
-            'Please check the errors in the *<https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-us/20/deploy-canary/1/deploy-backend|Canary Logs>* and the *<https://sentry.sentry.io/releases/backend@2b0034becc4ab26b985f4c1a08ab068f153c274c/?project=1|Sentry Release>*, take appropriate rollback actions if needed and unpause the pipeline once it is safe to do so.'
+            `The deployment pipeline has been paused due to detected issues in canary.
+            Here are the steps you should follow to address the situation:\n\n
+            :mag_right: *Step 1: Review the Errors*\n Review the errors in the *<https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-us/20/deploy-canary/1/deploy-backend|Canary Logs>*.\n
+            :sentry: *Step 2: Check Sentry Release*\n Check the *<https://sentry.sentry.io/releases/backend@2b0034becc4ab26b985f4c1a08ab068f153c274c/?project=|Sentry Release>* for any related issues.\n
+            :thinking_face: *Step 3: Is a Rollback Necessary?*\nDetermine if a rollback is necessary by reviewing our *<${IS_ROLLBACK_NECESSARY_LINK}|Guidelines>*.\n
+            :arrow_backward: *Step 4: Rollback Procedure*\nIf a rollback is necessary, use the *<${ROLLBACK_PLAYBOOK_LINK}|GoCD Playbook>* or *<${GOCD_USER_GUIDE_LINK}|GoCD User Guide>* to guide you.\n
+            :arrow_forward: *Step 5: Unpause the Pipeline*\nWhether or not a rollback was necessary, make sure to unpause the pipeline once it is safe to do so.`
           )
         ),
         slackblocks.context(

--- a/src/brain/gocdSlackFeeds/index.ts
+++ b/src/brain/gocdSlackFeeds/index.ts
@@ -169,7 +169,8 @@ const engineeringFeed = new DeployFeed({
           :mag_right: *Step 1: Review the Errors*\n Review the errors in the *<${gocdLogsLink}|Canary Logs>*.\n
           :sentry: *Step 2: Check Sentry Release*\n Check the *<${sentryReleaseLink}|Sentry Release>* for any related issues.\n
           :thinking_face: *Step 3: Is a Rollback Necessary?*\nDetermine if a rollback is necessary by reviewing our *<${IS_ROLLBACK_NECESSARY_LINK}|Guidelines>*.\n
-          :arrow_backward: *Step 4: Rollback Procedure*\nIf a rollback is necessary, use the *<${ROLLBACK_PLAYBOOK_LINK}|GoCD Playbook>* or *<${GOCD_USER_GUIDE_LINK}|GoCD User Guide>* to guide you.`
+          :arrow_backward: *Step 4: Rollback Procedure*\nIf a rollback is necessary, use the *<${ROLLBACK_PLAYBOOK_LINK}|GoCD Playbook>* or *<${GOCD_USER_GUIDE_LINK}|GoCD User Guide>* to guide you.\n
+          :arrow_forward: *Step 5: Unpause the Pipeline*\nWhether or not a rollback was necessary, make sure to unpause the pipeline once it is safe to do so.`
         )
       ),
     ];

--- a/src/brain/gocdSlackFeeds/index.ts
+++ b/src/brain/gocdSlackFeeds/index.ts
@@ -152,11 +152,23 @@ const engineeringFeed = new DeployFeed({
       .join(' ');
     const gocdLogsLink = `https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-us/${pipeline.counter}/deploy-canary/${pipeline.stage.counter}/deploy-backend`;
     const sentryReleaseLink = `https://sentry.sentry.io/releases/backend@${head}/?project=1`;
+    const isRollbackNecessaryLink =
+      'https://www.notion.so/sentry/GoCD-Playbook-920a1a88cf40499ab0baeb9226ffe86d?pvs=4#2e88c4be0354433282267bf09e945973';
+    const rollbackPlaybookLink =
+      'https://www.notion.so/sentry/GoCD-Playbook-920a1a88cf40499ab0baeb9226ffe86d?pvs=4#c6961edd7db34e979623288fe46fd45b';
+    const gocdUserGuideLink =
+      'https://www.notion.so/sentry/GoCD-User-Guide-4f8456d2477c458095c4aa0e67fc38a6?pvs=4#73e3d374ca744ba8bf66aa6330283f79';
+
     const blocks = [
       header(plaintext(':double_vertical_bar: Canary has been paused')),
       section(
         markdown(
-          `Please check the errors in the *<${gocdLogsLink}|Canary Logs>* and the *<${sentryReleaseLink}|Sentry Release>*, take appropriate rollback actions if needed and unpause the pipeline once it is safe to do so.`
+          `The deployment pipeline has been paused due to detected issues in canary.
+          Here are the steps you should follow to address the situation:\n\n
+          :mag_right: *Step 1: Review the Errors*\n Review the errors in the *<${gocdLogsLink}|Canary Logs>*.\n
+          :sentry: *Step 2: Check Sentry Release*\n Check the *<${sentryReleaseLink}|Sentry Release>* for any related issues.\n
+          :thinking_face: *Step 3: Is a Rollback Necessary?*\nDetermine if a rollback is necessary by reviewing our *<${isRollbackNecessaryLink}|Guidelines>*.\n
+          :arrow_backward: *Step 4: Rollback Procedure*\nIf a rollback is necessary, use the *<${rollbackPlaybookLink}|GoCD Playbook>* or *<${gocdUserGuideLink}|GoCD User Guide>* to guide you.`
         )
       ),
     ];

--- a/src/brain/gocdSlackFeeds/index.ts
+++ b/src/brain/gocdSlackFeeds/index.ts
@@ -51,11 +51,11 @@ const DEV_INFRA_PIPELINE_FILTER = [
   ...ENGINEERING_PIPELINE_FILTER,
 ];
 
-const IS_ROLLBACK_NECESSARY_LINK =
+export const IS_ROLLBACK_NECESSARY_LINK =
   'https://www.notion.so/sentry/GoCD-Playbook-920a1a88cf40499ab0baeb9226ffe86d?pvs=4#2e88c4be0354433282267bf09e945973';
-const ROLLBACK_PLAYBOOK_LINK =
+export const ROLLBACK_PLAYBOOK_LINK =
   'https://www.notion.so/sentry/GoCD-Playbook-920a1a88cf40499ab0baeb9226ffe86d?pvs=4#c6961edd7db34e979623288fe46fd45b';
-const GOCD_USER_GUIDE_LINK =
+export const GOCD_USER_GUIDE_LINK =
   'https://www.notion.so/sentry/GoCD-User-Guide-4f8456d2477c458095c4aa0e67fc38a6?pvs=4#73e3d374ca744ba8bf66aa6330283f79';
 
 // Post all pipelines to #feed-deploys

--- a/src/brain/gocdSlackFeeds/index.ts
+++ b/src/brain/gocdSlackFeeds/index.ts
@@ -51,6 +51,13 @@ const DEV_INFRA_PIPELINE_FILTER = [
   ...ENGINEERING_PIPELINE_FILTER,
 ];
 
+const IS_ROLLBACK_NECESSARY_LINK =
+  'https://www.notion.so/sentry/GoCD-Playbook-920a1a88cf40499ab0baeb9226ffe86d?pvs=4#2e88c4be0354433282267bf09e945973';
+const ROLLBACK_PLAYBOOK_LINK =
+  'https://www.notion.so/sentry/GoCD-Playbook-920a1a88cf40499ab0baeb9226ffe86d?pvs=4#c6961edd7db34e979623288fe46fd45b';
+const GOCD_USER_GUIDE_LINK =
+  'https://www.notion.so/sentry/GoCD-User-Guide-4f8456d2477c458095c4aa0e67fc38a6?pvs=4#73e3d374ca744ba8bf66aa6330283f79';
+
 // Post all pipelines to #feed-deploys
 const deployFeed = new DeployFeed({
   feedName: 'gocdSlackFeed',
@@ -152,12 +159,6 @@ const engineeringFeed = new DeployFeed({
       .join(' ');
     const gocdLogsLink = `https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-us/${pipeline.counter}/deploy-canary/${pipeline.stage.counter}/deploy-backend`;
     const sentryReleaseLink = `https://sentry.sentry.io/releases/backend@${head}/?project=1`;
-    const isRollbackNecessaryLink =
-      'https://www.notion.so/sentry/GoCD-Playbook-920a1a88cf40499ab0baeb9226ffe86d?pvs=4#2e88c4be0354433282267bf09e945973';
-    const rollbackPlaybookLink =
-      'https://www.notion.so/sentry/GoCD-Playbook-920a1a88cf40499ab0baeb9226ffe86d?pvs=4#c6961edd7db34e979623288fe46fd45b';
-    const gocdUserGuideLink =
-      'https://www.notion.so/sentry/GoCD-User-Guide-4f8456d2477c458095c4aa0e67fc38a6?pvs=4#73e3d374ca744ba8bf66aa6330283f79';
 
     const blocks = [
       header(plaintext(':double_vertical_bar: Canary has been paused')),
@@ -167,8 +168,8 @@ const engineeringFeed = new DeployFeed({
           Here are the steps you should follow to address the situation:\n\n
           :mag_right: *Step 1: Review the Errors*\n Review the errors in the *<${gocdLogsLink}|Canary Logs>*.\n
           :sentry: *Step 2: Check Sentry Release*\n Check the *<${sentryReleaseLink}|Sentry Release>* for any related issues.\n
-          :thinking_face: *Step 3: Is a Rollback Necessary?*\nDetermine if a rollback is necessary by reviewing our *<${isRollbackNecessaryLink}|Guidelines>*.\n
-          :arrow_backward: *Step 4: Rollback Procedure*\nIf a rollback is necessary, use the *<${rollbackPlaybookLink}|GoCD Playbook>* or *<${gocdUserGuideLink}|GoCD User Guide>* to guide you.`
+          :thinking_face: *Step 3: Is a Rollback Necessary?*\nDetermine if a rollback is necessary by reviewing our *<${IS_ROLLBACK_NECESSARY_LINK}|Guidelines>*.\n
+          :arrow_backward: *Step 4: Rollback Procedure*\nIf a rollback is necessary, use the *<${ROLLBACK_PLAYBOOK_LINK}|GoCD Playbook>* or *<${GOCD_USER_GUIDE_LINK}|GoCD User Guide>* to guide you.`
         )
       ),
     ];


### PR DESCRIPTION
Updating the message sent following a canary failure in order to provide clearer steps to mitigate the situation. 

<img width="455" alt="image" src="https://github.com/getsentry/eng-pipes/assets/17186604/5f20b255-86c2-4e80-9f7c-0c5117bd758c">
