### PR TITLE
fix: Add details for new gh project

### DIFF
--- a/github-orgs.yml
+++ b/github-orgs.yml
@@ -5,7 +5,7 @@ getsentry:
     installationId: 9303463
   project:
     # GH project: https://github.com/orgs/getsentry/projects/227
-    nodeId: 'PVT_kwDOABVQ184AZ4Df'
+    nodeId: 'PVT_kwDOABVQ184AhGO2'
     fieldIds:
       productArea: 'PVTSSF_lADOABVQ184AhGO2zgZ0pYk'
       status: 'PVTSSF_lADOABVQ184AhGO2zgZ0pX4'

--- a/github-orgs.yml
+++ b/github-orgs.yml
@@ -4,12 +4,19 @@ getsentry:
     privateKey: 'GH_APP_PRIVATE_KEY_FOR_GETSENTRY'
     installationId: 9303463
   project:
+    # GH project: https://github.com/orgs/getsentry/projects/227
     nodeId: 'PVT_kwDOABVQ184AZ4Df'
     fieldIds:
-      productArea: 'PVTSSF_lADOABVQ184AZ4DfzgQkiSc'
-      status: 'PVTSSF_lADOABVQ184AZ4DfzgQkiPA'
-      responseDue: 'PVTF_lADOABVQ184AZ4DfzgQkiSs'
-    # Old GH project: https://github.com/orgs/getsentry/projects/76
+      productArea: 'PVTSSF_lADOABVQ184AhGO2zgZ0pYk'
+      status: 'PVTSSF_lADOABVQ184AhGO2zgZ0pX4'
+      responseDue: 'PVTF_lADOABVQ184AhGO2zgZ0pY0'
+    # GH project: https://github.com/orgs/getsentry/projects/190
+    # nodeId: 'PVT_kwDOABVQ184AZ4Df'
+    # fieldIds:
+    #   productArea: 'PVTSSF_lADOABVQ184AZ4DfzgQkiSc'
+    #   status: 'PVTSSF_lADOABVQ184AZ4DfzgQkiPA'
+    #   responseDue: 'PVTF_lADOABVQ184AZ4DfzgQkiSs'
+    # GH project: https://github.com/orgs/getsentry/projects/76
     # nodeId: 'PVT_kwDOABVQ184AOGW8'
     # fieldIds:
     #   productArea: 'PVTSSF_lADOABVQ184AOGW8zgJEBno'


### PR DESCRIPTION
Seeing errors where we are surpassing 1200 max items in GH project we use to store issues across the getsentry org. Until GH offers projects with unlimited amount of items, we need to create a new project 

https://sentry.sentry.io/issues/4526816142/?project=5246761&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=24h&stream_index=0&utc=true