### PR TITLE
Adding de to the team-engineering gocd feed

### DIFF
--- a/src/brain/gocdSlackFeeds/index.ts
+++ b/src/brain/gocdSlackFeeds/index.ts
@@ -32,8 +32,10 @@ enum PauseCause {
   SOAK = 'soak-time',
 }
 
+// TODO: consolidate constants for regions
 const ENGINEERING_PIPELINE_FILTER = [
   'deploy-getsentry-backend-s4s',
+  'deploy-getsentry-backend-de',
   GOCD_SENTRYIO_BE_PIPELINE_NAME,
   GOCD_SENTRYIO_FE_PIPELINE_NAME,
 ];


### PR DESCRIPTION
Now that DE comes after S4S and before US, we should make sure it alerts when it fails to prevent silent failures that go unnoticed. I also created an issue to update/refactor the constants for GoCD pipeline names, but given that I want this out before the end of the day, I opted to punt this for later.
https://github.com/getsentry/eng-pipes/issues/773