### PR TITLE
Move github types out of big types folder

### DIFF
--- a/src/api/github/org.test.ts
+++ b/src/api/github/org.test.ts
@@ -1,7 +1,7 @@
 import { createAppAuth } from '@octokit/auth-app';
 
 import { GETSENTRY_ORG } from '@/config';
-import { GitHubOrgConfig } from '@/types';
+import { GitHubOrgConfig } from '@/types/github';
 import { OctokitWithRetries as octokitClassImport } from '@api/github/octokitWithRetries';
 
 import { MockedGithubOrg } from '../../../test/utils/testTypes';

--- a/src/api/github/org.ts
+++ b/src/api/github/org.ts
@@ -7,7 +7,7 @@ import {
   GitHubIssuesSomeoneElseCaresAbout,
   GitHubOrgConfig,
   GitHubOrgRepos,
-} from '@/types';
+} from '@/types/github';
 
 // We can't use @ to import config here or we get an error from jest due to
 // circular import or something. Try it out if you want. :)

--- a/src/blocks/jobStatuses.ts
+++ b/src/blocks/jobStatuses.ts
@@ -1,4 +1,4 @@
-import { Annotation } from '@/types';
+import { Annotation } from '@/types/github';
 
 /**
  * Transform GitHub Markdown link to Slack link

--- a/src/brain/notifyOnGoCDStageEvent/index.ts
+++ b/src/brain/notifyOnGoCDStageEvent/index.ts
@@ -13,7 +13,7 @@ import {
   SENTRY_REPO_SLUG,
 } from '@/config';
 import { SlackMessage } from '@/config/slackMessage';
-import { CompareCommits } from '@/types';
+import { CompareCommits } from '@/types/github';
 import {
   GoCDBuildCause,
   GoCDPipeline,

--- a/src/brain/requiredChecks/getAnnotations.ts
+++ b/src/brain/requiredChecks/getAnnotations.ts
@@ -1,5 +1,5 @@
 import { GETSENTRY_ORG, GETSENTRY_REPO_SLUG } from '@/config';
-import { Annotation } from '@/types';
+import { Annotation } from '@/types/github';
 
 import { extractRunId } from './extractRunId';
 

--- a/src/brain/requiredChecks/getTextParts.ts
+++ b/src/brain/requiredChecks/getTextParts.ts
@@ -1,5 +1,5 @@
 import { GETSENTRY_ORG, GETSENTRY_REPO_SLUG } from '@/config';
-import { CheckRunForRequiredChecksText } from '@/types';
+import { CheckRunForRequiredChecksText } from '@/types/github';
 
 /**
  * Given a CheckRun, returns a Slack message string that is split up into a list so that you can opt to replace pieces of the message

--- a/src/brain/requiredChecks/handleNewFailedBuild.ts
+++ b/src/brain/requiredChecks/handleNewFailedBuild.ts
@@ -3,12 +3,15 @@ import '@sentry/tracing';
 import * as Sentry from '@sentry/node';
 import { KnownBlock } from '@slack/types';
 
-import { ReposGetCommit } from '@types';
-
 import { jobStatuses } from '@/blocks/jobStatuses';
 import { BuildStatus, Color, REQUIRED_CHECK_CHANNEL } from '@/config';
 import { SlackMessage } from '@/config/slackMessage';
-import { CHECK_RUN_PROPERTIES, CheckRun, CheckRunProperty } from '@/types';
+import {
+  CHECK_RUN_PROPERTIES,
+  CheckRun,
+  CheckRunProperty,
+  ReposGetCommit,
+} from '@/types/github';
 import { getRelevantCommit } from '@/utils/github/getRelevantCommit';
 import { getBlocksForCommit } from '@/utils/slack/getBlocksForCommit';
 import { bolt } from '@api/slack';

--- a/src/brain/requiredChecks/recordFailures.ts
+++ b/src/brain/requiredChecks/recordFailures.ts
@@ -1,4 +1,4 @@
-import { Annotation, CheckRun } from '@/types';
+import { Annotation, CheckRun } from '@/types/github';
 import { db } from '@/utils/db';
 
 interface RecordFailuresParams {

--- a/src/brain/requiredChecks/resolveFlakeyFailure.ts
+++ b/src/brain/requiredChecks/resolveFlakeyFailure.ts
@@ -5,7 +5,7 @@ import { SlackMessageRow } from 'knex/types/tables';
 
 import { BuildStatus, Color } from '@/config';
 import { SlackMessage } from '@/config/slackMessage';
-import { CheckRun } from '@/types';
+import { CheckRun } from '@/types/github';
 import { updateRequiredCheck } from '@/utils/db/updateRequiredCheck';
 import { bolt } from '@api/slack';
 

--- a/src/brain/requiredChecks/resolveOtherFailure.ts
+++ b/src/brain/requiredChecks/resolveOtherFailure.ts
@@ -3,7 +3,7 @@ import '@sentry/tracing';
 import * as Sentry from '@sentry/node';
 
 import { BuildStatus, Color } from '@/config';
-import { CheckRun } from '@/types';
+import { CheckRun } from '@/types/github';
 import { updateRequiredCheck } from '@/utils/db/updateRequiredCheck';
 import { bolt } from '@api/slack';
 import { getFailureMessages } from '@utils/db/getFailureMessages';

--- a/src/config/loadGitHubOrgs.ts
+++ b/src/config/loadGitHubOrgs.ts
@@ -4,7 +4,7 @@ import yaml from 'js-yaml';
 
 // Don't use '@api' here, because it's ... not loaded yet, or something?
 import { GitHubOrg } from '../api/github/org';
-import { GitHubOrgConfig } from '../types';
+import { GitHubOrgConfig } from '../types/github';
 
 // Orgs are used throughout the codebase via `{ import GH_ORGS } from
 // '@/config'`. They are accessed by org slug, often taken from a GitHub event

--- a/src/types/github/index.ts
+++ b/src/types/github/index.ts
@@ -1,0 +1,63 @@
+import { Octokit } from '@octokit/rest';
+import { GetResponseDataTypeFromEndpointMethod } from '@octokit/types';
+import { EmitterWebhookEvent } from '@octokit/webhooks';
+
+/**
+ * GitHub types
+ */
+const octokit = new Octokit();
+
+export type Issue = GetResponseDataTypeFromEndpointMethod<
+  typeof octokit.issues.get
+>;
+
+export type CompareCommits = GetResponseDataTypeFromEndpointMethod<
+  typeof octokit.repos.compareCommits
+>;
+
+export type ReposGetCommit = GetResponseDataTypeFromEndpointMethod<
+  typeof octokit.repos.getCommit
+>;
+
+export type Annotation = GetResponseDataTypeFromEndpointMethod<
+  typeof octokit.checks.listAnnotations
+>[number];
+
+export interface AppAuthStrategyOptions {
+  appId: number;
+  privateKey: string;
+  installationId: number;
+}
+
+export interface GitHubIssuesSomeoneElseCaresAbout {
+  nodeId: string;
+  fieldIds: {
+    productArea: string;
+    status: string;
+    responseDue: string;
+  };
+}
+
+export interface GitHubOrgConfig {
+  slug: any;
+  appAuth: any;
+  project: any;
+  repos: any;
+}
+
+export interface GitHubOrgRepos {
+  all: string[];
+  withRouting: string[];
+  withoutRouting: string[];
+}
+
+export type CheckRun = EmitterWebhookEvent<'check_run'>['payload']['check_run'];
+
+// Note we intentionally only pick the pieces of checkRun that is needed to
+// construct a message in "requiredChecks", as we want to minimize the
+// properties to save to database
+//
+// Need to do this as we can't convert a string literal union to an array of literals
+export const CHECK_RUN_PROPERTIES = ['id', 'head_sha', 'html_url'] as const;
+export type CheckRunProperty = typeof CHECK_RUN_PROPERTIES[number];
+export type CheckRunForRequiredChecksText = Pick<CheckRun, CheckRunProperty>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,72 +1,9 @@
 import { IncomingMessage, Server, ServerResponse } from 'http';
 
-import { Octokit } from '@octokit/rest';
-import { GetResponseDataTypeFromEndpointMethod } from '@octokit/types';
-import { EmitterWebhookEvent } from '@octokit/webhooks';
 import { FastifyInstance } from 'fastify';
 
 // e.g. the return type of `buildServer`
 export type Fastify = FastifyInstance<Server, IncomingMessage, ServerResponse>;
-
-/**
- * GitHub types
- */
-const octokit = new Octokit();
-
-export type Issue = GetResponseDataTypeFromEndpointMethod<
-  typeof octokit.issues.get
->;
-
-export type CompareCommits = GetResponseDataTypeFromEndpointMethod<
-  typeof octokit.repos.compareCommits
->;
-
-export type ReposGetCommit = GetResponseDataTypeFromEndpointMethod<
-  typeof octokit.repos.getCommit
->;
-
-export type Annotation = GetResponseDataTypeFromEndpointMethod<
-  typeof octokit.checks.listAnnotations
->[number];
-
-export interface AppAuthStrategyOptions {
-  appId: number;
-  privateKey: string;
-  installationId: number;
-}
-
-export interface GitHubIssuesSomeoneElseCaresAbout {
-  nodeId: string;
-  fieldIds: {
-    productArea: string;
-    status: string;
-    responseDue: string;
-  };
-}
-
-export interface GitHubOrgConfig {
-  slug: any;
-  appAuth: any;
-  project: any;
-  repos: any;
-}
-
-export interface GitHubOrgRepos {
-  all: string[];
-  withRouting: string[];
-  withoutRouting: string[];
-}
-
-export type CheckRun = EmitterWebhookEvent<'check_run'>['payload']['check_run'];
-
-// Note we intentionally only pick the pieces of checkRun that is needed to
-// construct a message in "requiredChecks", as we want to minimize the
-// properties to save to database
-//
-// Need to do this as we can't convert a string literal union to an array of literals
-export const CHECK_RUN_PROPERTIES = ['id', 'head_sha', 'html_url'] as const;
-export type CheckRunProperty = typeof CHECK_RUN_PROPERTIES[number];
-export type CheckRunForRequiredChecksText = Pick<CheckRun, CheckRunProperty>;
 
 export interface SentryOptionsResponse {
   region: string;

--- a/src/types/knex/index.d.ts
+++ b/src/types/knex/index.d.ts
@@ -3,7 +3,7 @@ import { MessageAttachment } from '@slack/bolt';
 import { BuildStatus } from '@/config';
 import { SlackMessage } from '@/config/slackMessage';
 
-import { CheckRunForRequiredChecksText } from '..';
+import { CheckRunForRequiredChecksText } from '../github';
 
 declare module 'knex/types/tables' {
   interface User {

--- a/src/utils/db/getDeployForQueuedCommit.test.ts
+++ b/src/utils/db/getDeployForQueuedCommit.test.ts
@@ -1,4 +1,4 @@
-import { CompareCommits } from '@/types';
+import { CompareCommits } from '@/types/github';
 import { queueCommitsForDeploy } from '@/utils/db/queueCommitsForDeploy';
 import { db } from '@utils/db';
 

--- a/src/utils/db/queueCommitsForDeploy.ts
+++ b/src/utils/db/queueCommitsForDeploy.ts
@@ -1,4 +1,4 @@
-import { CompareCommits } from '@types';
+import { CompareCommits } from '@/types/github';
 
 import { db } from '.';
 

--- a/src/utils/db/updateRequiredCheck.ts
+++ b/src/utils/db/updateRequiredCheck.ts
@@ -1,6 +1,6 @@
 import { BuildStatus } from '@/config';
 import { SlackMessage } from '@/config/slackMessage';
-import { CheckRun } from '@/types';
+import { CheckRun } from '@/types/github';
 
 import { insertBuildFailure } from './metrics';
 import { saveSlackMessage } from './saveSlackMessage';

--- a/src/utils/slack/getBlocksForCommit/index.ts
+++ b/src/utils/slack/getBlocksForCommit/index.ts
@@ -1,6 +1,6 @@
 import { KnownBlock } from '@slack/types';
 
-import { ReposGetCommit } from '@types';
+import { ReposGetCommit } from '@/types/github';
 
 import { getUser } from '../../github/getUser';
 

--- a/src/webhooks/pubsub/slackNotifications.ts
+++ b/src/webhooks/pubsub/slackNotifications.ts
@@ -5,7 +5,7 @@ import {
   PRODUCT_AREA_LABEL_PREFIX,
   WAITING_FOR_PRODUCT_OWNER_LABEL,
 } from '@/config';
-import { Issue } from '@/types';
+import { Issue } from '@/types/github';
 import { getBusinessHoursLeft } from '@/utils/misc/businessHours';
 import {
   ChannelItem,

--- a/test/utils/testTypes.ts
+++ b/test/utils/testTypes.ts
@@ -1,7 +1,7 @@
 import {
   AppAuthStrategyOptions,
   GitHubIssuesSomeoneElseCaresAbout,
-} from '@/types';
+} from '@/types/github';
 
 // Mocked Github Org for Jest
 export type MockedGithubOrg = {


### PR DESCRIPTION
This PR moves github types out of `types/index.ts` and into `types/github/index.ts`