### PR TITLE
Adding GoCD feed foundation for ingest

### DIFF
--- a/src/brain/gocdSlackFeeds/index.ts
+++ b/src/brain/gocdSlackFeeds/index.ts
@@ -14,6 +14,7 @@ import {
   FEED_DEPLOY_CHANNEL_ID,
   FEED_DEV_INFRA_CHANNEL_ID,
   FEED_ENGINEERING_CHANNEL_ID,
+  FEED_INGEST_CHANNEL_ID,
   FEED_SNS_SAAS_CHANNEL_ID,
   FEED_SNS_ST_CHANNEL_ID,
   GOCD_SENTRYIO_BE_PIPELINE_NAME,
@@ -36,6 +37,8 @@ const ENGINEERING_PIPELINE_FILTER = [
   GOCD_SENTRYIO_BE_PIPELINE_NAME,
   GOCD_SENTRYIO_FE_PIPELINE_NAME,
 ];
+
+const INGEST_PIPELINE_FILTER = ['deploy-relay', 'deploy-relay-pop'];
 
 const SNS_SAAS_PIPELINE_FILTER = [
   'deploy-snuba',
@@ -160,6 +163,16 @@ const snsSTFeed = new DeployFeed({
   },
 });
 
+// Post certain pipelines to #discuss-ingest
+const ingestFeed = new DeployFeed({
+  feedName: 'ingestSlackFeed',
+  channelID: FEED_INGEST_CHANNEL_ID,
+  msgType: SlackMessage.FEED_INGEST_DEPLOY,
+  pipelineFilter: (pipeline) => {
+    return INGEST_PIPELINE_FILTER.includes(pipeline.name);
+  },
+});
+
 // Post certain pipelines to #team-engineering
 const engineeringFeed = new DeployFeed({
   feedName: 'engineeringSlackFeed',
@@ -246,6 +259,7 @@ export async function handler(body: GoCDResponse) {
     devinfraFeed.handle(body),
     snsSaaSFeed.handle(body),
     snsSTFeed.handle(body),
+    ingestFeed.handle(body),
     engineeringFeed.handle(body),
   ]);
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -41,6 +41,8 @@ export const FEED_SNS_SAAS_CHANNEL_ID = // #feed-sns
   process.env.FEED_SNS_SAAS_CHANNEL_ID || 'C0220QQNUHE';
 export const FEED_SNS_ST_CHANNEL_ID = // #feed-sns-st
   process.env.FEED_SNS_ST_CHANNEL_ID || 'C0596EHDD9N';
+export const FEED_INGEST_CHANNEL_ID = // #discuss-ingest
+  process.env.FEED_INGEST_CHANNEL_ID || 'C019637C760';
 export const SUPPORT_CHANNEL_ID = // #discuss-support-open-source
   process.env.SUPPORT_CHANNEL_ID || 'C02KHRNRZ1B';
 export const TEAM_OSPO_CHANNEL_ID = // #team-ospo

--- a/src/config/slackMessage.ts
+++ b/src/config/slackMessage.ts
@@ -6,4 +6,5 @@ export enum SlackMessage {
   FEED_ENGINGEERING_DEPLOY = 'feed-engineering-deploy',
   FEED_SNS_SAAS_DEPLOY = 'feed-sns-saas-deploy',
   FEED_SNS_ST_DEPLOY = 'feed-sns-st-deploy',
+  FEED_INGEST_DEPLOY = 'feed-ingest-deploy',
 }


### PR DESCRIPTION
This PR adds the initial functionality that will enable a message to be sent in #discuss-ingest each time either relay (soon to be renamed, we will have to circle back and rename it here once that is done) and relay-pop are deployed. From here, you all are free to extend the functionality to fit your needs.