### PR TITLE
chore(github): Adding note about case-sensitivity

### DIFF
--- a/src/api/slack/updateAppHome/index.ts
+++ b/src/api/slack/updateAppHome/index.ts
@@ -12,7 +12,9 @@ function getGitHubUsernameInput(currentUsername?: string): KnownBlock {
     dispatch_action: true,
     label: {
       type: 'plain_text',
-      text: currentUsername ? 'Update GitHub username' : 'GitHub username',
+      text: currentUsername
+        ? 'Update GitHub username (case-sensitive)'
+        : 'GitHub username (case-sensitive)',
     },
     element: {
       type: 'plain_text_input',

--- a/src/brain/slack/appHome/index.test.ts
+++ b/src/brain/slack/appHome/index.test.ts
@@ -95,7 +95,7 @@ describe('appHome', function () {
             "type": "plain_text_input",
           },
           "label": Object {
-            "text": "Update GitHub username",
+            "text": "Update GitHub username (case-sensitive)",
             "type": "plain_text",
           },
           "type": "input",
@@ -205,7 +205,7 @@ describe('appHome', function () {
             "type": "plain_text_input",
           },
           "label": Object {
-            "text": "GitHub username",
+            "text": "GitHub username (case-sensitive)",
             "type": "plain_text",
           },
           "type": "input",


### PR DESCRIPTION
This change adds a note about the case-sensitivity of GitHub usernames on the Slack homepage.