### PR TITLE
chore: update sns gocd failure message

### DIFF
--- a/src/brain/gocdSlackFeeds/index.test.ts
+++ b/src/brain/gocdSlackFeeds/index.test.ts
@@ -1729,6 +1729,7 @@ describe('gocdSlackFeeds', function () {
         ),
         slackblocks.section(
           slackblocks.markdown(`The deployment pipeline has failed due to detected issues in deploy-canary.\n
+Please do not ignore this message just because the environment is not SaaS, because deployment to any subsequent environment will be cancelled.\n
 *Review the errors* in the *<https://deploy.getsentry.net/go/tab/build/detail/deploy-snuba-us/20/deploy-canary/1/health_check|GoCD Logs>*.`)
         ),
         slackblocks.context(

--- a/src/brain/gocdSlackFeeds/index.ts
+++ b/src/brain/gocdSlackFeeds/index.ts
@@ -214,6 +214,7 @@ const discussSnSFeed = new DeployFeed({
       header(plaintext(`:x: ${pipeline.name} has failed`)),
       section(
         markdown(`The deployment pipeline has failed due to detected issues in ${pipeline.stage.name}.\n
+Please do not ignore this message just because the environment is not SaaS, because deployment to any subsequent environment will be cancelled.\n
 *Review the errors* in the *<${gocdLogsLink}|GoCD Logs>*.`)
       ),
     ];


### PR DESCRIPTION
this updates the failure message sent in slack for sns deploy fail