### PR TITLE
ref: update gocd failure message + sns feeds

### DIFF
--- a/src/brain/gocdSlackFeeds/deployFeed.ts
+++ b/src/brain/gocdSlackFeeds/deployFeed.ts
@@ -298,7 +298,12 @@ export class DeployFeed {
   }
 
   async getBodyText(pipeline: GoCDPipeline) {
-    let body = `GoCD deployment started`;
+    let body  = '';
+    if (pipeline.stage.result.toLowerCase() == 'failed') {
+      body = 'GoCD deployment failed'
+    } else {
+      body = `GoCD deployment started`;
+    }
     const approvedBy = pipeline.stage['approved-by'];
     if (approvedBy) {
       // We check for "changes" since `getUser() can return an email

--- a/src/brain/gocdSlackFeeds/index.ts
+++ b/src/brain/gocdSlackFeeds/index.ts
@@ -167,7 +167,7 @@ const snsSaaSFeed = new DeployFeed({
   channelID: FEED_SNS_SAAS_CHANNEL_ID,
   msgType: SlackMessage.FEED_SNS_SAAS_DEPLOY,
   pipelineFilter: (pipeline) => {
-    return SNS_SAAS_PIPELINE_FILTER.includes(pipeline.name);
+    return SNS_SAAS_PIPELINE_FILTER.includes(pipeline.name) && pipeline.stage.result.toLowerCase() === 'failed';
   },
 });
 


### PR DESCRIPTION
This PR:
1. Changes the GoCD deploy failure message to 'GoCD auto-deployment failed'
2. make feed-sns only get pipeline fail message and not start message