### PR TITLE
Add comment on PR's for stalebot ignore condition

### DIFF
--- a/src/webhooks/pubsub/stalebot.test.ts
+++ b/src/webhooks/pubsub/stalebot.test.ts
@@ -62,7 +62,7 @@ But! If you comment or otherwise update it, I will reset the clock, and if you r
 
   it('should not mark PR as stale if it has been under 3 weeks', async function () {
     org.api.issues.listForRepo = () => [];
-    org.api.pulls.list = () => [{ ...issueInfo, pull_request: {} }];
+    org.api.pulls.list = () => [{ ...issueInfo, merge_commit_sha: '12345' }];
     await triggerStaleBot(org, moment('2023-04-10T14:28:13Z').utc());
     expect(org.api.issues._labels).not.toContain(STALE_LABEL);
     expect(org.api.issues._comments).toEqual([]);
@@ -72,7 +72,7 @@ But! If you comment or otherwise update it, I will reset the clock, and if you r
     org.api.issues.listForRepo = () => [];
     org.api.pulls.list = ({ repo }) => {
       return org.repos.withRouting.includes(repo)
-        ? [{ ...issueInfo, pull_request: {} }]
+        ? [{ ...issueInfo, merge_commit_sha: '12345' }]
         : [];
     };
     await triggerStaleBot(org, moment('2023-04-27T14:28:13Z').utc());
@@ -80,7 +80,7 @@ But! If you comment or otherwise update it, I will reset the clock, and if you r
     expect(org.api.issues._comments).toEqual([
       `This pull request has gone three weeks without activity. In another week, I will close it.
 
-But! If you comment or otherwise update it, I will reset the clock, and if you remove the label \`Waiting for: Community\`, I will leave it alone ... forever!
+But! If you comment or otherwise update it, I will reset the clock, and if you add the label \`WIP\`, I will leave it alone ... forever!
 
 ----
 
@@ -96,7 +96,7 @@ But! If you comment or otherwise update it, I will reset the clock, and if you r
             {
               ...issueInfo,
               labels: [WAITING_FOR_COMMUNITY_LABEL, WORK_IN_PROGRESS_LABEL],
-              pull_request: {},
+              merge_commit_sha: '12345',
             },
           ]
         : [];
@@ -110,7 +110,7 @@ But! If you comment or otherwise update it, I will reset the clock, and if you r
     org.api.issues.listForRepo = () => [];
     org.api.pulls.list = ({ repo }) => {
       return org.repos.withoutRouting.includes(repo)
-        ? [{ ...issueInfo, pull_request: {} }]
+        ? [{ ...issueInfo, merge_commit_sha: '12345' }]
         : [];
     };
     await triggerStaleBot(org, moment('2023-04-27T14:28:13Z').utc());

--- a/src/webhooks/pubsub/stalebot.ts
+++ b/src/webhooks/pubsub/stalebot.ts
@@ -41,7 +41,9 @@ But! If you comment or otherwise update it, I will reset the clock, and if you $
               isPullRequest
                 ? 'add the label `WIP`'
                 : 'remove the label `Waiting for: Community`'
-            }, I will leave it alone ... forever!
+            }, I will leave it alone ${
+              isPullRequest ? 'unless `WIP` is removed ' : ''
+            }... forever!
 
 ----
 

--- a/src/webhooks/pubsub/stalebot.ts
+++ b/src/webhooks/pubsub/stalebot.ts
@@ -21,7 +21,7 @@ const staleStatusUpdater = async (
     issues.map((issue) => {
       // Only pull requests will have issue.merge_commit_sha property
       const isPullRequest = issue.merge_commit_sha ? true : false;
-      if (now.diff(issue.updated_at, 'seconds') >= DAYS_BEFORE_STALE) {
+      if (now.diff(issue.updated_at, 'days') >= DAYS_BEFORE_STALE) {
         return Promise.all([
           org.api.issues.addLabels({
             owner: org.slug,

--- a/src/webhooks/pubsub/stalebot.ts
+++ b/src/webhooks/pubsub/stalebot.ts
@@ -19,8 +19,9 @@ const staleStatusUpdater = async (
 ) => {
   await Promise.all(
     issues.map((issue) => {
-      const isPullRequest = issue.pull_request ? true : false;
-      if (now.diff(issue.updated_at, 'days') >= DAYS_BEFORE_STALE) {
+      // Only pull requests will have issue.merge_commit_sha property
+      const isPullRequest = issue.merge_commit_sha ? true : false;
+      if (now.diff(issue.updated_at, 'seconds') >= DAYS_BEFORE_STALE) {
         return Promise.all([
           org.api.issues.addLabels({
             owner: org.slug,
@@ -36,7 +37,11 @@ const staleStatusUpdater = async (
               isPullRequest ? 'pull request' : 'issue'
             } has gone three weeks without activity. In another week, I will close it.
 
-But! If you comment or otherwise update it, I will reset the clock, and if you remove the label \`Waiting for: Community\`, I will leave it alone ... forever!
+But! If you comment or otherwise update it, I will reset the clock, and if you ${
+              isPullRequest
+                ? 'add the label `WIP`'
+                : 'remove the label `Waiting for: Community`'
+            }, I will leave it alone ... forever!
 
 ----
 


### PR DESCRIPTION
I believe GH changed the way they structure the PR json bodies recently. There is no longer a `pull_request` property, so this fixes that. Also, adds a comment where adding `WIP` on PR's will get stalebot to ignore it forever