### PR TITLE
disable API status notification to team-engineering channel

### DIFF
--- a/src/jobs/slackScores.test.ts
+++ b/src/jobs/slackScores.test.ts
@@ -1,6 +1,5 @@
 import { OAuth2Client } from 'google-auth-library';
 
-import * as getAPIsStatsMessage from '@/brain/github/apis/getStatsMessage';
 import { GETSENTRY_ORG, GH_ORGS } from '@/config';
 import * as scoresUtils from '@/utils/db/scores';
 import { bolt } from '@api/slack';
@@ -18,25 +17,14 @@ import {
 } from './slackScores';
 
 describe('slackScores tests', function () {
-  let getIssueEventsForTeamSpy,
-    getGithubActivityMetricsSpy,
-    postMessageSpy,
-    getStatsMessageSpy;
+  let getIssueEventsForTeamSpy, getGithubActivityMetricsSpy, postMessageSpy;
   beforeAll(() => {
     getIssueEventsForTeamSpy = jest.spyOn(scoresUtils, 'getIssueEventsForTeam');
     getGithubActivityMetricsSpy = jest.spyOn(
       scoresUtils,
       'getGitHubActivityMetrics'
     );
-    getStatsMessageSpy = jest.spyOn(getAPIsStatsMessage, 'getStatsMessage');
-    getStatsMessageSpy.mockImplementation(() => {
-      return {
-        messages: ['Some random message'],
-        should_show_docs: false,
-        goal: 50,
-        review_link: getAPIsStatsMessage.OWNERSHIP_FILE_LINK,
-      };
-    });
+
     postMessageSpy = jest.spyOn(bolt.client.chat, 'postMessage');
     jest
       .spyOn(OAuth2Client.prototype, 'verifyIdToken')
@@ -67,12 +55,7 @@ describe('slackScores tests', function () {
         gitHubCommenters: [],
       });
       await triggerSlackScores(GETSENTRY_ORG);
-      expect(postMessageSpy).toHaveBeenCalledTimes(2);
-      expect(postMessageSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          text: 'API Publish Stats By Team',
-        })
-      );
+      expect(postMessageSpy).toHaveBeenCalledTimes(1);
       expect(postMessageSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           text: 'Weekly GitHub Team Scores',

--- a/src/jobs/slackScores.ts
+++ b/src/jobs/slackScores.ts
@@ -1,10 +1,7 @@
 import moment from 'moment-timezone';
 
-import { getMessageBlocks } from '@/brain/github/apis';
-import { getStatsMessage } from '@/brain/github/apis/getStatsMessage';
 import {
   DISCUSS_PRODUCT_CHANNEL_ID,
-  FEED_ENGINEERING_CHANNEL_ID,
   GETSENTRY_ORG,
   PRODUCT_OWNERS_INFO,
   TEAM_DEV_INFRA_CHANNEL_ID,
@@ -52,25 +49,6 @@ const LESS_THAN_SIGN_LENGTH = 1;
 const SPACE_LENGTH = 1;
 const NUM_DISCUSSION_SCOREBOARD_ELEMENTS = 5;
 const TEAM_PREFIX = 'team-';
-
-export const sendApisPublishStatus = async () => {
-  const message = await getStatsMessage();
-  let messageBlocks = [
-    {
-      type: 'section',
-      text: {
-        type: 'mrkdwn',
-        text: 'API Publish Stats By Team',
-      },
-    },
-  ];
-  messageBlocks = messageBlocks.concat(getMessageBlocks(message));
-  await bolt.client.chat.postMessage({
-    channel: FEED_ENGINEERING_CHANNEL_ID,
-    text: 'API Publish Stats By Team',
-    blocks: messageBlocks,
-  });
-};
 
 export const sendGitHubEngagementMetrics = async (
   dev_infra_internal: boolean = false
@@ -341,7 +319,6 @@ export const triggerSlackScores = async (
     return;
   }
   await Promise.all([
-    sendApisPublishStatus(),
     sendGitHubActivityMetrics(),
     sendGitHubEngagementMetrics(),
   ]);


### PR DESCRIPTION
We have a weekly notification that goes to team engineering to let people know about published APIs. This notification is not needed anymore since the teams are not actively working on this.