### PR TITLE
Moving team-engineering feed to discuss-backend

### DIFF
--- a/src/brain/gocdSlackFeeds/index.test.ts
+++ b/src/brain/gocdSlackFeeds/index.test.ts
@@ -6,9 +6,9 @@ import * as slackblocks from '@/blocks/slackBlocks';
 import { buildServer } from '@/buildServer';
 import {
   Color,
+  DISCUSS_BACKEND_CHANNEL_ID,
   FEED_DEPLOY_CHANNEL_ID,
   FEED_DEV_INFRA_CHANNEL_ID,
-  FEED_ENGINEERING_CHANNEL_ID,
   GETSENTRY_ORG,
   GOCD_SENTRYIO_BE_PIPELINE_NAME,
 } from '@/config';
@@ -157,10 +157,10 @@ describe('gocdSlackFeeds', function () {
     postCalls.sort(sortMessages);
     expect(postCalls[0][0]).toMatchObject(canaryReply);
     expect(postCalls[1][0]).toMatchObject(
-      merge({}, wantPostMsg, { channel: FEED_DEPLOY_CHANNEL_ID })
+      merge({}, wantPostMsg, { channel: DISCUSS_BACKEND_CHANNEL_ID })
     );
     expect(postCalls[2][0]).toMatchObject(
-      merge({}, wantPostMsg, { channel: FEED_ENGINEERING_CHANNEL_ID })
+      merge({}, wantPostMsg, { channel: FEED_DEPLOY_CHANNEL_ID })
     );
     expect(postCalls[3][0]).toMatchObject(
       merge({}, wantPostMsg, { channel: FEED_DEV_INFRA_CHANNEL_ID })
@@ -232,10 +232,10 @@ describe('gocdSlackFeeds', function () {
     const updateCalls = bolt.client.chat.update.mock.calls;
     updateCalls.sort(sortMessages);
     expect(updateCalls[0][0]).toMatchObject(
-      merge({}, wantUpdate, { channel: FEED_DEPLOY_CHANNEL_ID })
+      merge({}, wantUpdate, { channel: DISCUSS_BACKEND_CHANNEL_ID })
     );
     expect(updateCalls[1][0]).toMatchObject(
-      merge({}, wantUpdate, { channel: FEED_ENGINEERING_CHANNEL_ID })
+      merge({}, wantUpdate, { channel: FEED_DEPLOY_CHANNEL_ID })
     );
     expect(updateCalls[2][0]).toMatchObject(
       merge({}, wantUpdate, { channel: FEED_DEV_INFRA_CHANNEL_ID })
@@ -351,10 +351,10 @@ describe('gocdSlackFeeds', function () {
     postCalls.sort(sortMessages);
     expect(postCalls[0][0]).toMatchObject(soakReply);
     expect(postCalls[1][0]).toMatchObject(
-      merge({}, wantPostMsg, { channel: FEED_DEPLOY_CHANNEL_ID })
+      merge({}, wantPostMsg, { channel: DISCUSS_BACKEND_CHANNEL_ID })
     );
     expect(postCalls[2][0]).toMatchObject(
-      merge({}, wantPostMsg, { channel: FEED_ENGINEERING_CHANNEL_ID })
+      merge({}, wantPostMsg, { channel: FEED_DEPLOY_CHANNEL_ID })
     );
     expect(postCalls[3][0]).toMatchObject(
       merge({}, wantPostMsg, { channel: FEED_DEV_INFRA_CHANNEL_ID })
@@ -426,10 +426,10 @@ describe('gocdSlackFeeds', function () {
     const updateCalls = bolt.client.chat.update.mock.calls;
     updateCalls.sort(sortMessages);
     expect(updateCalls[0][0]).toMatchObject(
-      merge({}, wantUpdate, { channel: FEED_DEPLOY_CHANNEL_ID })
+      merge({}, wantUpdate, { channel: DISCUSS_BACKEND_CHANNEL_ID })
     );
     expect(updateCalls[1][0]).toMatchObject(
-      merge({}, wantUpdate, { channel: FEED_ENGINEERING_CHANNEL_ID })
+      merge({}, wantUpdate, { channel: FEED_DEPLOY_CHANNEL_ID })
     );
     expect(updateCalls[2][0]).toMatchObject(
       merge({}, wantUpdate, { channel: FEED_DEV_INFRA_CHANNEL_ID })
@@ -545,10 +545,10 @@ describe('gocdSlackFeeds', function () {
     postCalls.sort(sortMessages);
     expect(postCalls[0][0]).toMatchObject(soakReply);
     expect(postCalls[1][0]).toMatchObject(
-      merge({}, wantPostMsg, { channel: FEED_DEPLOY_CHANNEL_ID })
+      merge({}, wantPostMsg, { channel: DISCUSS_BACKEND_CHANNEL_ID })
     );
     expect(postCalls[2][0]).toMatchObject(
-      merge({}, wantPostMsg, { channel: FEED_ENGINEERING_CHANNEL_ID })
+      merge({}, wantPostMsg, { channel: FEED_DEPLOY_CHANNEL_ID })
     );
     expect(postCalls[3][0]).toMatchObject(
       merge({}, wantPostMsg, { channel: FEED_DEV_INFRA_CHANNEL_ID })
@@ -620,10 +620,10 @@ describe('gocdSlackFeeds', function () {
     const updateCalls = bolt.client.chat.update.mock.calls;
     updateCalls.sort(sortMessages);
     expect(updateCalls[0][0]).toMatchObject(
-      merge({}, wantUpdate, { channel: FEED_DEPLOY_CHANNEL_ID })
+      merge({}, wantUpdate, { channel: DISCUSS_BACKEND_CHANNEL_ID })
     );
     expect(updateCalls[1][0]).toMatchObject(
-      merge({}, wantUpdate, { channel: FEED_ENGINEERING_CHANNEL_ID })
+      merge({}, wantUpdate, { channel: FEED_DEPLOY_CHANNEL_ID })
     );
     expect(updateCalls[2][0]).toMatchObject(
       merge({}, wantUpdate, { channel: FEED_DEV_INFRA_CHANNEL_ID })
@@ -717,10 +717,10 @@ describe('gocdSlackFeeds', function () {
     const postCalls = bolt.client.chat.postMessage.mock.calls;
     postCalls.sort(sortMessages);
     expect(postCalls[0][0]).toMatchObject(
-      merge({}, wantPostMsg, { channel: FEED_DEPLOY_CHANNEL_ID })
+      merge({}, wantPostMsg, { channel: DISCUSS_BACKEND_CHANNEL_ID })
     );
     expect(postCalls[1][0]).toMatchObject(
-      merge({}, wantPostMsg, { channel: FEED_ENGINEERING_CHANNEL_ID })
+      merge({}, wantPostMsg, { channel: FEED_DEPLOY_CHANNEL_ID })
     );
     expect(postCalls[2][0]).toMatchObject(
       merge({}, wantPostMsg, { channel: FEED_DEV_INFRA_CHANNEL_ID })
@@ -792,10 +792,10 @@ describe('gocdSlackFeeds', function () {
     const updateCalls = bolt.client.chat.update.mock.calls;
     updateCalls.sort(sortMessages);
     expect(updateCalls[0][0]).toMatchObject(
-      merge({}, wantUpdate, { channel: FEED_DEPLOY_CHANNEL_ID })
+      merge({}, wantUpdate, { channel: DISCUSS_BACKEND_CHANNEL_ID })
     );
     expect(updateCalls[1][0]).toMatchObject(
-      merge({}, wantUpdate, { channel: FEED_ENGINEERING_CHANNEL_ID })
+      merge({}, wantUpdate, { channel: FEED_DEPLOY_CHANNEL_ID })
     );
     expect(updateCalls[2][0]).toMatchObject(
       merge({}, wantUpdate, { channel: FEED_DEV_INFRA_CHANNEL_ID })
@@ -906,10 +906,10 @@ describe('gocdSlackFeeds', function () {
     postCalls.sort(sortMessages);
     expect(postCalls[0][0]).toMatchObject(canaryReply);
     expect(postCalls[1][0]).toMatchObject(
-      merge({}, wantPostMsg, { channel: FEED_DEPLOY_CHANNEL_ID })
+      merge({}, wantPostMsg, { channel: DISCUSS_BACKEND_CHANNEL_ID })
     );
     expect(postCalls[2][0]).toMatchObject(
-      merge({}, wantPostMsg, { channel: FEED_ENGINEERING_CHANNEL_ID })
+      merge({}, wantPostMsg, { channel: FEED_DEPLOY_CHANNEL_ID })
     );
     expect(postCalls[3][0]).toMatchObject(
       merge({}, wantPostMsg, { channel: FEED_DEV_INFRA_CHANNEL_ID })
@@ -981,10 +981,10 @@ describe('gocdSlackFeeds', function () {
     const updateCalls = bolt.client.chat.update.mock.calls;
     updateCalls.sort(sortMessages);
     expect(updateCalls[0][0]).toMatchObject(
-      merge({}, wantUpdate, { channel: FEED_DEPLOY_CHANNEL_ID })
+      merge({}, wantUpdate, { channel: DISCUSS_BACKEND_CHANNEL_ID })
     );
     expect(updateCalls[1][0]).toMatchObject(
-      merge({}, wantUpdate, { channel: FEED_ENGINEERING_CHANNEL_ID })
+      merge({}, wantUpdate, { channel: FEED_DEPLOY_CHANNEL_ID })
     );
     expect(updateCalls[2][0]).toMatchObject(
       merge({}, wantUpdate, { channel: FEED_DEV_INFRA_CHANNEL_ID })
@@ -1118,10 +1118,10 @@ describe('gocdSlackFeeds', function () {
     postCalls.sort(sortMessages);
     expect(postCalls[0][0]).toMatchObject(canaryReply);
     expect(postCalls[1][0]).toMatchObject(
-      merge({}, wantPostMsg, { channel: FEED_DEPLOY_CHANNEL_ID })
+      merge({}, wantPostMsg, { channel: DISCUSS_BACKEND_CHANNEL_ID })
     );
     expect(postCalls[2][0]).toMatchObject(
-      merge({}, wantPostMsg, { channel: FEED_ENGINEERING_CHANNEL_ID })
+      merge({}, wantPostMsg, { channel: FEED_DEPLOY_CHANNEL_ID })
     );
     expect(postCalls[3][0]).toMatchObject(
       merge({}, wantPostMsg, { channel: FEED_DEV_INFRA_CHANNEL_ID })
@@ -1193,10 +1193,10 @@ describe('gocdSlackFeeds', function () {
     const updateCalls = bolt.client.chat.update.mock.calls;
     updateCalls.sort(sortMessages);
     expect(updateCalls[0][0]).toMatchObject(
-      merge({}, wantUpdate, { channel: FEED_DEPLOY_CHANNEL_ID })
+      merge({}, wantUpdate, { channel: DISCUSS_BACKEND_CHANNEL_ID })
     );
     expect(updateCalls[1][0]).toMatchObject(
-      merge({}, wantUpdate, { channel: FEED_ENGINEERING_CHANNEL_ID })
+      merge({}, wantUpdate, { channel: FEED_DEPLOY_CHANNEL_ID })
     );
     expect(updateCalls[2][0]).toMatchObject(
       merge({}, wantUpdate, { channel: FEED_DEV_INFRA_CHANNEL_ID })
@@ -1378,10 +1378,10 @@ describe('gocdSlackFeeds', function () {
     postCalls.sort(sortMessages);
     expect(postCalls[0][0]).toMatchObject(canaryReply);
     expect(postCalls[1][0]).toMatchObject(
-      merge({}, wantPostMsg, { channel: FEED_DEPLOY_CHANNEL_ID })
+      merge({}, wantPostMsg, { channel: DISCUSS_BACKEND_CHANNEL_ID })
     );
     expect(postCalls[2][0]).toMatchObject(
-      merge({}, wantPostMsg, { channel: FEED_ENGINEERING_CHANNEL_ID })
+      merge({}, wantPostMsg, { channel: FEED_DEPLOY_CHANNEL_ID })
     );
     expect(postCalls[3][0]).toMatchObject(
       merge({}, wantPostMsg, { channel: FEED_DEV_INFRA_CHANNEL_ID })
@@ -1453,10 +1453,10 @@ describe('gocdSlackFeeds', function () {
     const updateCalls = bolt.client.chat.update.mock.calls;
     updateCalls.sort(sortMessages);
     expect(updateCalls[0][0]).toMatchObject(
-      merge({}, wantUpdate, { channel: FEED_DEPLOY_CHANNEL_ID })
+      merge({}, wantUpdate, { channel: DISCUSS_BACKEND_CHANNEL_ID })
     );
     expect(updateCalls[1][0]).toMatchObject(
-      merge({}, wantUpdate, { channel: FEED_ENGINEERING_CHANNEL_ID })
+      merge({}, wantUpdate, { channel: FEED_DEPLOY_CHANNEL_ID })
     );
     expect(updateCalls[2][0]).toMatchObject(
       merge({}, wantUpdate, { channel: FEED_DEV_INFRA_CHANNEL_ID })
@@ -1515,7 +1515,7 @@ describe('gocdSlackFeeds', function () {
     });
   });
 
-  it('post message to feed-deploy and not feed-engineering for failing checks', async function () {
+  it('post message to feed-deploy and not discuss-backend for failing checks', async function () {
     const gocdPayload = merge({}, payload, {
       data: {
         pipeline: {

--- a/src/brain/gocdSlackFeeds/index.ts
+++ b/src/brain/gocdSlackFeeds/index.ts
@@ -11,9 +11,9 @@ import {
   section,
 } from '@/blocks/slackBlocks';
 import {
+  DISCUSS_BACKEND_CHANNEL_ID,
   FEED_DEPLOY_CHANNEL_ID,
   FEED_DEV_INFRA_CHANNEL_ID,
-  FEED_ENGINEERING_CHANNEL_ID,
   FEED_INGEST_CHANNEL_ID,
   FEED_SNS_SAAS_CHANNEL_ID,
   FEED_SNS_ST_CHANNEL_ID,
@@ -33,7 +33,7 @@ enum PauseCause {
 }
 
 // TODO: consolidate constants for regions
-const ENGINEERING_PIPELINE_FILTER = [
+const BACKEND_PIPELINE_FILTER = [
   'deploy-getsentry-backend-s4s',
   'deploy-getsentry-backend-de',
   GOCD_SENTRYIO_BE_PIPELINE_NAME,
@@ -76,7 +76,7 @@ const SNS_S4S_K8S_PIPELINE_FILTER = [
 const DEV_INFRA_PIPELINE_FILTER = [
   'deploy-gocd-staging',
   'deploy-gocd-production',
-  ...ENGINEERING_PIPELINE_FILTER,
+  ...BACKEND_PIPELINE_FILTER,
 ];
 
 export const IS_ROLLBACK_NECESSARY_LINK =
@@ -215,14 +215,14 @@ const ingestFeed = new DeployFeed({
   },
 });
 
-// Post certain pipelines to #team-engineering
-const engineeringFeed = new DeployFeed({
-  feedName: 'engineeringSlackFeed',
-  channelID: FEED_ENGINEERING_CHANNEL_ID,
-  msgType: SlackMessage.FEED_ENGINGEERING_DEPLOY,
+// Post certain pipelines to #discuss-backend
+const discussBackendFeed = new DeployFeed({
+  feedName: 'discussBackendSlackFeed',
+  channelID: DISCUSS_BACKEND_CHANNEL_ID,
+  msgType: SlackMessage.DISCUSS_BACKEND_DEPLOY,
   pipelineFilter: (pipeline) => {
     // We only want to log the getsentry FE and BE pipelines
-    if (!ENGINEERING_PIPELINE_FILTER.includes(pipeline.name)) {
+    if (!BACKEND_PIPELINE_FILTER.includes(pipeline.name)) {
       return false;
     }
 
@@ -299,10 +299,10 @@ export async function handler(body: GoCDResponse) {
   await Promise.all([
     deployFeed.handle(body),
     devinfraFeed.handle(body),
+    discussBackendFeed.handle(body),
     snsSaaSFeed.handle(body),
     snsSTFeed.handle(body),
     ingestFeed.handle(body),
-    engineeringFeed.handle(body),
     snsS4SK8sFeed.handle(body),
     snsSaaSK8sFeed.handle(body),
   ]);

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -51,6 +51,8 @@ export const TEAM_PRODUCT_OWNERS_CHANNEL_ID =
   process.env.TEAM_PRODUCT_OWNERS_CHANNEL_ID || 'C063DCB4PGF';
 export const DISCUSS_PRODUCT_CHANNEL_ID = // #discuss-product
   process.env.DISCUSS_PRODUCT_CHANNEL_ID || 'CDXAKMGTU';
+export const DISCUSS_BACKEND_CHANNEL_ID = // #discuss-backend
+  process.env.DISCUSS_BACKEND_CHANNEL_ID || 'CUHS29QJ0';
 export const DISCUSS_FRONTEND_CHANNEL_ID = // #discuss-frontend
   process.env.DISCUSS_FRONTEND_CHANNEL_ID || 'C8V02RHC7';
 export const DISABLE_GITHUB_METRICS =

--- a/src/config/slackMessage.ts
+++ b/src/config/slackMessage.ts
@@ -9,4 +9,5 @@ export enum SlackMessage {
   FEED_INGEST_DEPLOY = 'feed-ingest-deploy',
   FEED_SNS_SAAS_K8S = 'feed-sns-saas-k8s',
   FEED_SNS_S4S_K8S = 'feed-sns-st-k8s',
+  DISCUSS_BACKEND_DEPLOY = 'discuss-backend-deploy',
 }


### PR DESCRIPTION
To reduce noise in team-engineering, this change moves the team-engineering deploy feed to discuss-backend.