### PR TITLE
Add Sentry txn observability for webhooks

### DIFF
--- a/src/webhooks/bootstrap-dev-env/index.ts
+++ b/src/webhooks/bootstrap-dev-env/index.ts
@@ -1,1 +1,0 @@
-export { bootstrapWebhook } from './bootstrap-dev-env';

--- a/src/webhooks/gocd/index.ts
+++ b/src/webhooks/gocd/index.ts
@@ -1,1 +1,0 @@
-export { gocdWebhook } from './gocd';

--- a/src/webhooks/index.test.ts
+++ b/src/webhooks/index.test.ts
@@ -88,7 +88,7 @@ describe('cron jobs testing', function () {
       }
     );
     const reply = new MockReply() as FastifyReply;
-    await handleRoute(mockError, {} as FastifyRequest, reply);
+    await handleRoute(mockError, {} as FastifyRequest, reply, '');
     expect(mockError).toHaveBeenCalled();
     expect(reply.statusCode).toBe(400);
   });

--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -9,38 +9,47 @@ import { kafkactlWebhook } from './kafka-control-plane/kafka-control-plane';
 import { sentryOptionsWebhook } from './sentry-options/sentry-options';
 import { webpackWebhook } from './webpack/webpack';
 
+type WebhookHandler = (
+  request: FastifyRequest<any>,
+  reply: FastifyReply
+) => Promise<void>;
+
 // Error handling wrapper function
 export async function handleRoute(
-  handler,
+  handler: WebhookHandler,
   request: FastifyRequest,
-  reply: FastifyReply
+  reply: FastifyReply,
+  name: string
 ): Promise<void> {
+  const tx = Sentry.startTransaction({
+    op: 'webhooks',
+    name: 'webhooks.' + name,
+  });
   try {
     await handler(request, reply);
   } catch (err) {
-    console.error(err);
     Sentry.captureException(err);
     reply.code(400).send('Bad Request');
-    return;
   }
+  tx.finish();
 }
 
 // Function that maps routes to their respective handlers
 export async function routeHandlers(server: Fastify, _options): Promise<void> {
   server.post('/metrics/bootstrap-dev-env/webhook', (request, reply) =>
-    handleRoute(bootstrapWebhook, request, reply)
+    handleRoute(bootstrapWebhook, request, reply, 'bootstrap-dev-env')
   );
   server.post('/metrics/gocd/webhook', (request, reply) =>
-    handleRoute(gocdWebhook, request, reply)
+    handleRoute(gocdWebhook, request, reply, 'gocd')
   );
   server.post('/metrics/kafka-control-plane/webhook', (request, reply) =>
-    handleRoute(kafkactlWebhook, request, reply)
+    handleRoute(kafkactlWebhook, request, reply, 'kafka-control-plane')
   );
   server.post('/metrics/sentry-options/webhook', (request, reply) =>
-    handleRoute(sentryOptionsWebhook, request, reply)
+    handleRoute(sentryOptionsWebhook, request, reply, 'sentry-options')
   );
   server.post('/metrics/webpack/webhook', (request, reply) =>
-    handleRoute(webpackWebhook, request, reply)
+    handleRoute(webpackWebhook, request, reply, 'webpack')
   );
 
   // Default handler for invalid routes

--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -1,3 +1,5 @@
+import '@sentry/tracing';
+
 import * as Sentry from '@sentry/node';
 import { FastifyReply, FastifyRequest } from 'fastify';
 

--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -32,6 +32,7 @@ export async function handleRoute(
   } catch (err) {
     Sentry.captureException(err);
     reply.code(400).send('Bad Request');
+    tx.setHttpStatus(400);
   }
   tx.finish();
 }

--- a/src/webhooks/kafka-control-plane/index.ts
+++ b/src/webhooks/kafka-control-plane/index.ts
@@ -1,1 +1,0 @@
-export { kafkactlWebhook } from './kafka-control-plane';

--- a/src/webhooks/sentry-options/index.ts
+++ b/src/webhooks/sentry-options/index.ts
@@ -1,1 +1,0 @@
-export { sentryOptionsWebhook } from './sentry-options';

--- a/src/webhooks/webpack/index.ts
+++ b/src/webhooks/webpack/index.ts
@@ -1,1 +1,0 @@
-export { webpackWebhook } from './webpack';


### PR DESCRIPTION
This PR adds Sentry txn tracing to the webhook endpoints