### PR TITLE
Adding alert to discuss-frontend on consecutive FE deploy failures

### DIFF
--- a/src/brain/gocdConsecutiveUnsuccessfulAlert/index.ts
+++ b/src/brain/gocdConsecutiveUnsuccessfulAlert/index.ts
@@ -1,5 +1,6 @@
 import { gocdevents } from '@/api/gocdevents';
 import {
+  DISCUSS_FRONTEND_CHANNEL_ID,
   FEED_DEV_INFRA_CHANNEL_ID,
   GOCD_SENTRYIO_BE_PIPELINE_NAME,
   GOCD_SENTRYIO_FE_PIPELINE_NAME,
@@ -21,8 +22,16 @@ const devinfraAlert = new ConsecutiveUnsuccessfulDeploysAlert({
   },
 });
 
+const discussFrontendAlert = new ConsecutiveUnsuccessfulDeploysAlert({
+  slackChannelID: DISCUSS_FRONTEND_CHANNEL_ID,
+  consecutiveUnsuccessfulLimit: 3,
+  pipelineFilter: (pipeline) =>
+    pipeline.name === GOCD_SENTRYIO_FE_PIPELINE_NAME,
+});
+
 export async function handler(body: GoCDResponse) {
   await devinfraAlert.handle(body);
+  await discussFrontendAlert.handle(body);
 }
 
 export async function gocdConsecutiveUnsuccessfulAlert() {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -19,6 +19,8 @@ export const DAY_IN_MS = 1000 * 60 * 60 * 24;
 export const SENTRY_REPO_SLUG = process.env.SENTRY_REPO || 'sentry';
 export const GETSENTRY_REPO_SLUG = process.env.GETSENTRY_REPO || 'getsentry';
 export const GETSENTRY_BOT_ID = 10587625;
+export const GOCD_SENTRYIO_FE_PIPELINE_GROUP =
+  process.env.GOCD_SENTRYIO_FE_PIPELINE_GROUP || 'getsentry-frontend';
 export const GOCD_SENTRYIO_FE_PIPELINE_NAME =
   process.env.GOCD_SENTRYIO_FE_PIPELINE_NAME || 'getsentry-frontend';
 export const GOCD_SENTRYIO_BE_PIPELINE_GROUP =
@@ -47,6 +49,8 @@ export const TEAM_PRODUCT_OWNERS_CHANNEL_ID =
   process.env.TEAM_PRODUCT_OWNERS_CHANNEL_ID || 'C063DCB4PGF';
 export const DISCUSS_PRODUCT_CHANNEL_ID = // #discuss-product
   process.env.DISCUSS_PRODUCT_CHANNEL_ID || 'CDXAKMGTU';
+export const DISCUSS_FRONTEND_CHANNEL_ID = // #discuss-frontend
+  process.env.DISCUSS_FRONTEND_CHANNEL_ID || 'C8V02RHC7';
 export const DISABLE_GITHUB_METRICS =
   process.env.DISABLE_GITHUB_METRICS === 'true' ||
   process.env.DISABLE_GITHUB_METRICS === '1';


### PR DESCRIPTION
This aims to prevent long stretches of consecutive frontend deploy failures from going unnoticed.