### PR TITLE
[SRE-176] Update GoCD pipeline Slack notifications to consider thread replies on each stage update

### DIFF
--- a/src/api/slack/__mocks__/index.ts
+++ b/src/api/slack/__mocks__/index.ts
@@ -20,10 +20,10 @@ jest.mock('@slack/web-api', () => ({
         ),
       },
       chat: {
-        postMessage: jest.fn(() =>
+        postMessage: jest.fn(({ channel }) =>
           // TODO: this is incomplete
           Promise.resolve({
-            channel: 'channel_id',
+            channel: channel,
             ts: '1234123.123',
             message: {
               bot_id: 'B01834PAJDT',

--- a/src/brain/gocdSlackFeeds/deployFeed.test.ts
+++ b/src/brain/gocdSlackFeeds/deployFeed.test.ts
@@ -42,7 +42,7 @@ describe('DeployFeed', () => {
 
     const feed = new DeployFeed({
       feedName: 'example-feed',
-      channelID: 'example-channel-id',
+      channelID: 'messages-without-filter-channel',
       msgType: SlackMessage.FEED_ENG_DEPLOY,
     });
     await feed.handle(gocdPayload);
@@ -50,7 +50,7 @@ describe('DeployFeed', () => {
     expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(1);
     expect(bolt.client.chat.postMessage.mock.calls[0][0]).toMatchObject({
       text: 'GoCD deployment started',
-      channel: 'example-channel-id',
+      channel: 'messages-without-filter-channel',
       attachments: [
         {
           color: Color.OFF_WHITE_TOO,
@@ -84,7 +84,7 @@ describe('DeployFeed', () => {
     expect(slackMessages).toHaveLength(1);
     expect(slackMessages[0]).toMatchObject({
       refId: `sentryio-${gocdPayload.data.pipeline.name}/20@2b0034becc4ab26b985f4c1a08ab068f153c274c`,
-      channel: 'channel_id',
+      channel: 'messages-without-filter-channel',
       ts: '1234123.123',
       context: {
         text: 'GoCD deployment started',
@@ -103,7 +103,7 @@ describe('DeployFeed', () => {
 
     const feed = new DeployFeed({
       feedName: 'example-feed',
-      channelID: 'example-channel-id',
+      channelID: 'messages-with-filter-channel',
       msgType: SlackMessage.FEED_ENG_DEPLOY,
       pipelineFilter: (pipeline: GoCDPipeline) => {
         return pipeline.name === 'ONLY_THIS_PIPELINE';
@@ -143,7 +143,7 @@ describe('DeployFeed', () => {
 
     const feed = new DeployFeed({
       feedName: 'example-feed',
-      channelID: 'example-channel-id',
+      channelID: 'auto-deploy-messages-channel',
       msgType: SlackMessage.FEED_ENG_DEPLOY,
     });
     await feed.handle(gocdPayload);
@@ -151,7 +151,7 @@ describe('DeployFeed', () => {
     expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(1);
     expect(bolt.client.chat.postMessage.mock.calls[0][0]).toMatchObject({
       text: 'GoCD auto-deployment started',
-      channel: 'example-channel-id',
+      channel: 'auto-deploy-messages-channel',
       attachments: [
         {
           color: Color.SUCCESS,
@@ -196,7 +196,7 @@ describe('DeployFeed', () => {
 
     const feed = new DeployFeed({
       feedName: 'example-feed',
-      channelID: 'example-channel-id',
+      channelID: 'update-user-channel',
       msgType: SlackMessage.FEED_ENG_DEPLOY,
     });
     await feed.handle(gocdPayload);
@@ -204,7 +204,7 @@ describe('DeployFeed', () => {
     expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(1);
     expect(bolt.client.chat.postMessage.mock.calls[0][0]).toMatchObject({
       text: 'GoCD deployment started by <@U018H4DA8N5>',
-      channel: 'example-channel-id',
+      channel: 'update-user-channel',
       attachments: [
         {
           color: Color.DANGER,
@@ -238,7 +238,7 @@ describe('DeployFeed', () => {
     expect(slackMessages).toHaveLength(1);
     expect(slackMessages[0]).toMatchObject({
       refId: `sentryio-${gocdPayload.data.pipeline.name}/20@2b0034becc4ab26b985f4c1a08ab068f153c274c`,
-      channel: 'channel_id',
+      channel: 'update-user-channel',
       ts: '1234123.123',
       context: {
         text: 'GoCD deployment started by <@U018H4DA8N5>',
@@ -260,7 +260,7 @@ describe('DeployFeed', () => {
     expect(bolt.client.chat.update).toHaveBeenCalledTimes(1);
     expect(bolt.client.chat.update.mock.calls[0][0]).toMatchObject({
       text: 'GoCD deployment started by <@U018H4DA8N5>',
-      channel: 'example-channel-id',
+      channel: 'update-user-channel',
       attachments: [
         {
           color: Color.DANGER,
@@ -293,7 +293,7 @@ describe('DeployFeed', () => {
     expect(slackMessages).toHaveLength(1);
     expect(slackMessages[0]).toMatchObject({
       refId: `sentryio-${gocdPayload.data.pipeline.name}/20@2b0034becc4ab26b985f4c1a08ab068f153c274c`,
-      channel: 'channel_id',
+      channel: 'update-user-channel',
       ts: '1234123.123',
       context: {
         text: 'GoCD deployment started by <@U018H4DA8N5>',
@@ -316,7 +316,7 @@ describe('DeployFeed', () => {
 
     const feed = new DeployFeed({
       feedName: 'example-feed',
-      channelID: 'example-channel-id',
+      channelID: 'no-build-cause-channel',
       msgType: SlackMessage.FEED_ENG_DEPLOY,
     });
     await feed.handle(gocdPayload);
@@ -324,7 +324,7 @@ describe('DeployFeed', () => {
     expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(1);
     expect(bolt.client.chat.postMessage.mock.calls[0][0]).toMatchObject({
       text: 'GoCD deployment started',
-      channel: 'example-channel-id',
+      channel: 'no-build-cause-channel',
       attachments: [
         {
           color: Color.DANGER,
@@ -370,7 +370,7 @@ describe('DeployFeed', () => {
 
     const feed = new DeployFeed({
       feedName: 'example-feed',
-      channelID: 'example-channel-id',
+      channelID: 'url-test-channel',
       msgType: SlackMessage.FEED_ENG_DEPLOY,
     });
     await feed.handle(gocdPayload);
@@ -378,7 +378,7 @@ describe('DeployFeed', () => {
     expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(1);
     expect(bolt.client.chat.postMessage.mock.calls[0][0]).toMatchObject({
       text: 'GoCD deployment started',
-      channel: 'example-channel-id',
+      channel: 'url-test-channel',
       attachments: [
         {
           color: Color.OFF_WHITE_TOO,
@@ -470,7 +470,7 @@ describe('DeployFeed', () => {
 
     const feed = new DeployFeed({
       feedName: 'example-feed',
-      channelID: 'example-channel-id',
+      channelID: 'non-getsentry-commits-channel',
       msgType: SlackMessage.FEED_ENG_DEPLOY,
     });
     await feed.handle(gocdPayload);
@@ -478,7 +478,7 @@ describe('DeployFeed', () => {
     expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(1);
     expect(bolt.client.chat.postMessage.mock.calls[0][0]).toMatchObject({
       text: 'GoCD deployment started',
-      channel: 'example-channel-id',
+      channel: 'non-getsentry-commits-channel',
       attachments: [
         {
           color: Color.OFF_WHITE_TOO,
@@ -598,7 +598,7 @@ describe('DeployFeed', () => {
 
     const feed = new DeployFeed({
       feedName: 'example-feed',
-      channelID: 'example-channel-id',
+      channelID: 'getsentry-commits-channel',
       msgType: SlackMessage.FEED_ENG_DEPLOY,
     });
     await feed.handle(gocdPayload);
@@ -606,7 +606,7 @@ describe('DeployFeed', () => {
     expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(1);
     expect(bolt.client.chat.postMessage.mock.calls[0][0]).toMatchObject({
       text: 'GoCD deployment started',
-      channel: 'example-channel-id',
+      channel: 'getsentry-commits-channel',
       attachments: [
         {
           color: Color.OFF_WHITE_TOO,
@@ -707,7 +707,7 @@ describe('DeployFeed', () => {
 
     const feed = new DeployFeed({
       feedName: 'example-feed',
-      channelID: 'example-channel-id',
+      channelID: 'handle-error-channel',
       msgType: SlackMessage.FEED_ENG_DEPLOY,
     });
     await feed.handle(gocdPayload);
@@ -715,7 +715,7 @@ describe('DeployFeed', () => {
     expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(1);
     expect(bolt.client.chat.postMessage.mock.calls[0][0]).toMatchObject({
       text: 'GoCD deployment started',
-      channel: 'example-channel-id',
+      channel: 'handle-error-channel',
       attachments: [
         {
           color: Color.OFF_WHITE_TOO,

--- a/src/brain/gocdSlackFeeds/deployFeed.ts
+++ b/src/brain/gocdSlackFeeds/deployFeed.ts
@@ -359,10 +359,8 @@ export class DeployFeed {
       const attachment = await this.getMessageAttachment(pipeline);
       await Promise.all(
         messages.map(async (message) => {
-          // eslint-disable-next-line no-console
-          console.log(message.channel, this.slackChannelID);
           if (message.channel === this.slackChannelID) {
-            // Updates even if pipeline filter predicate is false
+            // Updates message even if pipeline filter predicate is false
             await this.updateSlackMessage(message, attachment);
             // Post reply if required (if reply callback exists and pipeline filter predicate is true)
             await this.replyToMessage(pipeline, message);

--- a/src/brain/gocdSlackFeeds/index.test.ts
+++ b/src/brain/gocdSlackFeeds/index.test.ts
@@ -7,6 +7,7 @@ import { buildServer } from '@/buildServer';
 import {
   Color,
   DISCUSS_BACKEND_CHANNEL_ID,
+  DISCUSS_ENG_SNS_CHANNEL_ID,
   FEED_DEPLOY_CHANNEL_ID,
   FEED_DEV_INFRA_CHANNEL_ID,
   FEED_GOCD_JOB_RUNNER_CHANNEL_ID,
@@ -98,7 +99,7 @@ describe('gocdSlackFeeds', function () {
     expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(4);
 
     const canaryReply = {
-      channel: 'channel_id',
+      channel: DISCUSS_BACKEND_CHANNEL_ID,
       text: '',
       blocks: [
         slackblocks.header(
@@ -156,10 +157,10 @@ describe('gocdSlackFeeds', function () {
 
     const postCalls = bolt.client.chat.postMessage.mock.calls;
     postCalls.sort(sortMessages);
-    expect(postCalls[0][0]).toMatchObject(canaryReply);
-    expect(postCalls[1][0]).toMatchObject(
+    expect(postCalls[0][0]).toMatchObject(
       merge({}, wantPostMsg, { channel: DISCUSS_BACKEND_CHANNEL_ID })
     );
+    expect(postCalls[1][0]).toMatchObject(canaryReply);
     expect(postCalls[2][0]).toMatchObject(
       merge({}, wantPostMsg, { channel: FEED_DEPLOY_CHANNEL_ID })
     );
@@ -168,19 +169,28 @@ describe('gocdSlackFeeds', function () {
     );
 
     let slackMessages = await db('slack_messages').select('*');
+    slackMessages.sort(sortMessages);
     expect(slackMessages).toHaveLength(3);
 
     const wantSlack = {
       refId: `sentryio-${gocdPayload.data.pipeline.name}/20@2b0034becc4ab26b985f4c1a08ab068f153c274c`,
-      channel: 'channel_id',
       ts: '1234123.123',
       context: {
         text: 'GoCD deployment started',
       },
     };
-    expect(slackMessages[0]).toMatchObject(wantSlack);
-    expect(slackMessages[1]).toMatchObject(wantSlack);
-    expect(slackMessages[2]).toMatchObject(wantSlack);
+    expect(slackMessages[0]).toMatchObject({
+      ...wantSlack,
+      channel: DISCUSS_BACKEND_CHANNEL_ID,
+    });
+    expect(slackMessages[1]).toMatchObject({
+      ...wantSlack,
+      channel: FEED_DEPLOY_CHANNEL_ID,
+    });
+    expect(slackMessages[2]).toMatchObject({
+      ...wantSlack,
+      channel: FEED_DEV_INFRA_CHANNEL_ID,
+    });
 
     // Second Event
     await handler(
@@ -292,7 +302,7 @@ describe('gocdSlackFeeds', function () {
     expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(4);
 
     const soakReply = {
-      channel: 'channel_id',
+      channel: DISCUSS_BACKEND_CHANNEL_ID,
       text: '',
       blocks: [
         slackblocks.header(
@@ -350,10 +360,10 @@ describe('gocdSlackFeeds', function () {
 
     const postCalls = bolt.client.chat.postMessage.mock.calls;
     postCalls.sort(sortMessages);
-    expect(postCalls[0][0]).toMatchObject(soakReply);
-    expect(postCalls[1][0]).toMatchObject(
+    expect(postCalls[0][0]).toMatchObject(
       merge({}, wantPostMsg, { channel: DISCUSS_BACKEND_CHANNEL_ID })
     );
+    expect(postCalls[1][0]).toMatchObject(soakReply);
     expect(postCalls[2][0]).toMatchObject(
       merge({}, wantPostMsg, { channel: FEED_DEPLOY_CHANNEL_ID })
     );
@@ -362,19 +372,28 @@ describe('gocdSlackFeeds', function () {
     );
 
     let slackMessages = await db('slack_messages').select('*');
+    slackMessages.sort(sortMessages);
     expect(slackMessages).toHaveLength(3);
 
     const wantSlack = {
       refId: `sentryio-${gocdPayload.data.pipeline.name}/20@2b0034becc4ab26b985f4c1a08ab068f153c274c`,
-      channel: 'channel_id',
       ts: '1234123.123',
       context: {
         text: 'GoCD deployment started',
       },
     };
-    expect(slackMessages[0]).toMatchObject(wantSlack);
-    expect(slackMessages[1]).toMatchObject(wantSlack);
-    expect(slackMessages[2]).toMatchObject(wantSlack);
+    expect(slackMessages[0]).toMatchObject({
+      ...wantSlack,
+      channel: DISCUSS_BACKEND_CHANNEL_ID,
+    });
+    expect(slackMessages[1]).toMatchObject({
+      ...wantSlack,
+      channel: FEED_DEPLOY_CHANNEL_ID,
+    });
+    expect(slackMessages[2]).toMatchObject({
+      ...wantSlack,
+      channel: FEED_DEV_INFRA_CHANNEL_ID,
+    });
 
     // Second Event
     await handler(
@@ -486,7 +505,7 @@ describe('gocdSlackFeeds', function () {
     expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(4);
 
     const soakReply = {
-      channel: 'channel_id',
+      channel: DISCUSS_BACKEND_CHANNEL_ID,
       text: '',
       blocks: [
         slackblocks.header(
@@ -544,10 +563,10 @@ describe('gocdSlackFeeds', function () {
 
     const postCalls = bolt.client.chat.postMessage.mock.calls;
     postCalls.sort(sortMessages);
-    expect(postCalls[0][0]).toMatchObject(soakReply);
-    expect(postCalls[1][0]).toMatchObject(
+    expect(postCalls[0][0]).toMatchObject(
       merge({}, wantPostMsg, { channel: DISCUSS_BACKEND_CHANNEL_ID })
     );
+    expect(postCalls[1][0]).toMatchObject(soakReply);
     expect(postCalls[2][0]).toMatchObject(
       merge({}, wantPostMsg, { channel: FEED_DEPLOY_CHANNEL_ID })
     );
@@ -556,19 +575,28 @@ describe('gocdSlackFeeds', function () {
     );
 
     let slackMessages = await db('slack_messages').select('*');
+    slackMessages.sort(sortMessages);
     expect(slackMessages).toHaveLength(3);
 
     const wantSlack = {
       refId: `sentryio-${gocdPayload.data.pipeline.name}/20@2b0034becc4ab26b985f4c1a08ab068f153c274c`,
-      channel: 'channel_id',
       ts: '1234123.123',
       context: {
         text: 'GoCD deployment started',
       },
     };
-    expect(slackMessages[0]).toMatchObject(wantSlack);
-    expect(slackMessages[1]).toMatchObject(wantSlack);
-    expect(slackMessages[2]).toMatchObject(wantSlack);
+    expect(slackMessages[0]).toMatchObject({
+      ...wantSlack,
+      channel: DISCUSS_BACKEND_CHANNEL_ID,
+    });
+    expect(slackMessages[1]).toMatchObject({
+      ...wantSlack,
+      channel: FEED_DEPLOY_CHANNEL_ID,
+    });
+    expect(slackMessages[2]).toMatchObject({
+      ...wantSlack,
+      channel: FEED_DEV_INFRA_CHANNEL_ID,
+    });
 
     // Second Event
     await handler(
@@ -728,19 +756,28 @@ describe('gocdSlackFeeds', function () {
     );
 
     let slackMessages = await db('slack_messages').select('*');
+    slackMessages.sort(sortMessages);
     expect(slackMessages).toHaveLength(3);
 
     const wantSlack = {
       refId: `sentryio-${gocdPayload.data.pipeline.name}/20@2b0034becc4ab26b985f4c1a08ab068f153c274c`,
-      channel: 'channel_id',
       ts: '1234123.123',
       context: {
         text: 'GoCD deployment started',
       },
     };
-    expect(slackMessages[0]).toMatchObject(wantSlack);
-    expect(slackMessages[1]).toMatchObject(wantSlack);
-    expect(slackMessages[2]).toMatchObject(wantSlack);
+    expect(slackMessages[0]).toMatchObject({
+      ...wantSlack,
+      channel: DISCUSS_BACKEND_CHANNEL_ID,
+    });
+    expect(slackMessages[1]).toMatchObject({
+      ...wantSlack,
+      channel: FEED_DEPLOY_CHANNEL_ID,
+    });
+    expect(slackMessages[2]).toMatchObject({
+      ...wantSlack,
+      channel: FEED_DEV_INFRA_CHANNEL_ID,
+    });
 
     // Second Event
     await handler(
@@ -852,7 +889,7 @@ describe('gocdSlackFeeds', function () {
     expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(4);
 
     const canaryReply = {
-      channel: 'channel_id',
+      channel: DISCUSS_BACKEND_CHANNEL_ID,
       text: '',
       blocks: [
         slackblocks.header(
@@ -905,10 +942,10 @@ describe('gocdSlackFeeds', function () {
 
     const postCalls = bolt.client.chat.postMessage.mock.calls;
     postCalls.sort(sortMessages);
-    expect(postCalls[0][0]).toMatchObject(canaryReply);
-    expect(postCalls[1][0]).toMatchObject(
+    expect(postCalls[0][0]).toMatchObject(
       merge({}, wantPostMsg, { channel: DISCUSS_BACKEND_CHANNEL_ID })
     );
+    expect(postCalls[1][0]).toMatchObject(canaryReply);
     expect(postCalls[2][0]).toMatchObject(
       merge({}, wantPostMsg, { channel: FEED_DEPLOY_CHANNEL_ID })
     );
@@ -917,19 +954,28 @@ describe('gocdSlackFeeds', function () {
     );
 
     let slackMessages = await db('slack_messages').select('*');
+    slackMessages.sort(sortMessages);
     expect(slackMessages).toHaveLength(3);
 
     const wantSlack = {
       refId: `sentryio-${gocdPayload.data.pipeline.name}/20@2b0034becc4ab26b985f4c1a08ab068f153c274c`,
-      channel: 'channel_id',
       ts: '1234123.123',
       context: {
         text: 'GoCD deployment started',
       },
     };
-    expect(slackMessages[0]).toMatchObject(wantSlack);
-    expect(slackMessages[1]).toMatchObject(wantSlack);
-    expect(slackMessages[2]).toMatchObject(wantSlack);
+    expect(slackMessages[0]).toMatchObject({
+      ...wantSlack,
+      channel: DISCUSS_BACKEND_CHANNEL_ID,
+    });
+    expect(slackMessages[1]).toMatchObject({
+      ...wantSlack,
+      channel: FEED_DEPLOY_CHANNEL_ID,
+    });
+    expect(slackMessages[2]).toMatchObject({
+      ...wantSlack,
+      channel: FEED_DEV_INFRA_CHANNEL_ID,
+    });
 
     // Second Event
     await handler(
@@ -1059,7 +1105,7 @@ describe('gocdSlackFeeds', function () {
     expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(4);
 
     const canaryReply = {
-      channel: 'channel_id',
+      channel: DISCUSS_BACKEND_CHANNEL_ID,
       text: '',
       blocks: [
         slackblocks.header(
@@ -1117,10 +1163,10 @@ describe('gocdSlackFeeds', function () {
 
     const postCalls = bolt.client.chat.postMessage.mock.calls;
     postCalls.sort(sortMessages);
-    expect(postCalls[0][0]).toMatchObject(canaryReply);
-    expect(postCalls[1][0]).toMatchObject(
+    expect(postCalls[0][0]).toMatchObject(
       merge({}, wantPostMsg, { channel: DISCUSS_BACKEND_CHANNEL_ID })
     );
+    expect(postCalls[1][0]).toMatchObject(canaryReply);
     expect(postCalls[2][0]).toMatchObject(
       merge({}, wantPostMsg, { channel: FEED_DEPLOY_CHANNEL_ID })
     );
@@ -1129,19 +1175,28 @@ describe('gocdSlackFeeds', function () {
     );
 
     let slackMessages = await db('slack_messages').select('*');
+    slackMessages.sort(sortMessages);
     expect(slackMessages).toHaveLength(3);
 
     const wantSlack = {
       refId: `sentryio-${gocdPayload.data.pipeline.name}/20@2b0034becc4ab26b985f4c1a08ab068f153c274c`,
-      channel: 'channel_id',
       ts: '1234123.123',
       context: {
         text: 'GoCD deployment started',
       },
     };
-    expect(slackMessages[0]).toMatchObject(wantSlack);
-    expect(slackMessages[1]).toMatchObject(wantSlack);
-    expect(slackMessages[2]).toMatchObject(wantSlack);
+    expect(slackMessages[0]).toMatchObject({
+      ...wantSlack,
+      channel: DISCUSS_BACKEND_CHANNEL_ID,
+    });
+    expect(slackMessages[1]).toMatchObject({
+      ...wantSlack,
+      channel: FEED_DEPLOY_CHANNEL_ID,
+    });
+    expect(slackMessages[2]).toMatchObject({
+      ...wantSlack,
+      channel: FEED_DEV_INFRA_CHANNEL_ID,
+    });
 
     // Second Event
     await handler(
@@ -1319,7 +1374,7 @@ describe('gocdSlackFeeds', function () {
     expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(4);
 
     const canaryReply = {
-      channel: 'channel_id',
+      channel: DISCUSS_BACKEND_CHANNEL_ID,
       text: '',
       blocks: [
         slackblocks.header(
@@ -1377,10 +1432,10 @@ describe('gocdSlackFeeds', function () {
 
     const postCalls = bolt.client.chat.postMessage.mock.calls;
     postCalls.sort(sortMessages);
-    expect(postCalls[0][0]).toMatchObject(canaryReply);
-    expect(postCalls[1][0]).toMatchObject(
+    expect(postCalls[0][0]).toMatchObject(
       merge({}, wantPostMsg, { channel: DISCUSS_BACKEND_CHANNEL_ID })
     );
+    expect(postCalls[1][0]).toMatchObject(canaryReply);
     expect(postCalls[2][0]).toMatchObject(
       merge({}, wantPostMsg, { channel: FEED_DEPLOY_CHANNEL_ID })
     );
@@ -1389,19 +1444,28 @@ describe('gocdSlackFeeds', function () {
     );
 
     let slackMessages = await db('slack_messages').select('*');
+    slackMessages.sort(sortMessages);
     expect(slackMessages).toHaveLength(3);
 
     const wantSlack = {
       refId: `sentryio-${gocdPayload.data.pipeline.name}/20@2b0034becc4ab26b985f4c1a08ab068f153c274c`,
-      channel: 'channel_id',
       ts: '1234123.123',
       context: {
         text: 'GoCD deployment started',
       },
     };
-    expect(slackMessages[0]).toMatchObject(wantSlack);
-    expect(slackMessages[1]).toMatchObject(wantSlack);
-    expect(slackMessages[2]).toMatchObject(wantSlack);
+    expect(slackMessages[0]).toMatchObject({
+      ...wantSlack,
+      channel: DISCUSS_BACKEND_CHANNEL_ID,
+    });
+    expect(slackMessages[1]).toMatchObject({
+      ...wantSlack,
+      channel: FEED_DEPLOY_CHANNEL_ID,
+    });
+    expect(slackMessages[2]).toMatchObject({
+      ...wantSlack,
+      channel: FEED_DEV_INFRA_CHANNEL_ID,
+    });
 
     // Second Event
     await handler(
@@ -1722,7 +1786,7 @@ describe('gocdSlackFeeds', function () {
     expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(4);
 
     const pipelineFailureReply = {
-      channel: 'channel_id',
+      channel: DISCUSS_ENG_SNS_CHANNEL_ID,
       text: '',
       blocks: [
         slackblocks.header(
@@ -1743,7 +1807,7 @@ Please do not ignore this message just because the environment is not SaaS, beca
 
     const postCalls = bolt.client.chat.postMessage.mock.calls;
     postCalls.sort(sortMessages);
-    expect(postCalls[0][0]).toMatchObject(pipelineFailureReply);
+    expect(postCalls[1][0]).toMatchObject(pipelineFailureReply);
   });
 
   it(`post message without a reply for run-custom-job when the stage result is unknown`, async function () {
@@ -1849,23 +1913,6 @@ Please do not ignore this message just because the environment is not SaaS, beca
     postCalls.sort(sortMessages);
 
     expect(postCalls[0][0]).toMatchObject({
-      channel: 'channel_id',
-      text: '',
-      blocks: [
-        slackblocks.header(
-          slackblocks.plaintext('run-custom-job stage update')
-        ),
-        {
-          elements: [
-            slackblocks.markdown('✅ *execute*'),
-            slackblocks.markdown(
-              '<https://deploy.getsentry.net/go/pipelines/run-custom-job/20/execute/1|Passed>'
-            ),
-          ],
-        },
-      ],
-    });
-    expect(postCalls[1][0]).toMatchObject({
       text: 'GoCD deployment started',
       channel: FEED_GOCD_JOB_RUNNER_CHANNEL_ID,
       attachments: [
@@ -1892,6 +1939,23 @@ Please do not ignore this message just because the environment is not SaaS, beca
                 ),
               ],
             },
+          ],
+        },
+      ],
+    });
+    expect(postCalls[1][0]).toMatchObject({
+      channel: FEED_GOCD_JOB_RUNNER_CHANNEL_ID,
+      text: '',
+      blocks: [
+        slackblocks.header(
+          slackblocks.plaintext('run-custom-job stage update')
+        ),
+        {
+          elements: [
+            slackblocks.markdown('✅ *execute*'),
+            slackblocks.markdown(
+              '<https://deploy.getsentry.net/go/pipelines/run-custom-job/20/execute/1|Passed>'
+            ),
           ],
         },
       ],
@@ -1953,29 +2017,6 @@ Please do not ignore this message just because the environment is not SaaS, beca
     postCalls.sort(sortMessages);
 
     expect(postCalls[0][0]).toMatchObject({
-      channel: 'channel_id',
-      text: '',
-      blocks: [
-        slackblocks.header(
-          slackblocks.plaintext('run-custom-job stage update')
-        ),
-        {
-          elements: [
-            slackblocks.markdown('❌ *checks*'),
-            slackblocks.markdown(
-              '<https://deploy.getsentry.net/go/pipelines/run-custom-job/20/checks/1|Failed>'
-            ),
-          ],
-        },
-        slackblocks.divider(),
-        slackblocks.context(
-          slackblocks.markdown(
-            `cc'ing the user who started this deployment: <@GoCD_Slack_User>`
-          )
-        ),
-      ],
-    });
-    expect(postCalls[1][0]).toMatchObject({
       text: 'GoCD deployment started by <@GoCD_Slack_User>',
       channel: FEED_GOCD_JOB_RUNNER_CHANNEL_ID,
       attachments: [
@@ -2004,6 +2045,29 @@ Please do not ignore this message just because the environment is not SaaS, beca
             },
           ],
         },
+      ],
+    });
+    expect(postCalls[1][0]).toMatchObject({
+      channel: FEED_GOCD_JOB_RUNNER_CHANNEL_ID,
+      text: '',
+      blocks: [
+        slackblocks.header(
+          slackblocks.plaintext('run-custom-job stage update')
+        ),
+        {
+          elements: [
+            slackblocks.markdown('❌ *checks*'),
+            slackblocks.markdown(
+              '<https://deploy.getsentry.net/go/pipelines/run-custom-job/20/checks/1|Failed>'
+            ),
+          ],
+        },
+        slackblocks.divider(),
+        slackblocks.context(
+          slackblocks.markdown(
+            `cc'ing the user who started this deployment: <@GoCD_Slack_User>`
+          )
+        ),
       ],
     });
     expect(postCalls[2][0]).toMatchObject({
@@ -2039,13 +2103,180 @@ Please do not ignore this message just because the environment is not SaaS, beca
     });
   });
 
+  it(`post message and reply for run-custom-job when there are stage updates`, async function () {
+    const gocdPayload1 = merge({}, payload, {
+      data: {
+        pipeline: {
+          name: 'run-custom-job',
+          stage: {
+            name: 'checks',
+            result: 'Unknown',
+          },
+        },
+      },
+    });
+    const gocdPayload2 = merge({}, payload, {
+      data: {
+        pipeline: {
+          name: 'run-custom-job',
+          stage: {
+            name: 'checks',
+            result: 'Passed',
+          },
+        },
+      },
+    });
+    const gocdPayload3 = merge({}, payload, {
+      data: {
+        pipeline: {
+          name: 'run-custom-job',
+          stage: {
+            name: 'dry-run',
+            result: 'Unknown',
+          },
+        },
+      },
+    });
+    const gocdPayload4 = merge({}, payload, {
+      data: {
+        pipeline: {
+          name: 'run-custom-job',
+          stage: {
+            name: 'dry-run',
+            result: 'Failed',
+          },
+        },
+      },
+    });
+    await handler(gocdPayload1);
+    await handler(gocdPayload2);
+    await handler(gocdPayload3);
+    await handler(gocdPayload4);
+
+    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(4);
+    expect(bolt.client.chat.update).toHaveBeenCalledTimes(6);
+    const postCalls = bolt.client.chat.postMessage.mock.calls;
+    const updateCalls = bolt.client.chat.update.mock.calls;
+    postCalls.sort(sortMessages);
+    updateCalls.sort(sortMessages);
+
+    expect(postCalls[0][0]).toMatchObject({
+      text: 'GoCD deployment started by <@GoCD_Slack_User>',
+      channel: FEED_GOCD_JOB_RUNNER_CHANNEL_ID,
+      attachments: [
+        {
+          color: Color.OFF_WHITE_TOO,
+          blocks: [
+            slackblocks.section(
+              slackblocks.markdown('*sentryio/run-custom-job*')
+            ),
+            {
+              elements: [
+                slackblocks.markdown('Deploying'),
+                slackblocks.markdown(
+                  '<https://github.com/getsentry/getsentry/commits/2b0034becc4ab26b985f4c1a08ab068f153c274c|getsentry@2b0034becc4a>'
+                ),
+              ],
+            },
+            slackblocks.divider(),
+            {
+              elements: [
+                slackblocks.markdown('⏳ *checks*'),
+                slackblocks.markdown(
+                  '<https://deploy.getsentry.net/go/pipelines/run-custom-job/20/checks/1|In progress>'
+                ),
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    expect(postCalls[1][0]).toMatchObject({
+      channel: FEED_GOCD_JOB_RUNNER_CHANNEL_ID,
+      text: '',
+      blocks: [
+        slackblocks.header(
+          slackblocks.plaintext('run-custom-job stage update')
+        ),
+        {
+          elements: [
+            slackblocks.markdown('✅ *checks*'),
+            slackblocks.markdown(
+              '<https://deploy.getsentry.net/go/pipelines/run-custom-job/20/checks/1|Passed>'
+            ),
+          ],
+        },
+        slackblocks.divider(),
+        slackblocks.context(
+          slackblocks.markdown(
+            `cc'ing the user who started this deployment: <@GoCD_Slack_User>`
+          )
+        ),
+      ],
+    });
+    expect(postCalls[2][0]).toMatchObject({
+      channel: FEED_GOCD_JOB_RUNNER_CHANNEL_ID,
+      text: '',
+      blocks: [
+        slackblocks.header(
+          slackblocks.plaintext('run-custom-job stage update')
+        ),
+        {
+          elements: [
+            slackblocks.markdown('❌ *dry-run*'),
+            slackblocks.markdown(
+              '<https://deploy.getsentry.net/go/pipelines/run-custom-job/20/dry-run/1|Failed>'
+            ),
+          ],
+        },
+        slackblocks.divider(),
+        slackblocks.context(
+          slackblocks.markdown(
+            `cc'ing the user who started this deployment: <@GoCD_Slack_User>`
+          )
+        ),
+      ],
+    });
+    expect(postCalls[3][0]).toMatchObject({
+      text: 'GoCD deployment started by <@GoCD_Slack_User>',
+      channel: FEED_DEPLOY_CHANNEL_ID,
+      attachments: [
+        {
+          color: Color.OFF_WHITE_TOO,
+          blocks: [
+            slackblocks.section(
+              slackblocks.markdown('*sentryio/run-custom-job*')
+            ),
+            {
+              elements: [
+                slackblocks.markdown('Deploying'),
+                slackblocks.markdown(
+                  '<https://github.com/getsentry/getsentry/commits/2b0034becc4ab26b985f4c1a08ab068f153c274c|getsentry@2b0034becc4a>'
+                ),
+              ],
+            },
+            slackblocks.divider(),
+            {
+              elements: [
+                slackblocks.markdown('⏳ *checks*'),
+                slackblocks.markdown(
+                  '<https://deploy.getsentry.net/go/pipelines/run-custom-job/20/checks/1|In progress>'
+                ),
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   function sortMessages(ao, bo) {
-    const a = ao[0].channel;
-    const b = bo[0].channel;
-    if (a < b) {
+    const aChannel = ao.channel ?? ao[0].channel;
+    const bChannel = bo.channel ?? bo[0].channel;
+    if (aChannel < bChannel) {
       return 1;
     }
-    if (a > b) {
+    if (aChannel > bChannel) {
       return -1;
     }
     return 0;

--- a/src/brain/notifyOnGoCDStageEvent/index.test.ts
+++ b/src/brain/notifyOnGoCDStageEvent/index.test.ts
@@ -251,7 +251,7 @@ describe('notifyOnGoCDStageEvent', function () {
     expect(slackMessages).toHaveLength(1);
     expect(slackMessages[0]).toMatchObject({
       refId: HEAD_SHA,
-      channel: 'channel_id',
+      channel: 'U789123',
       ts: '1234123.123',
       context: {
         target: 'U789123',
@@ -310,7 +310,7 @@ describe('notifyOnGoCDStageEvent', function () {
             "color": "#E7E1EC",
           },
         ],
-        "channel": "channel_id",
+        "channel": "U789123",
         "text": "Your commit getsentry@<https://github.com/getsentry/getsentry/commits/${HEAD_SHA}|${HEAD_SHA}> ${INPROGRESS_MSG}",
         "ts": "1234123.123",
       }
@@ -374,7 +374,7 @@ describe('notifyOnGoCDStageEvent', function () {
             "color": "#E7E1EC",
           },
         ],
-        "channel": "channel_id",
+        "channel": "U789123",
         "text": "Your commit getsentry@<https://github.com/getsentry/getsentry/commits/${HEAD_SHA}|${HEAD_SHA}> is being deployed",
         "ts": "1234123.123",
       }
@@ -440,7 +440,7 @@ describe('notifyOnGoCDStageEvent', function () {
             "color": "#E7E1EC",
           },
         ],
-        "channel": "channel_id",
+        "channel": "U789123",
         "text": "Your commit getsentry@<https://github.com/getsentry/getsentry/commits/${HEAD_SHA}|${HEAD_SHA}> is being deployed",
         "ts": "1234123.123",
       }
@@ -473,7 +473,7 @@ describe('notifyOnGoCDStageEvent', function () {
     expect(bolt.client.chat.postMessage.mock.calls[0][0])
       .toMatchInlineSnapshot(`
       Object {
-        "channel": "channel_id",
+        "channel": "U789123",
         "text": "Your commit has been deployed. *Note* This message from Sentaur is now deprecated as this feature is now native to Sentry. Please <https://sentry.io/settings/account/notifications/deploy/|configure your Sentry deploy notifications here> to turn on Slack deployment notifications",
         "thread_ts": "1234123.123",
       }
@@ -507,7 +507,7 @@ describe('notifyOnGoCDStageEvent', function () {
     expect(slackMessages).toHaveLength(1);
     expect(slackMessages[0]).toMatchObject({
       refId: HEAD_SHA,
-      channel: 'channel_id',
+      channel: 'U789123',
       ts: '1234123.123',
       context: {
         target: 'U789123',
@@ -566,7 +566,7 @@ describe('notifyOnGoCDStageEvent', function () {
             "color": "#E7E1EC",
           },
         ],
-        "channel": "channel_id",
+        "channel": "U789123",
         "text": "Your commit getsentry@<https://github.com/getsentry/getsentry/commits/${HEAD_SHA}|${HEAD_SHA}> ${INPROGRESS_MSG}",
         "ts": "1234123.123",
       }
@@ -641,7 +641,7 @@ describe('notifyOnGoCDStageEvent', function () {
             "color": "#F55459",
           },
         ],
-        "channel": "channel_id",
+        "channel": "U789123",
         "text": "Your commit getsentry@<https://github.com/getsentry/getsentry/commits/${HEAD_SHA}|${HEAD_SHA}> failed to deploy",
         "ts": "1234123.123",
       }

--- a/src/brain/pleaseDeployNotifier/index.test.ts
+++ b/src/brain/pleaseDeployNotifier/index.test.ts
@@ -262,7 +262,7 @@ describe('pleaseDeployNotifier', function () {
 
     expect(await db('slack_messages').first('*')).toMatchObject({
       refId: '6d225cb77225ac655d817a7551a26fff85090fe6',
-      channel: 'channel_id',
+      channel: 'U789123',
       ts: '1234123.123',
       context: {
         status: 'undeployed',
@@ -927,7 +927,7 @@ describe('pleaseDeployNotifier', function () {
 
     expect(await db('slack_messages').first('*')).toMatchObject({
       refId: '6d225cb77225ac655d817a7551a26fff85090fe6',
-      channel: 'channel_id',
+      channel: 'U789123',
       ts: '1234123.123',
       context: {
         status: 'undeployed',
@@ -1082,7 +1082,7 @@ describe('pleaseDeployNotifier', function () {
 
     expect(await db('slack_messages').first('*')).toMatchObject({
       refId: '6d225cb77225ac655d817a7551a26fff85090fe6',
-      channel: 'channel_id',
+      channel: 'U789123',
       ts: '1234123.123',
       context: {
         status: 'undeployed',
@@ -1262,7 +1262,7 @@ Remove "always()" from GHA workflows`,
 
     expect(await db('slack_messages').first('*')).toMatchObject({
       refId: '6d225cb77225ac655d817a7551a26fff85090fe6',
-      channel: 'channel_id',
+      channel: 'U789123',
       ts: '1234123.123',
       context: {
         status: 'undeployed',
@@ -1442,7 +1442,7 @@ Remove "always()" from GHA workflows`,
 
     expect(await db('slack_messages').first('*')).toMatchObject({
       refId: '6d225cb77225ac655d817a7551a26fff85090fe6',
-      channel: 'channel_id',
+      channel: 'U789123',
       ts: '1234123.123',
       context: {
         status: 'undeployed',
@@ -1617,7 +1617,7 @@ Remove "always()" from GHA workflows`,
 
     expect(await db('slack_messages').first('*')).toMatchObject({
       refId: '6d225cb77225ac655d817a7551a26fff85090fe6',
-      channel: 'channel_id',
+      channel: 'U789123',
       ts: '1234123.123',
       context: {
         status: 'undeployed',
@@ -1751,7 +1751,7 @@ Remove "always()" from GHA workflows`,
 
     expect(await db('slack_messages').first('*')).toMatchObject({
       refId: '333333',
-      channel: 'channel_id',
+      channel: 'U789123',
       ts: '1234123.123',
       context: {
         status: 'undeployed',
@@ -1933,7 +1933,7 @@ Remove "always()" from GHA workflows`,
 
     expect(await db('slack_messages').first('*')).toMatchObject({
       refId: '333333',
-      channel: 'channel_id',
+      channel: 'U789123',
       ts: '1234123.123',
       context: {
         status: 'undeployed',
@@ -2115,7 +2115,7 @@ Remove "always()" from GHA workflows`,
 
     expect(await db('slack_messages').first('*')).toMatchObject({
       refId: '333333',
-      channel: 'channel_id',
+      channel: 'U789123',
       ts: '1234123.123',
       context: {
         status: 'undeployed',

--- a/src/brain/requiredChecks/index.test.ts
+++ b/src/brain/requiredChecks/index.test.ts
@@ -273,7 +273,7 @@ describe('requiredChecks', function () {
     // Threaded message with job statuses
     expect(postMessage).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        channel: 'channel_id',
+        channel: REQUIRED_CHECK_CHANNEL,
         thread_ts: '1234123.123',
       })
     );
@@ -284,7 +284,7 @@ describe('requiredChecks', function () {
 
     expect(await db('slack_messages').first('*')).toMatchObject({
       refId: '6d225cb77225ac655d817a7551a26fff85090fe6',
-      channel: 'channel_id',
+      channel: REQUIRED_CHECK_CHANNEL,
       ts: '1234123.123',
       context: {
         status: 'failure',
@@ -523,7 +523,7 @@ describe('requiredChecks', function () {
     // Threaded message with job statuses
     expect(postMessage).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        channel: 'channel_id',
+        channel: REQUIRED_CHECK_CHANNEL,
         thread_ts: '1234123.123',
       })
     );
@@ -780,14 +780,14 @@ describe('requiredChecks', function () {
     // Threaded message with job statuses
     expect(postMessage).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        channel: 'channel_id',
+        channel: REQUIRED_CHECK_CHANNEL,
         thread_ts: '1234123.123',
       })
     );
 
     expect(await db('slack_messages').first('*')).toMatchObject({
       refId: '6d225cb77225ac655d817a7551a26fff85090fe6',
-      channel: 'channel_id',
+      channel: REQUIRED_CHECK_CHANNEL,
       ts: '1234123.123',
       context: {
         status: 'failure',
@@ -853,7 +853,7 @@ describe('requiredChecks', function () {
           color: '#33BF9E',
         },
       ]),
-      channel: 'channel_id',
+      channel: REQUIRED_CHECK_CHANNEL,
       ts: '1234123.123',
     });
 

--- a/src/brain/typescript/index.test.ts
+++ b/src/brain/typescript/index.test.ts
@@ -79,7 +79,7 @@ describe('slack app', function () {
             "type": "section",
           },
         ],
-        "channel": "channel_id",
+        "channel": "G018X8Y9B1N",
         "text": "TypeScript progress: 50% completed, 10 files remaining",
         "ts": "1234123.123",
       }


### PR DESCRIPTION
Updates Slack message functionality on GoCD pipeline updates to produce replies (in thread) for stage updates if required. Mocks and tests have been updated.

Tests:
- `yarn test gocdSlackFeeds/index.test.ts`
- `yarn test gocdSlackFeeds/deployFeed.test.ts`