### PR TITLE
fix(tests): Cleaning up gocdHelpers and tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,4 +16,5 @@
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "terminal.integrated.shellArgs.linux": ["-l"],
   "terminal.integrated.shellArgs.osx": ["-l"],
+  "jest.runMode": "on-demand",
 }

--- a/src/utils/gocdHelpers.ts
+++ b/src/utils/gocdHelpers.ts
@@ -91,12 +91,15 @@ export function getProgressColor(pipeline: GoCDPipeline) {
 }
 
 export function firstGitMaterialSHA(
-  deploy: DBGoCDDeployment | undefined
+  deploy?: Pick<DBGoCDDeployment, 'pipeline_build_cause'>
 ): string | null {
-  if (!deploy) {
+  if (deploy === undefined) {
     return null;
   }
-  if (deploy.pipeline_build_cause.length === 0) {
+  if (
+    deploy.pipeline_build_cause === undefined ||
+    deploy.pipeline_build_cause.length === 0
+  ) {
     return null;
   }
   for (const bc of deploy.pipeline_build_cause) {
@@ -112,11 +115,11 @@ export function firstGitMaterialSHA(
 }
 
 export function filterBuildCauses(
-  pipeline: GoCDPipeline,
+  pipeline: Pick<GoCDPipeline, 'build-cause'>,
   type: GoCDBuildType
 ): Array<GoCDBuildCause> {
   const buildCauses = pipeline['build-cause'];
-  if (!buildCauses || buildCauses.length === 0) {
+  if (buildCauses.length === 0) {
     return [];
   }
 
@@ -135,7 +138,7 @@ export function filterBuildCauses(
 }
 
 export async function getBaseAndHeadCommit(
-  pipeline: GoCDPipeline
+  pipeline: Pick<GoCDPipeline, 'build-cause' | 'group' | 'name'>
 ): Promise<[string | null, string | null]> {
   const buildCauses = filterBuildCauses(pipeline, 'git');
   if (buildCauses.length === 0) {


### PR DESCRIPTION
Updated gocdHelpers to use more specific types (using Typescript's Pick operator) to make mocking data easier. Fixed some but not all issues with the gocdHelpers tests. The last one is to fix the typing for the "git-configurations" which is required currently, but doesn't exist when the material type is "pipeline" so it shouldn't be in that case. However, this does put us in a better state than before.
(Also updating vscode settings to only run tests "on-demand")