### PR TITLE
Remove path module loading from webhooks and use imports

### DIFF
--- a/src/buildServer.ts
+++ b/src/buildServer.ts
@@ -90,14 +90,7 @@ export async function buildServer(
   );
   await loadBrain();
 
-  // Other webhooks operate as regular Fastify handlers (albeit routed to
-  // filesystem/module-space based on service name) rather than through a
-  // middleware/event abstraction layer.
-  // server.post<{ Params: { service: string } }>(
-  //   '/metrics/:service/webhook',
-  //   {},
-  //   WebhookRouter(server)
-  // );
+  // Other webhooks operate as regular Fastify handlers
   routeHandlers(server);
 
   // Endpoint for Google PubSub events

--- a/src/buildServer.ts
+++ b/src/buildServer.ts
@@ -2,7 +2,7 @@ import { createNodeMiddleware } from '@octokit/webhooks';
 import { RewriteFrames } from '@sentry/integrations';
 import * as Sentry from '@sentry/node';
 import * as Tracing from '@sentry/tracing';
-import { WebhookRouter } from '@webhooks';
+import { routeHandlers } from '@webhooks';
 import fastify from 'fastify';
 import fastifyFormBody from 'fastify-formbody';
 import middie from 'middie';
@@ -93,11 +93,12 @@ export async function buildServer(
   // Other webhooks operate as regular Fastify handlers (albeit routed to
   // filesystem/module-space based on service name) rather than through a
   // middleware/event abstraction layer.
-  server.post<{ Params: { service: string } }>(
-    '/metrics/:service/webhook',
-    {},
-    WebhookRouter(server)
-  );
+  // server.post<{ Params: { service: string } }>(
+  //   '/metrics/:service/webhook',
+  //   {},
+  //   WebhookRouter(server)
+  // );
+  routeHandlers(server);
 
   // Endpoint for Google PubSub events
   // TODO: Unify all these webhooks URL patterns!

--- a/src/webhooks/bootstrap-dev-env/bootstrap-dev-env.ts
+++ b/src/webhooks/bootstrap-dev-env/bootstrap-dev-env.ts
@@ -2,7 +2,7 @@ import { FastifyRequest } from 'fastify';
 
 import { insert } from '@/utils/db/metrics';
 
-export async function handler(
+export async function bootstrapWebhook(
   request: FastifyRequest<{ Body: { event: string; name: string } }>
 ) {
   const { body: payload } = request;

--- a/src/webhooks/bootstrap-dev-env/index.ts
+++ b/src/webhooks/bootstrap-dev-env/index.ts
@@ -1,1 +1,1 @@
-export { handler } from './bootstrap-dev-env';
+export { bootstrapWebhook } from './bootstrap-dev-env';

--- a/src/webhooks/gocd/gocd.ts
+++ b/src/webhooks/gocd/gocd.ts
@@ -6,7 +6,7 @@ import { GOCD_WEBHOOK_SECRET } from '@/config';
 import { GoCDResponse } from '@/types/gocd';
 import { extractAndVerifySignature } from '@/utils/auth/extractAndVerifySignature';
 
-export async function handler(
+export async function gocdWebhook(
   request: FastifyRequest<{ Body: GoCDResponse }>,
   reply: FastifyReply
 ) {

--- a/src/webhooks/gocd/index.ts
+++ b/src/webhooks/gocd/index.ts
@@ -1,1 +1,1 @@
-export { handler } from './gocd';
+export { gocdWebhook } from './gocd';

--- a/src/webhooks/kafka-control-plane/index.ts
+++ b/src/webhooks/kafka-control-plane/index.ts
@@ -1,1 +1,1 @@
-export { handler } from './kafka-control-plane';
+export { kafkactlWebhook } from './kafka-control-plane';

--- a/src/webhooks/kafka-control-plane/kafka-control-plane.ts
+++ b/src/webhooks/kafka-control-plane/kafka-control-plane.ts
@@ -12,7 +12,7 @@ import {
 } from '@/config';
 import { extractAndVerifySignature } from '@/utils/auth/extractAndVerifySignature';
 
-export async function handler(
+export async function kafkactlWebhook(
   request: FastifyRequest<{ Body: KafkaControlPlaneResponse }>,
   reply: FastifyReply
 ) {

--- a/src/webhooks/sentry-options/index.ts
+++ b/src/webhooks/sentry-options/index.ts
@@ -1,1 +1,1 @@
-export { handler } from './sentry-options';
+export { sentryOptionsWebhook } from './sentry-options';

--- a/src/webhooks/sentry-options/sentry-options.ts
+++ b/src/webhooks/sentry-options/sentry-options.ts
@@ -15,7 +15,7 @@ import {
 } from '@/config';
 import { extractAndVerifySignature } from '@/utils/auth/extractAndVerifySignature';
 
-export async function handler(
+export async function sentryOptionsWebhook(
   request: FastifyRequest<{ Body: SentryOptionsResponse }>,
   reply: FastifyReply
 ) {

--- a/src/webhooks/webpack/index.ts
+++ b/src/webhooks/webpack/index.ts
@@ -1,1 +1,1 @@
-export { handler } from './webpack';
+export { webpackWebhook } from './webpack';

--- a/src/webhooks/webpack/webpack.ts
+++ b/src/webhooks/webpack/webpack.ts
@@ -4,7 +4,7 @@ import { insertAssetSize } from '@/utils/db/metrics';
 
 import { verifyWebhook } from './verifyWebhook';
 
-export async function handler(
+export async function webpackWebhook(
   request: FastifyRequest<{
     Body: { pull_request_number: number } & Record<string, any>;
   }>,


### PR DESCRIPTION
Similar to #865 , this PR removes the dynamic module loading based off of path and switches to hard coded imports for URLs in the pattern `/metrics/:module/webhook`