### PR TITLE
Modify loadBrain to use imports instead of dynamic path loading

### DIFF
--- a/src/utils/loadBrain.test.ts
+++ b/src/utils/loadBrain.test.ts
@@ -1,4 +1,4 @@
-import { getBrainModules, getExportedFunctions } from './loadBrain';
+import { getBrainModules, getExportedFunctions, loadBrain } from './loadBrain';
 
 jest.unmock('./loadBrain');
 
@@ -8,5 +8,12 @@ describe('loadBrain', function () {
     const fns = getExportedFunctions(modules);
 
     expect(new Set(modules)).toEqual(new Set(fns.map((f) => f.name)));
+  });
+  it('makes sure that every exported function in `brain/` is actually loaded', async function () {
+    const modules = await getBrainModules();
+    const fns = getExportedFunctions(modules);
+
+    const loadedFns = await loadBrain();
+    expect(new Set(loadedFns)).toEqual(new Set(fns.map((f) => f.name)));
   });
 });

--- a/src/utils/loadBrain.test.ts
+++ b/src/utils/loadBrain.test.ts
@@ -23,8 +23,7 @@ async function getBrainModules(dir: string = ROOT): Promise<string[]> {
       nestedDirs.forEach((nestedDir) => directories.add(nestedDir));
     } else if (
       !file.name.endsWith('.d.ts') &&
-      !file.name.endsWith('.map') &&
-      !file.name.endsWith('.md')
+      (file.name.endsWith('.ts') || file.name.endsWith('.js'))
     ) {
       directories.add(path.relative(ROOT, dir));
     }

--- a/src/utils/loadBrain.test.ts
+++ b/src/utils/loadBrain.test.ts
@@ -1,19 +1,96 @@
-import { getBrainModules, getExportedFunctions, loadBrain } from './loadBrain';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+import * as Sentry from '@sentry/node';
+
+import { loadBrain } from './loadBrain';
 
 jest.unmock('./loadBrain');
+const ROOT = path.join(__dirname, '../brain');
+
+/**
+ * This is only exported for test
+ */
+async function getBrainModules(dir: string = ROOT): Promise<string[]> {
+  // Read the directory contents
+  const files = await fs.readdir(dir, { withFileTypes: true });
+  const directories: Set<string> = new Set();
+
+  // Loop through each file or directory in the current directory
+  for (const file of files) {
+    if (file.isDirectory()) {
+      const nestedDirs = await getBrainModules(path.join(dir, file.name));
+      nestedDirs.forEach((nestedDir) => directories.add(nestedDir));
+    } else if (
+      !file.name.endsWith('.d.ts') &&
+      !file.name.endsWith('.map') &&
+      !file.name.endsWith('.md')
+    ) {
+      directories.add(path.relative(ROOT, dir));
+    }
+  }
+  return Array.from(directories);
+}
+
+/**
+ * This is only exported for test
+ * This function takes a list of relative paths to directories in brain
+ * and returns a list of exported functions from those directories
+ * which have the same name as the directory
+ */
+function getExportedFunctions(fileNames: string[]): Function[] {
+  return fileNames.flatMap((f) => {
+    try {
+      // Only return imported functions that match filename
+      // This is because we sometimes need to export other functions to test
+      const fileName = f.split('/').pop();
+      return (
+        Object.entries(require(path.join(ROOT, f)))
+          // @ts-ignore
+          .filter(([key]) => key === fileName)
+          .map(([, value]) => value)
+      );
+    } catch (e) {
+      const err = new Error(`Unable to load brain: ${f}`);
+      Sentry.captureException(err);
+      console.error(err);
+      return [];
+    }
+  }) as Function[];
+}
 
 describe('loadBrain', function () {
-  it('makes sure that for every file in `brain/`, we load at least one function from it', async function () {
-    const modules = await getBrainModules();
-    const fns = getExportedFunctions(modules);
-
-    expect(new Set(modules)).toEqual(new Set(fns.map((f) => f.name)));
-  });
   it('makes sure that every exported function in `brain/` is actually loaded', async function () {
     const modules = await getBrainModules();
     const fns = getExportedFunctions(modules);
 
     const loadedFns = await loadBrain();
     expect(new Set(loadedFns)).toEqual(new Set(fns.map((f) => f.name)));
+  });
+  it('makes sure that every loaded function is one of these ones', async function () {
+    const expected = [
+      'apis',
+      'appHome',
+      'ghaCancel',
+      'githubMetrics',
+      'gocdConsecutiveUnsuccessfulAlert',
+      'gocdDataDog',
+      'gocdNoDeploysAlert',
+      'gocdSlackFeeds',
+      'issueLabelHandler',
+      'issueNotifier',
+      'notificationPreferences',
+      'notifyOnGoCDStageEvent',
+      'pleaseDeployNotifier',
+      'projectsHandler',
+      'requiredChecks',
+      'saveGoCDStageEvents',
+      'syncSlackUsers',
+      'syncUserProfileChange',
+      'triggerPubSub',
+      'typescript',
+    ];
+    const loadedFns = await loadBrain();
+    expect(new Set(loadedFns)).toEqual(new Set(expected));
   });
 });

--- a/src/utils/loadBrain.ts
+++ b/src/utils/loadBrain.ts
@@ -3,40 +3,69 @@ import path from 'path';
 
 import * as Sentry from '@sentry/node';
 
+import { apis } from '@/brain/apis';
+import { appHome } from '@/brain/appHome';
+import { ghaCancel } from '@/brain/ghaCancel';
+import { githubMetrics } from '@/brain/githubMetrics';
+import { gocdConsecutiveUnsuccessfulAlert } from '@/brain/gocdConsecutiveUnsuccessfulAlert';
+import { gocdDataDog } from '@/brain/gocdDataDog';
+import { gocdNoDeploysAlert } from '@/brain/gocdNoDeploysAlert';
+import { gocdSlackFeeds } from '@/brain/gocdSlackFeeds';
+import { issueLabelHandler } from '@/brain/issueLabelHandler';
+import { issueNotifier } from '@/brain/issueNotifier';
+import { notificationPreferences } from '@/brain/notificationPreferences';
+import { notifyOnGoCDStageEvent } from '@/brain/notifyOnGoCDStageEvent';
+import { pleaseDeployNotifier } from '@/brain/pleaseDeployNotifier';
+import { projectsHandler } from '@/brain/projectsHandler';
+import { requiredChecks } from '@/brain/requiredChecks';
+import { saveGoCDStageEvents } from '@/brain/saveGoCDStageEvents';
+import { syncSlackUsers } from '@/brain/syncSlackUsers';
+import { syncUserProfileChange } from '@/brain/syncUserProfileChange';
+import { triggerPubSub } from '@/brain/triggerPubSub';
+import { typescript } from '@/brain/typescript';
+
 const ROOT = path.join(__dirname, '../brain');
 
 /**
- * Loads all modules in the root of `@/brain`
- *
- * Currently we only want to load the exported fn whose name matches the module name,
- * this is because we sometimes export functions only for testing.
+ * This is only exported for test
  */
-export async function loadBrain() {
-  const modules = getExportedFunctions(await getBrainModules());
-  modules.forEach((m) => m());
+export async function getBrainModules(dir: string = ROOT): Promise<string[]> {
+  // Read the directory contents
+  const files = await fs.readdir(dir, { withFileTypes: true });
+  const directories: Set<string> = new Set();
+
+  // Loop through each file or directory in the current directory
+  for (const file of files) {
+    if (file.isDirectory()) {
+      const nestedDirs = await getBrainModules(path.join(dir, file.name));
+      nestedDirs.forEach((nestedDir) => directories.add(nestedDir));
+    } else if (
+      !file.name.endsWith('.d.ts') &&
+      !file.name.endsWith('.map') &&
+      !file.name.endsWith('.md')
+    ) {
+      directories.add(path.relative(ROOT, dir));
+    }
+  }
+  return Array.from(directories);
 }
 
 /**
  * This is only exported for test
+ * This function takes a list of relative paths to directories in brain
+ * and returns a list of exported functions from those directories
+ * which have the same name as the directory
  */
-export async function getBrainModules() {
-  return (await fs.readdir(ROOT)).filter(
-    (f) => !f.endsWith('.d.ts') && !f.endsWith('.map') && !f.endsWith('.md')
-  );
-}
-
-/**
- * This is only exported for test
- */
-export function getExportedFunctions(fileNames: string[]) {
+export function getExportedFunctions(fileNames: string[]): Function[] {
   return fileNames.flatMap((f) => {
     try {
       // Only return imported functions that match filename
       // This is because we sometimes need to export other functions to test
+      const fileName = f.split('/').pop();
       return (
         Object.entries(require(path.join(ROOT, f)))
           // @ts-ignore
-          .filter(([key]) => key === f)
+          .filter(([key]) => key === fileName)
           .map(([, value]) => value)
       );
     } catch (e) {
@@ -46,4 +75,39 @@ export function getExportedFunctions(fileNames: string[]) {
       return [];
     }
   }) as Function[];
+}
+
+/**
+ * Loads all functions in `@/brain`
+ *
+ * Currently we only want to load the exported fn whose name matches the module name,
+ * this is because we sometimes export functions only for testing.
+ */
+export async function loadBrain(): Promise<string[]> {
+  const loadFunctions = [
+    apis,
+    appHome,
+    ghaCancel,
+    githubMetrics,
+    gocdConsecutiveUnsuccessfulAlert,
+    gocdDataDog,
+    gocdNoDeploysAlert,
+    gocdSlackFeeds,
+    issueLabelHandler,
+    issueNotifier,
+    notificationPreferences,
+    notifyOnGoCDStageEvent,
+    pleaseDeployNotifier,
+    projectsHandler,
+    requiredChecks,
+    saveGoCDStageEvents,
+    syncSlackUsers,
+    syncUserProfileChange,
+    triggerPubSub,
+    typescript,
+  ];
+  loadFunctions.forEach((f) => f());
+
+  // For test purposes, return the names of the functions loaded
+  return loadFunctions.map((f) => f.name);
 }

--- a/src/utils/loadBrain.ts
+++ b/src/utils/loadBrain.ts
@@ -1,8 +1,3 @@
-import { promises as fs } from 'fs';
-import path from 'path';
-
-import * as Sentry from '@sentry/node';
-
 import { apis } from '@/brain/apis';
 import { appHome } from '@/brain/appHome';
 import { ghaCancel } from '@/brain/ghaCancel';
@@ -23,59 +18,6 @@ import { syncSlackUsers } from '@/brain/syncSlackUsers';
 import { syncUserProfileChange } from '@/brain/syncUserProfileChange';
 import { triggerPubSub } from '@/brain/triggerPubSub';
 import { typescript } from '@/brain/typescript';
-
-const ROOT = path.join(__dirname, '../brain');
-
-/**
- * This is only exported for test
- */
-export async function getBrainModules(dir: string = ROOT): Promise<string[]> {
-  // Read the directory contents
-  const files = await fs.readdir(dir, { withFileTypes: true });
-  const directories: Set<string> = new Set();
-
-  // Loop through each file or directory in the current directory
-  for (const file of files) {
-    if (file.isDirectory()) {
-      const nestedDirs = await getBrainModules(path.join(dir, file.name));
-      nestedDirs.forEach((nestedDir) => directories.add(nestedDir));
-    } else if (
-      !file.name.endsWith('.d.ts') &&
-      !file.name.endsWith('.map') &&
-      !file.name.endsWith('.md')
-    ) {
-      directories.add(path.relative(ROOT, dir));
-    }
-  }
-  return Array.from(directories);
-}
-
-/**
- * This is only exported for test
- * This function takes a list of relative paths to directories in brain
- * and returns a list of exported functions from those directories
- * which have the same name as the directory
- */
-export function getExportedFunctions(fileNames: string[]): Function[] {
-  return fileNames.flatMap((f) => {
-    try {
-      // Only return imported functions that match filename
-      // This is because we sometimes need to export other functions to test
-      const fileName = f.split('/').pop();
-      return (
-        Object.entries(require(path.join(ROOT, f)))
-          // @ts-ignore
-          .filter(([key]) => key === fileName)
-          .map(([, value]) => value)
-      );
-    } catch (e) {
-      const err = new Error(`Unable to load brain: ${f}`);
-      Sentry.captureException(err);
-      console.error(err);
-      return [];
-    }
-  }) as Function[];
-}
 
 /**
  * Loads all functions in `@/brain`


### PR DESCRIPTION
Per the discussion, this PR switches loadBrain to load handlers based off of imports & exported functions rather than based off of modules in the `brain/` path.