### PR TITLE
feat(sns): Add a deploy feed in discuss-eng-sns when pipeline fails

### DIFF
--- a/src/brain/gocdSlackFeeds/index.test.ts
+++ b/src/brain/gocdSlackFeeds/index.test.ts
@@ -1725,13 +1725,11 @@ describe('gocdSlackFeeds', function () {
       text: '',
       blocks: [
         slackblocks.header(
-          slackblocks.plaintext(
-            ':double_vertical_bar: deploy-snuba-us has failed'
-          )
+          slackblocks.plaintext(':x: deploy-snuba-us has failed')
         ),
         slackblocks.section(
           slackblocks.markdown(`The deployment pipeline has failed due to detected issues in deploy-canary.\n
-Review the Errors*\n Review the errors in the *<https://deploy.getsentry.net/go/tab/build/detail/deploy-snuba-us/20/deploy-canary/1/health_check|GoCD Logs>*.`)
+*Review the errors* in the *<https://deploy.getsentry.net/go/tab/build/detail/deploy-snuba-us/20/deploy-canary/1/health_check|GoCD Logs>*.`)
         ),
         slackblocks.context(
           slackblocks.markdown(

--- a/src/brain/gocdSlackFeeds/index.test.ts
+++ b/src/brain/gocdSlackFeeds/index.test.ts
@@ -1616,6 +1616,132 @@ describe('gocdSlackFeeds', function () {
     });
   });
 
+  it('post message to discuss-eng-sns and feed-sns on snuba pipeline failure', async function () {
+    org.api.repos.compareCommits.mockImplementation((args) => {
+      if (args.owner !== GETSENTRY_ORG.slug) {
+        throw new Error(`Unexpected compareCommits() owner: ${args.owner}`);
+      }
+      if (args.repo !== 'getsentry') {
+        throw new Error(`Unexpected compareCommits() repo: ${args.repo}`);
+      }
+      return {
+        status: 200,
+        data: {
+          commits: [
+            {
+              commit: {},
+              author: {
+                login: 'githubUser',
+              },
+            },
+          ],
+        },
+      };
+    });
+    const gocdPayload = merge({}, payload, {
+      data: {
+        pipeline: {
+          name: 'deploy-snuba-us',
+          stage: {
+            name: 'deploy-canary',
+            result: 'Failed',
+            jobs: [
+              {
+                name: 'health_check',
+                result: 'Failed',
+              },
+            ],
+          },
+        },
+      },
+    });
+    getUser.mockImplementation((args) => {
+      switch (args.email) {
+        case 'test@sentry.io':
+          return { slackUser: 'U1230' };
+        case 'test2@sentry.io':
+          return { slackUser: 'U1231' };
+        case 'test3@sentry.io':
+          return { slackUser: 'U1232' };
+        case 'test4@sentry.io':
+          return { slackUser: 'U1233' };
+        case 'test5@sentry.io':
+          return { slackUser: 'U1234' };
+        case 'test6@sentry.io':
+          return { slackUser: 'U1235' };
+        case 'test7@sentry.io':
+          return { slackUser: 'U1236' };
+        case 'test8@sentry.io':
+          return { slackUser: 'U1237' };
+        case 'test9@sentry.io':
+          return { slackUser: 'U1238' };
+        case 'test10@sentry.io':
+          return { slackUser: 'U1239' };
+        case 'test11@sentry.io':
+          return { slackUser: 'U12310' };
+        default:
+          return null;
+      }
+    });
+    org.api.repos.compareCommits.mockImplementation((_) => {
+      return {
+        status: 200,
+        data: {
+          commits: [
+            {
+              commit: { author: { email: 'test@sentry.io' } },
+              author: {},
+            },
+            {
+              commit: { author: { email: 'test2@sentry.io' } },
+              author: {},
+            },
+            {
+              commit: { author: { email: 'test3@sentry.io' } },
+              author: {},
+            },
+            {
+              commit: { author: { email: 'test4@sentry.io' } },
+              author: {},
+            },
+            {
+              commit: { author: { email: 'test5@sentry.io' } },
+              author: {},
+            },
+            {
+              commit: { author: { email: 'test6@sentry.io' } },
+              author: {},
+            },
+            {
+              commit: { author: { email: 'test7@sentry.io' } },
+              author: {},
+            },
+            {
+              commit: { author: { email: 'test8@sentry.io' } },
+              author: {},
+            },
+            {
+              commit: { author: { email: 'test9@sentry.io' } },
+              author: {},
+            },
+            {
+              commit: { author: { email: 'test10@sentry.io' } },
+              author: {},
+            },
+            {
+              commit: { author: { email: 'test11@sentry.io' } },
+              author: {},
+            },
+          ],
+        },
+      };
+    });
+
+    await handler(gocdPayload);
+
+    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(4);
+  });
+
   function sortMessages(ao, bo) {
     const a = ao[0].channel;
     const b = bo[0].channel;

--- a/src/brain/gocdSlackFeeds/index.ts
+++ b/src/brain/gocdSlackFeeds/index.ts
@@ -211,10 +211,10 @@ const discussSnSFeed = new DeployFeed({
     const gocdLogsLink = `https://deploy.getsentry.net/go/tab/build/detail/${pipeline.name}/${pipeline.counter}/${pipeline.stage.name}/${pipeline.stage.counter}/${failedJob.name}`;
 
     const blocks = [
-      header(plaintext(`:double_vertical_bar: ${pipeline.name} has failed`)),
+      header(plaintext(`:x: ${pipeline.name} has failed`)),
       section(
         markdown(`The deployment pipeline has failed due to detected issues in ${pipeline.stage.name}.\n
-Review the Errors*\n Review the errors in the *<${gocdLogsLink}|GoCD Logs>*.`)
+*Review the errors* in the *<${gocdLogsLink}|GoCD Logs>*.`)
       ),
     ];
     if (ccUsers.length > 0) {

--- a/src/brain/gocdSlackFeeds/index.ts
+++ b/src/brain/gocdSlackFeeds/index.ts
@@ -12,6 +12,7 @@ import {
 } from '@/blocks/slackBlocks';
 import {
   DISCUSS_BACKEND_CHANNEL_ID,
+  DISCUSS_ENG_SNS_CHANNEL_ID,
   FEED_DEPLOY_CHANNEL_ID,
   FEED_DEV_INFRA_CHANNEL_ID,
   FEED_INGEST_CHANNEL_ID,
@@ -169,6 +170,68 @@ const snsSaaSFeed = new DeployFeed({
   },
 });
 
+const discussSnSFeed = new DeployFeed({
+  feedName: 'discussEngSnSSlackFeed',
+  channelID: DISCUSS_ENG_SNS_CHANNEL_ID,
+  msgType: SlackMessage.DISCUSS_SNS_DEPLOY,
+  pipelineFilter: (pipeline) => {
+    // We only want to log the snuba pipeline
+    if (!SNS_SAAS_PIPELINE_FILTER.includes(pipeline.name)) {
+      return false;
+    }
+
+    // We only really care about creating new messages if the pipeline has
+    // failed.
+    return pipeline.stage.result.toLowerCase() === 'failed';
+  },
+  replyCallback: async (pipeline) => {
+    const [base, head] = await getBaseAndHeadCommit(pipeline);
+    const authors = head ? await getAuthors('snuba', base, head) : [];
+    // Get unique users from the authors
+    const uniqueUsers = await getUniqueUsers(authors);
+
+    // Pick at most 10 users to cc
+    const ccUsers = uniqueUsers.slice(0, 10);
+    const ccString = ccUsers
+      .map((user) => {
+        return `<@${user.slackUser}>`;
+      })
+      .join(' ');
+
+    const failedJob = pipeline.stage.jobs.find(
+      (job) => job.result.toLowerCase() === 'failed'
+    );
+    if (!failedJob) {
+      // This should never happen, but if it does, we want to know about it
+      Sentry.captureException(
+        new Error('Failed to find failed job in failed pipeline')
+      );
+      return [];
+    }
+    const gocdLogsLink = `https://deploy.getsentry.net/go/tab/build/detail/${pipeline.name}/${pipeline.counter}/${pipeline.stage.name}/${pipeline.stage.counter}/${failedJob.name}`;
+
+    const blocks = [
+      header(plaintext(`:double_vertical_bar: ${pipeline.name} has failed`)),
+      section(
+        markdown(`The deployment pipeline has failed due to detected issues in ${pipeline.stage.name}.\n
+Review the Errors*\n Review the errors in the *<${gocdLogsLink}|GoCD Logs>*.`)
+      ),
+    ];
+    if (ccUsers.length > 0) {
+      blocks.push(
+        context(
+          markdown(
+            `cc'ing the following ${
+              uniqueUsers.length > 10 ? `10 of ${uniqueUsers.length} ` : ''
+            }people who have commits in this deploy:\n${ccString}`
+          )
+        )
+      );
+    }
+    return blocks;
+  },
+});
+
 const snsSaaSK8sFeed = new DeployFeed({
   feedName: 'snsSaaSK8sSlackFeed',
   channelID: FEED_SNS_SAAS_CHANNEL_ID,
@@ -299,6 +362,7 @@ export async function handler(body: GoCDResponse) {
     devinfraFeed.handle(body),
     discussBackendFeed.handle(body),
     snsSaaSFeed.handle(body),
+    discussSnSFeed.handle(body),
     snsSTFeed.handle(body),
     ingestFeed.handle(body),
     snsS4SK8sFeed.handle(body),

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -55,6 +55,8 @@ export const DISCUSS_BACKEND_CHANNEL_ID = // #discuss-backend
   process.env.DISCUSS_BACKEND_CHANNEL_ID || 'CUHS29QJ0';
 export const DISCUSS_FRONTEND_CHANNEL_ID = // #discuss-frontend
   process.env.DISCUSS_FRONTEND_CHANNEL_ID || 'C8V02RHC7';
+export const DISCUSS_ENG_SNS_CHANNEL_ID = // #discuss-eng-sns
+  process.env.DISCUSS_FRONTEND_CHANNEL_ID || 'CLTE78L73';
 export const DISABLE_GITHUB_METRICS =
   process.env.DISABLE_GITHUB_METRICS === 'true' ||
   process.env.DISABLE_GITHUB_METRICS === '1';

--- a/src/config/slackMessage.ts
+++ b/src/config/slackMessage.ts
@@ -10,4 +10,5 @@ export enum SlackMessage {
   FEED_SNS_SAAS_K8S = 'feed-sns-saas-k8s',
   FEED_SNS_S4S_K8S = 'feed-sns-st-k8s',
   DISCUSS_BACKEND_DEPLOY = 'discuss-backend-deploy',
+  DISCUSS_SNS_DEPLOY = 'discuss-sns-deploy',
 }


### PR DESCRIPTION
Add a deploy feed in discuss-eng-sns when pipeline fails.
When any stage of the deploy-snuba-us or deploy-snuba-de deployment pipeline fails, a message will be sent out in #discuss-eng-sns pining the commit authors.