### PR TITLE
Switching to promise.all for consecutive failed deploys handler

### DIFF
--- a/src/brain/gocdConsecutiveUnsuccessfulAlert/index.ts
+++ b/src/brain/gocdConsecutiveUnsuccessfulAlert/index.ts
@@ -30,8 +30,10 @@ const discussFrontendAlert = new ConsecutiveUnsuccessfulDeploysAlert({
 });
 
 export async function handler(body: GoCDResponse) {
-  await devinfraAlert.handle(body);
-  await discussFrontendAlert.handle(body);
+  await Promise.all([
+    devinfraAlert.handle(body),
+    discussFrontendAlert.handle(body),
+  ]);
 }
 
 export async function gocdConsecutiveUnsuccessfulAlert() {


### PR DESCRIPTION
A slight improvement I realized I could add.