### PR TITLE
fixing json parsing logic

### DIFF
--- a/src/api/gocd/index.test.ts
+++ b/src/api/gocd/index.test.ts
@@ -126,12 +126,11 @@ describe('gocd', () => {
   it('fetches the GoCD dashboard', async () => {
     fetchUsingProxyAuthSpy.mockReturnValue(
       Promise.resolve({
-        data: `
-        {
-          "_embedded": {
-            "pipelines": []
-          }
-        }`,
+        data: {
+          _embedded: {
+            pipelines: [],
+          },
+        },
       })
     );
 

--- a/src/api/gocd/index.ts
+++ b/src/api/gocd/index.ts
@@ -43,7 +43,7 @@ async function gocdFetch<T>(
   };
 
   const resp = await fetchUsingProxyAuth(fullURL, opts);
-  const json = JSON.parse(resp.data);
+  const json = JSON.parse(JSON.stringify(resp.data));
   return removeNestedEmbeddings(json) as T;
 }
 

--- a/src/api/gocd/index.ts
+++ b/src/api/gocd/index.ts
@@ -43,8 +43,7 @@ async function gocdFetch<T>(
   };
 
   const resp = await fetchUsingProxyAuth(fullURL, opts);
-  const json = JSON.parse(JSON.stringify(resp.data));
-  return removeNestedEmbeddings(json) as T;
+  return removeNestedEmbeddings(resp.data) as T;
 }
 
 export async function fetchDashboard() {

--- a/src/utils/iap.ts
+++ b/src/utils/iap.ts
@@ -35,7 +35,7 @@ export async function fetchUsingProxyAuth(
       ...opts.headers,
     },
   });
-  return gaxiosInstance.request({
+  const result = await gaxiosInstance.request({
     url,
     responseType: 'json',
     retry: true,
@@ -46,4 +46,13 @@ export async function fetchUsingProxyAuth(
     timeout: 10000,
     ...opts,
   });
+  // eslint-disable-next-line no-console
+  console.log('headers', JSON.stringify(result.headers));
+  // eslint-disable-next-line no-console
+  console.log('statusCode', result.status);
+  // eslint-disable-next-line no-console
+  console.log('statusText', result.statusText);
+  // eslint-disable-next-line no-console
+  console.log('body', JSON.stringify(result.data));
+  return result;
 }


### PR DESCRIPTION
Fixing an issue with json parsing for the new gocd paused pipeline reminder bot. This doesn't fix the IAP problem, will continue debugging that.