### PR TITLE
[OPS-6812] Add Slack DeployFeed for GoCD Job Runner pipeline

### DIFF
--- a/src/brain/gocdSlackFeeds/index.ts
+++ b/src/brain/gocdSlackFeeds/index.ts
@@ -15,6 +15,7 @@ import {
   DISCUSS_ENG_SNS_CHANNEL_ID,
   FEED_DEPLOY_CHANNEL_ID,
   FEED_DEV_INFRA_CHANNEL_ID,
+  FEED_GOCD_JOB_RUNNER_CHANNEL_ID,
   FEED_INGEST_CHANNEL_ID,
   FEED_SNS_SAAS_CHANNEL_ID,
   FEED_SNS_ST_CHANNEL_ID,
@@ -38,6 +39,8 @@ const BACKEND_PIPELINE_FILTER = [
   'deploy-getsentry-backend-de',
   GOCD_SENTRYIO_BE_PIPELINE_NAME,
 ];
+
+const GOCD_CUSTOM_JOB_PIPELINE_NAME = 'run-custom-job';
 
 const INGEST_PIPELINE_FILTER = ['deploy-relay-processing', 'deploy-relay-pop'];
 
@@ -357,17 +360,29 @@ const discussBackendFeed = new DeployFeed({
   },
 });
 
+const goCDCustomJobRunnerFeed = new DeployFeed({
+  feedName: 'goCDCustomJobRunnerSlackFeed',
+  channelID: FEED_GOCD_JOB_RUNNER_CHANNEL_ID,
+  msgType: SlackMessage.GOCD_CUSTOM_JOB_RUN,
+  pipelineFilter: (pipeline) => {
+    // We only want to capture updates for the GoCD Job Runner pipeline,
+    // whether successful or failed
+    return pipeline.name === GOCD_CUSTOM_JOB_PIPELINE_NAME;
+  },
+});
+
 export async function handler(body: GoCDResponse) {
   await Promise.all([
     deployFeed.handle(body),
     devinfraFeed.handle(body),
     discussBackendFeed.handle(body),
-    snsSaaSFeed.handle(body),
     discussSnSFeed.handle(body),
-    snsSTFeed.handle(body),
+    goCDCustomJobRunnerFeed.handle(body),
     ingestFeed.handle(body),
     snsS4SK8sFeed.handle(body),
+    snsSaaSFeed.handle(body),
     snsSaaSK8sFeed.handle(body),
+    snsSTFeed.handle(body),
   ]);
 }
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -49,6 +49,8 @@ export const FEED_SNS_ST_CHANNEL_ID = // #feed-sns-st
   process.env.FEED_SNS_ST_CHANNEL_ID || 'C0596EHDD9N';
 export const FEED_INGEST_CHANNEL_ID = // #discuss-ingest
   process.env.FEED_INGEST_CHANNEL_ID || 'C019637C760';
+export const FEED_GOCD_JOB_RUNNER_CHANNEL_ID = // #feed-gocd-job-runner
+  process.env.FEED_GOCD_JOB_RUNNER_CHANNEL_ID || 'C07E8TG7VJP';
 export const SUPPORT_CHANNEL_ID = // #discuss-support-open-source
   process.env.SUPPORT_CHANNEL_ID || 'C02KHRNRZ1B';
 export const TEAM_OSPO_CHANNEL_ID = // #team-ospo

--- a/src/config/slackMessage.ts
+++ b/src/config/slackMessage.ts
@@ -1,6 +1,7 @@
 export enum SlackMessage {
   REQUIRED_CHECK = 'required-check',
   PLEASE_DEPLOY = 'please-deploy',
+  GOCD_CUSTOM_JOB_RUN = 'gocd-custom-job-run',
   FEED_ENG_DEPLOY = 'feed-eng-deploy',
   FEED_DEV_INFRA_GOCD_DEPLOY = 'feed-dev-infra-gocd-deploy',
   FEED_ENGINGEERING_DEPLOY = 'feed-engineering-deploy',


### PR DESCRIPTION
- Creates a new `DeployFeed` for messages triggered by GoCD events: `goCDCustomJobRunnerSlackFeed`
- The new feed alerts using the default `eng-pipes` functionality for events on the `run-custom-job` GoCD pipeline
- The `approved-by` Slack user will be tagged in messages
- Alerts are sent to a newly-created channel `#feed-gocd-job-runner`