### PR TITLE
Add wild issue popup every time issue is rerouted

### DIFF
--- a/src/brain/issueNotifier/index.test.ts
+++ b/src/brain/issueNotifier/index.test.ts
@@ -21,8 +21,16 @@ describe('issueNotifier Tests', function () {
       ],
       [
         'Only product area label',
-        { label: { name: 'Product Area: Multi-Team', id: 'test-id' } },
-        false,
+        {
+          label: { name: 'Product Area: Multi-Team', id: 'test-id' },
+          organization: {
+            login: 'getsentry',
+          },
+          repository: {
+            name: 'routing-repo',
+          },
+        },
+        true,
       ],
       [
         `Product Area label on ${WAITING_FOR_PRODUCT_OWNER_LABEL}`,

--- a/src/brain/issueNotifier/index.ts
+++ b/src/brain/issueNotifier/index.ts
@@ -5,7 +5,6 @@ import {
   GETSENTRY_ORG,
   PRODUCT_AREA_LABEL_PREFIX,
   SUPPORT_CHANNEL_ID,
-  WAITING_FOR_PRODUCT_OWNER_LABEL,
   WAITING_FOR_SUPPORT_LABEL,
 } from '@/config';
 import { githubEvents } from '@api/github';
@@ -21,12 +20,7 @@ export const githubLabelHandler = async ({
   }
 
   let productAreaLabel: undefined | string;
-  if (
-    label.name.startsWith(PRODUCT_AREA_LABEL_PREFIX) &&
-    issue.labels?.some(
-      (label) => label.name === WAITING_FOR_PRODUCT_OWNER_LABEL
-    )
-  ) {
+  if (label.name.startsWith(PRODUCT_AREA_LABEL_PREFIX)) {
     productAreaLabel = label.name;
   } else if (label.name === WAITING_FOR_SUPPORT_LABEL) {
     bolt.client.chat.postMessage({


### PR DESCRIPTION
This fixes an issue where an issue that is initially routed wasn't triggering the wild issue popup since it didn't have `Waiting for: Product Owner` label. We shouldn't gate this notification on the `Waiting for: Product Owner` label anyways. Any issue that is rerouted should notify the teams involved. 