### PR TITLE
fix(gocd-job-runner): Fixing approved by to check if valid sentry email

### DIFF
--- a/src/brain/gocdSlackFeeds/index.ts
+++ b/src/brain/gocdSlackFeeds/index.ts
@@ -26,6 +26,7 @@ import { SlackMessage } from '@/config/slackMessage';
 import { GoCDPipeline, GoCDResponse } from '@/types';
 import { filterNulls } from '@/utils/arrays';
 import { getBaseAndHeadCommit } from '@/utils/gocdHelpers';
+import { isSentryEmail } from '@/utils/isSentryEmail';
 
 import { DeployFeed } from './deployFeed';
 import { stageBlock } from './stage';
@@ -382,6 +383,9 @@ const goCDCustomJobRunnerFeed = new DeployFeed({
     ];
 
     const approvedBy = pipeline.stage['approved-by'];
+    if (!isSentryEmail(approvedBy)) {
+      return blocks;
+    }
     const user = await getUser({ email: approvedBy });
     if (user?.slackUser) {
       blocks.push(divider());

--- a/src/utils/isSentryEmail.test.ts
+++ b/src/utils/isSentryEmail.test.ts
@@ -1,0 +1,14 @@
+import { isSentryEmail } from './isSentryEmail';
+
+describe('isSentryEmail', function () {
+  it('returns true for a Sentry email', () => {
+    expect(isSentryEmail('shashank.jarmale@sentry.io')).toBe(true);
+    expect(isSentryEmail('ian.woodard@sentry.io')).toBe(true);
+  });
+
+  it('returns false for non Sentry emails', () => {
+    expect(isSentryEmail('blah@example.com')).toBe(false);
+    expect(isSentryEmail('test@email.com')).toBe(false);
+    expect(isSentryEmail('changes')).toBe(false);
+  });
+});

--- a/src/utils/isSentryEmail.ts
+++ b/src/utils/isSentryEmail.ts
@@ -1,0 +1,3 @@
+export function isSentryEmail(email?: string): boolean {
+  return email !== undefined && email.endsWith('@sentry.io');
+}

--- a/src/utils/isSentrySlackUser.ts
+++ b/src/utils/isSentrySlackUser.ts
@@ -1,3 +1,5 @@
+import { isSentryEmail } from './isSentryEmail';
+
 // This is incomplete
 type SlackUser = {
   id: string;
@@ -19,7 +21,7 @@ type SlackUser = {
  */
 export function isSentrySlackUser(user: SlackUser) {
   return (
-    user.profile?.email?.endsWith('@sentry.io') &&
+    isSentryEmail(user.profile.email) &&
     !(
       // Via Slack:
       // Since you're using SSO, the email isn't actually confirmed since the login


### PR DESCRIPTION
Added a check for the gocd-job-runner's deployFeed to ensure we only try to cc a user if the approvedBy is a valid Sentry email.