### PR TITLE
fix(tests): Fixing the typing of more tests

### DIFF
--- a/src/brain/apis/indext.test.ts
+++ b/src/brain/apis/indext.test.ts
@@ -1,7 +1,10 @@
 import { createSlackAppMention } from '@test/utils/createSlackAppMention';
 
 import { buildServer } from '@/buildServer';
-import { bolt } from '@api/slack';
+import { bolt as originalBolt } from '@api/slack';
+const bolt = originalBolt as unknown as MockedSlackAPI;
+
+import { MockedSlackAPI } from '@test/utils/testTypes';
 
 import * as getAPIsStatsMessage from './getStatsMessage';
 import { apis } from '.';

--- a/src/brain/apis/indext.test.ts
+++ b/src/brain/apis/indext.test.ts
@@ -1,10 +1,8 @@
 import { createSlackAppMention } from '@test/utils/createSlackAppMention';
+import { MockedBolt } from '@test/utils/testTypes';
 
 import { buildServer } from '@/buildServer';
 import { bolt as originalBolt } from '@api/slack';
-const bolt = originalBolt as unknown as MockedSlackAPI;
-
-import { MockedSlackAPI } from '@test/utils/testTypes';
 
 import * as getAPIsStatsMessage from './getStatsMessage';
 import { apis } from '.';
@@ -14,6 +12,7 @@ jest.mock('@api/slack');
 
 describe('slack app', function () {
   let fastify, getStatsMessageSpy, postMessageSpy;
+  const bolt = originalBolt as unknown as MockedBolt;
 
   beforeAll(() => {
     getStatsMessageSpy = jest.spyOn(getAPIsStatsMessage, 'getStatsMessage');

--- a/src/brain/ghaCancel/index.test.ts
+++ b/src/brain/ghaCancel/index.test.ts
@@ -1,4 +1,5 @@
 import { createSlackAppMention } from '@test/utils/createSlackAppMention';
+import { MockedGitHubAPI } from '@test/utils/testTypes';
 
 import { buildServer } from '@/buildServer';
 import { GETSENTRY_ORG } from '@/config';
@@ -9,7 +10,7 @@ import { ghaCancel } from '.';
 
 describe('gha-test', function () {
   let fastify;
-  const org = GETSENTRY_ORG;
+  const org = GETSENTRY_ORG as unknown as { api: MockedGitHubAPI };
 
   beforeAll(async function () {
     await db.migrate.latest();

--- a/src/brain/githubMetrics/index.test.ts
+++ b/src/brain/githubMetrics/index.test.ts
@@ -20,6 +20,7 @@ jest.mock('@google-cloud/bigquery', () => ({
 import { Fastify } from '@types';
 
 import { createGitHubEvent } from '@test/utils/github';
+import { MockedGitHubAPI } from '@test/utils/testTypes';
 
 import { buildServer } from '@/buildServer';
 import { DRY_RUN, GETSENTRY_ORG } from '@/config';
@@ -43,7 +44,7 @@ const SCHEMA = Object.entries(dbFunctions.TARGETS.oss.schema).map(
 
 describe('github webhook', function () {
   let fastify: Fastify;
-  const org = GETSENTRY_ORG;
+  const org = GETSENTRY_ORG as unknown as { api: MockedGitHubAPI };
 
   beforeEach(async function () {
     fastify = await buildServer(false);

--- a/src/brain/gocdConsecutiveUnsuccessfulAlert/index.test.ts
+++ b/src/brain/gocdConsecutiveUnsuccessfulAlert/index.test.ts
@@ -14,7 +14,10 @@ import {
   GOCD_SENTRYIO_FE_PIPELINE_NAME,
 } from '@/config';
 import { Fastify } from '@/types';
-import { bolt } from '@api/slack';
+import { bolt as originalBolt } from '@api/slack';
+const bolt = originalBolt as unknown as MockedSlackAPI;
+import { MockedSlackAPI } from '@test/utils/testTypes';
+
 import { db } from '@utils/db';
 
 import { CONSECUTIVE_UNSUCCESSFUL_DEPLOYS_LIMIT } from './consecutiveUnsuccessfulDeploysAlert';

--- a/src/brain/gocdConsecutiveUnsuccessfulAlert/index.test.ts
+++ b/src/brain/gocdConsecutiveUnsuccessfulAlert/index.test.ts
@@ -1,6 +1,7 @@
 import merge from 'lodash.merge';
 
 import payload from '@test/payloads/gocd/gocd-stage-building.json';
+import { MockedBolt } from '@test/utils/testTypes';
 
 import * as slackblocks from '@/blocks/slackBlocks';
 import { DB_TABLE_STAGES } from '@/brain/saveGoCDStageEvents';
@@ -15,9 +16,6 @@ import {
 } from '@/config';
 import { Fastify } from '@/types';
 import { bolt as originalBolt } from '@api/slack';
-const bolt = originalBolt as unknown as MockedSlackAPI;
-import { MockedSlackAPI } from '@test/utils/testTypes';
-
 import { db } from '@utils/db';
 
 import { CONSECUTIVE_UNSUCCESSFUL_DEPLOYS_LIMIT } from './consecutiveUnsuccessfulDeploysAlert';
@@ -27,6 +25,7 @@ jest.mock('@api/getUser');
 
 describe('gocdConsecutiveUnsuccessfulAlerts', function () {
   let fastify: Fastify;
+  const bolt = originalBolt as unknown as MockedBolt;
 
   beforeAll(async function () {
     await db.migrate.latest();

--- a/src/brain/gocdDataDog/deployDatadogEvents.test.ts
+++ b/src/brain/gocdDataDog/deployDatadogEvents.test.ts
@@ -7,6 +7,7 @@ import gocdStateChecksPayload from '@test/payloads/gocd/gocd-stage-checks.json';
 import gocdFrontendBuilding from '@test/payloads/gocd/gocd-stage-deploy-frontend.json';
 import testEmptyPayload from '@test/payloads/sentry-options/testEmptyPayload.json';
 import { createGoCDRequest } from '@test/utils/createGoCDRequest';
+import { MockedGitHubAPI } from '@test/utils/testTypes';
 
 import { buildServer } from '@/buildServer';
 import { DATADOG_API_INSTANCE, GETSENTRY_ORG } from '@/config';
@@ -151,7 +152,7 @@ describe('GocdDatadogEvents', () => {
     });
 
     it('post message with commits in deploy link for getsentry', async () => {
-      const org = GETSENTRY_ORG;
+      const org = GETSENTRY_ORG as unknown as { api: MockedGitHubAPI };
 
       org.api.repos.getContent.mockImplementation((args) => {
         if (args.owner !== 'getsentry') {

--- a/src/brain/gocdNoDeploysAlert/index.test.ts
+++ b/src/brain/gocdNoDeploysAlert/index.test.ts
@@ -1,6 +1,7 @@
 import merge from 'lodash.merge';
 
 import payload from '@test/payloads/gocd/gocd-stage-building.json';
+import { MockedBolt } from '@test/utils/testTypes';
 
 import * as slackblocks from '@/blocks/slackBlocks';
 import { DB_TABLE_STAGES } from '@/brain/saveGoCDStageEvents';
@@ -12,9 +13,6 @@ import {
 } from '@/config';
 import { Fastify } from '@/types';
 import { bolt as originalBolt } from '@api/slack';
-const bolt = originalBolt as unknown as MockedSlackAPI;
-import { MockedSlackAPI } from '@test/utils/testTypes';
-
 import { db } from '@utils/db';
 
 import { DEPLOYS_FAILING_LIMIT_MS, gocdNoDeploysAlert, handler } from '.';
@@ -23,6 +21,7 @@ jest.mock('@api/getUser');
 
 describe('gocdSlackFeeds', function () {
   let fastify: Fastify;
+  const bolt = originalBolt as unknown as MockedBolt;
 
   beforeAll(async function () {
     await db.migrate.latest();

--- a/src/brain/gocdNoDeploysAlert/index.test.ts
+++ b/src/brain/gocdNoDeploysAlert/index.test.ts
@@ -11,7 +11,10 @@ import {
   GOCD_SENTRYIO_BE_PIPELINE_NAME,
 } from '@/config';
 import { Fastify } from '@/types';
-import { bolt } from '@api/slack';
+import { bolt as originalBolt } from '@api/slack';
+const bolt = originalBolt as unknown as MockedSlackAPI;
+import { MockedSlackAPI } from '@test/utils/testTypes';
+
 import { db } from '@utils/db';
 
 import { DEPLOYS_FAILING_LIMIT_MS, gocdNoDeploysAlert, handler } from '.';

--- a/src/brain/gocdSlackFeeds/deployFeed.test.ts
+++ b/src/brain/gocdSlackFeeds/deployFeed.test.ts
@@ -6,7 +6,10 @@ import * as slackblocks from '@/blocks/slackBlocks';
 import { Color, GETSENTRY_ORG } from '@/config';
 import { SlackMessage } from '@/config/slackMessage';
 import { GoCDPipeline } from '@/types';
-import { bolt } from '@api/slack';
+import { bolt as originalBolt } from '@api/slack';
+const bolt = originalBolt as unknown as MockedSlackAPI;
+import { MockedSlackAPI } from '@test/utils/testTypes';
+
 import { db } from '@utils/db';
 
 import { DeployFeed } from './deployFeed';

--- a/src/brain/gocdSlackFeeds/deployFeed.test.ts
+++ b/src/brain/gocdSlackFeeds/deployFeed.test.ts
@@ -1,15 +1,13 @@
 import merge from 'lodash.merge';
 
 import payload from '@test/payloads/gocd/gocd-stage-building.json';
+import { MockedBolt } from '@test/utils/testTypes';
 
 import * as slackblocks from '@/blocks/slackBlocks';
 import { Color, GETSENTRY_ORG } from '@/config';
 import { SlackMessage } from '@/config/slackMessage';
 import { GoCDPipeline } from '@/types';
 import { bolt as originalBolt } from '@api/slack';
-const bolt = originalBolt as unknown as MockedSlackAPI;
-import { MockedSlackAPI } from '@test/utils/testTypes';
-
 import { db } from '@utils/db';
 
 import { DeployFeed } from './deployFeed';
@@ -18,6 +16,7 @@ jest.mock('@api/getUser');
 
 describe('DeployFeed', () => {
   const org = GETSENTRY_ORG;
+  const bolt = originalBolt as unknown as MockedBolt;
 
   beforeAll(async function () {
     await db.migrate.latest();

--- a/src/brain/gocdSlackFeeds/index.test.ts
+++ b/src/brain/gocdSlackFeeds/index.test.ts
@@ -1,6 +1,7 @@
 import merge from 'lodash.merge';
 
 import payload from '@test/payloads/gocd/gocd-stage-building.json';
+import { MockedGitHubAPI } from '@test/utils/testTypes';
 
 import * as slackblocks from '@/blocks/slackBlocks';
 import { buildServer } from '@/buildServer';
@@ -31,7 +32,7 @@ jest.mock('@api/getUser');
 
 describe('gocdSlackFeeds', function () {
   let fastify: Fastify;
-  const org = GETSENTRY_ORG;
+  const org = GETSENTRY_ORG as unknown as { api: MockedGitHubAPI };
 
   beforeAll(async function () {
     await db.migrate.latest();

--- a/src/brain/notifyOnGoCDStageEvent/index.test.ts
+++ b/src/brain/notifyOnGoCDStageEvent/index.test.ts
@@ -2,6 +2,7 @@ import merge from 'lodash.merge';
 
 import payload from '@test/payloads/gocd/gocd-stage-building.json';
 import { createGitHubEvent } from '@test/utils/github';
+import { MockedGitHubAPI } from '@test/utils/testTypes';
 
 import { buildServer } from '@/buildServer';
 import {
@@ -26,7 +27,7 @@ const HEAD_SHA = '982345';
 describe('notifyOnGoCDStageEvent', function () {
   let fastify: Fastify;
   let gocdPayload;
-  const org = GETSENTRY_ORG;
+  const org = GETSENTRY_ORG as unknown as { api: MockedGitHubAPI };
 
   beforeAll(async function () {
     await db.migrate.latest();

--- a/src/brain/pleaseDeployNotifier/index.test.ts
+++ b/src/brain/pleaseDeployNotifier/index.test.ts
@@ -27,9 +27,20 @@ import { FINAL_STAGE_NAMES } from '../../utils/gocdHelpers';
 import * as actions from './actionViewUndeployedCommits';
 import { pleaseDeployNotifier } from '.';
 
+type MockedGitHubAPI = {
+  checks: {
+    listForRef: jest.Mock;
+  };
+  repos: {
+    getCommit: jest.Mock;
+    compareCommits: jest.Mock;
+  };
+  paginate: jest.Mock;
+};
+
 describe('pleaseDeployNotifier', function () {
   let fastify: Fastify;
-  const org = GETSENTRY_ORG;
+  const org = GETSENTRY_ORG as unknown as { api: MockedGitHubAPI };
 
   beforeAll(async function () {
     await db.migrate.latest();
@@ -1628,7 +1639,6 @@ Remove "always()" from GHA workflows`,
   it('tells user GoCD frontend deploy is in progress', async function () {
     await queueCommitsForDeploy([
       {
-        head_sha: '333333',
         sha: '333333',
       },
     ]);
@@ -1762,7 +1772,6 @@ Remove "always()" from GHA workflows`,
   it('asks user to deploy backend while frontend deploy is in progress', async function () {
     await queueCommitsForDeploy([
       {
-        head_sha: '333333',
         sha: '333333',
       },
     ]);
@@ -1944,7 +1953,6 @@ Remove "always()" from GHA workflows`,
   it('asks user to deploy fullstack change', async function () {
     await queueCommitsForDeploy([
       {
-        head_sha: '333333',
         sha: '333333',
       },
     ]);

--- a/src/brain/pleaseDeployNotifier/index.test.ts
+++ b/src/brain/pleaseDeployNotifier/index.test.ts
@@ -2,6 +2,7 @@ import merge from 'lodash.merge';
 
 import { createSlackRequest } from '@test/utils/createSlackRequest';
 import { createGitHubEvent } from '@test/utils/github';
+import { MockedGitHubAPI } from '@test/utils/testTypes';
 
 import {
   DB_TABLE_MATERIALS,
@@ -18,25 +19,16 @@ import {
 } from '@/config';
 import { Fastify } from '@/types';
 import { queueCommitsForDeploy } from '@/utils/db/queueCommitsForDeploy';
-import { bolt } from '@api/slack';
+import { bolt as originalBolt } from '@api/slack';
+const bolt = originalBolt as unknown as MockedSlackAPI;
 import { db } from '@utils/db';
 import { getLastGetSentryGoCDDeploy } from '@utils/db/getLatestDeploy';
 
+import { MockedSlackAPI } from '../../../test/utils/testTypes';
 import { FINAL_STAGE_NAMES } from '../../utils/gocdHelpers';
 
 import * as actions from './actionViewUndeployedCommits';
 import { pleaseDeployNotifier } from '.';
-
-type MockedGitHubAPI = {
-  checks: {
-    listForRef: jest.Mock;
-  };
-  repos: {
-    getCommit: jest.Mock;
-    compareCommits: jest.Mock;
-  };
-  paginate: jest.Mock;
-};
 
 describe('pleaseDeployNotifier', function () {
   let fastify: Fastify;

--- a/src/brain/pleaseDeployNotifier/index.test.ts
+++ b/src/brain/pleaseDeployNotifier/index.test.ts
@@ -20,11 +20,10 @@ import {
 import { Fastify } from '@/types';
 import { queueCommitsForDeploy } from '@/utils/db/queueCommitsForDeploy';
 import { bolt as originalBolt } from '@api/slack';
-const bolt = originalBolt as unknown as MockedSlackAPI;
 import { db } from '@utils/db';
 import { getLastGetSentryGoCDDeploy } from '@utils/db/getLatestDeploy';
 
-import { MockedSlackAPI } from '../../../test/utils/testTypes';
+import { MockedBolt } from '../../../test/utils/testTypes';
 import { FINAL_STAGE_NAMES } from '../../utils/gocdHelpers';
 
 import * as actions from './actionViewUndeployedCommits';
@@ -33,6 +32,7 @@ import { pleaseDeployNotifier } from '.';
 describe('pleaseDeployNotifier', function () {
   let fastify: Fastify;
   const org = GETSENTRY_ORG as unknown as { api: MockedGitHubAPI };
+  const bolt = originalBolt as unknown as MockedBolt;
 
   beforeAll(async function () {
     await db.migrate.latest();

--- a/src/brain/requiredChecks/getAnnotations.test.ts
+++ b/src/brain/requiredChecks/getAnnotations.test.ts
@@ -1,9 +1,11 @@
 import { GETSENTRY_ORG } from '@/config';
 
+import { MockedGitHubAPI } from '../../../test/utils/testTypes';
+
 import { getAnnotations } from './getAnnotations';
 
 describe('getAnnotations', function () {
-  const org = GETSENTRY_ORG;
+  const org = GETSENTRY_ORG as unknown as { api: MockedGitHubAPI };
 
   beforeEach(function () {
     org.api.checks.listAnnotations.mockClear();

--- a/src/brain/requiredChecks/index.test.ts
+++ b/src/brain/requiredChecks/index.test.ts
@@ -18,6 +18,7 @@ jest.mock('@google-cloud/bigquery', () => ({
 import merge from 'lodash.merge';
 
 import { createGitHubEvent } from '@test/utils/github';
+import { MockedGitHubAPI } from '@test/utils/testTypes';
 
 import { buildServer } from '@/buildServer';
 import {
@@ -42,7 +43,7 @@ function tick(timeout = 10) {
 
 describe('requiredChecks', function () {
   let fastify: Fastify;
-  const org = GETSENTRY_ORG;
+  const org = GETSENTRY_ORG as unknown as { api: MockedGitHubAPI };
   const postMessage = bolt.client.chat.postMessage as jest.Mock;
   const updateMessage = bolt.client.chat.update as jest.Mock;
   const SCHEMA = Object.entries(TARGETS.brokenBuilds.schema).map(

--- a/src/utils/db/getDeployForQueuedCommit.test.ts
+++ b/src/utils/db/getDeployForQueuedCommit.test.ts
@@ -28,7 +28,6 @@ describe('getDeployForQueuedCommit', function () {
     it('return nothing for queued commit but no GoCD data', async function () {
       await queueCommitsForDeploy([
         {
-          head_sha: 'abc123',
           sha: 'abc123',
         },
       ]);
@@ -40,7 +39,6 @@ describe('getDeployForQueuedCommit', function () {
     it('return GoCD deploy', async function () {
       await queueCommitsForDeploy([
         {
-          head_sha: 'abc123',
           sha: 'abc123',
         },
       ]);

--- a/src/utils/db/getDeployForQueuedCommit.test.ts
+++ b/src/utils/db/getDeployForQueuedCommit.test.ts
@@ -97,7 +97,6 @@ describe('getDeployForQueuedCommit', function () {
 
         id: expect.any(Number),
         data: {
-          head_sha: 'abc123',
           sha: 'abc123',
         },
       });

--- a/src/utils/db/getDeployForQueuedCommit.test.ts
+++ b/src/utils/db/getDeployForQueuedCommit.test.ts
@@ -101,5 +101,120 @@ describe('getDeployForQueuedCommit', function () {
         },
       });
     });
+
+    it('return GoCD deploy with multiple commits', async function () {
+      await queueCommitsForDeploy([
+        {
+          sha: 'abc123',
+        },
+        {
+          sha: 'def456',
+        },
+      ]);
+
+      await db('gocd-stages').insert({
+        pipeline_id: 'pipeline-id-123',
+
+        pipeline_name: 'pipeline-name',
+        pipeline_counter: 2,
+        pipeline_group: 'pipeline-group',
+        pipeline_build_cause: '{}',
+
+        stage_name: 'stage-name',
+        stage_counter: 1,
+        stage_approval_type: '',
+        stage_approved_by: '',
+        stage_state: 'unknown',
+        stage_result: 'unknown',
+        stage_create_time: new Date('2022-10-26T17:57:53.000Z'),
+        stage_last_transition_time: new Date('2022-10-26T17:57:53.000Z'),
+        stage_jobs: '{}',
+      });
+
+      await db('gocd-stage-materials').insert([
+        {
+          stage_material_id: `123_github.com/example/example`,
+          pipeline_id: 'pipeline-id-123',
+          url: 'github.com/example/example',
+          branch: 'main',
+          revision: 'abc123',
+        },
+        {
+          stage_material_id: `456_github.com/example/example`,
+          pipeline_id: 'pipeline-id-123',
+          url: 'github.com/example/example',
+          branch: 'main',
+          revision: 'def456',
+        },
+      ]);
+
+      const gotNonHead = await getGoCDDeployForQueuedCommit(
+        'abc123',
+        'pipeline-name'
+      );
+      expect(gotNonHead).toEqual({
+        stage_material_id: `456_github.com/example/example`,
+        pipeline_id: 'pipeline-id-123',
+        url: 'github.com/example/example',
+        branch: 'main',
+        revision: 'def456',
+        head_sha: 'def456',
+        sha: 'abc123',
+
+        pipeline_name: 'pipeline-name',
+        pipeline_counter: 2,
+        pipeline_group: 'pipeline-group',
+        pipeline_build_cause: {},
+
+        stage_name: 'stage-name',
+        stage_counter: 1,
+        stage_approval_type: '',
+        stage_approved_by: '',
+        stage_state: 'unknown',
+        stage_result: 'unknown',
+        stage_create_time: new Date('2022-10-26T17:57:53.000Z'),
+        stage_last_transition_time: new Date('2022-10-26T17:57:53.000Z'),
+        stage_jobs: {},
+
+        id: expect.any(Number),
+        data: {
+          sha: 'abc123',
+        },
+      });
+
+      const gotHead = await getGoCDDeployForQueuedCommit(
+        'def456',
+        'pipeline-name'
+      );
+      expect(gotHead).toEqual({
+        stage_material_id: `456_github.com/example/example`,
+        pipeline_id: 'pipeline-id-123',
+        url: 'github.com/example/example',
+        branch: 'main',
+        revision: 'def456',
+        head_sha: 'def456',
+        sha: 'def456',
+
+        pipeline_name: 'pipeline-name',
+        pipeline_counter: 2,
+        pipeline_group: 'pipeline-group',
+        pipeline_build_cause: {},
+
+        stage_name: 'stage-name',
+        stage_counter: 1,
+        stage_approval_type: '',
+        stage_approved_by: '',
+        stage_state: 'unknown',
+        stage_result: 'unknown',
+        stage_create_time: new Date('2022-10-26T17:57:53.000Z'),
+        stage_last_transition_time: new Date('2022-10-26T17:57:53.000Z'),
+        stage_jobs: {},
+
+        id: expect.any(Number),
+        data: {
+          sha: 'def456',
+        },
+      });
+    });
   });
 });

--- a/src/utils/db/queueCommitsForDeploy.ts
+++ b/src/utils/db/queueCommitsForDeploy.ts
@@ -2,13 +2,13 @@ import { CompareCommits } from '@types';
 
 import { db } from '.';
 
+type CommitSha = Pick<CompareCommits['commits'][0], 'sha'>;
+
 /**
  * We want to save the list of commits that are currently queued to be deployed
  * so that we can later look up if it's queued given a sha
  */
-export async function queueCommitsForDeploy(
-  commits: CompareCommits['commits']
-) {
+export async function queueCommitsForDeploy(commits: CommitSha[]) {
   if (commits.length === 0) {
     return;
   }

--- a/test/utils/testTypes.ts
+++ b/test/utils/testTypes.ts
@@ -30,7 +30,7 @@ export type MockedGitHubAPI = {
 };
 
 // Mocked Slack API for Jest
-export type MockedSlackAPI = {
+export type MockedBolt = {
   client: {
     chat: {
       postMessage: jest.Mock;

--- a/test/utils/testTypes.ts
+++ b/test/utils/testTypes.ts
@@ -1,0 +1,45 @@
+// Mocked GitHub API for Jest
+export type MockedGitHubAPI = {
+  checks: {
+    listForRef: jest.Mock;
+    listAnnotations: jest.Mock;
+  };
+  repos: {
+    getCommit: jest.Mock;
+    compareCommits: jest.Mock;
+    getContent: jest.Mock;
+  };
+  paginate: jest.Mock;
+  pulls: {
+    get: jest.Mock;
+    list: jest.Mock;
+    merge: jest.Mock;
+    create: jest.Mock;
+    update: jest.Mock;
+  };
+  actions: {
+    listWorkflowRunsForRepo: jest.Mock;
+    cancelWorkflowRun: jest.Mock;
+  };
+  orgs: {
+    checkMembershipForUser: jest.Mock;
+  };
+  issues: {
+    createComment: jest.Mock;
+  };
+};
+
+// Mocked Slack API for Jest
+export type MockedSlackAPI = {
+  client: {
+    chat: {
+      postMessage: jest.Mock;
+      update: jest.Mock;
+    };
+    views: {
+      open: jest.Mock;
+      publish: jest.Mock;
+      update: jest.Mock;
+    };
+  };
+};


### PR DESCRIPTION
* Adding "better" typing for the mocked github api since we mock it here: https://github.com/getsentry/eng-pipes/blob/main/test/jest.setup.ts
* Made the typing for `queueCommitsForDeploy` more precise, making testing easier

There are still some linting/typing errors in these files, but there are less than there were before and they will be cleaned up in future PRs.