### PR TITLE
fix(sudo): Add region configuration in message

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,6 +31,7 @@ export interface SentryInformerResponse {
   source: string;
   user: string;
   incident_id: string;
+  region: string;
   action: string;
   permission: string;
 }

--- a/src/webhooks/sentry-informer/sentry-informer.test.ts
+++ b/src/webhooks/sentry-informer/sentry-informer.test.ts
@@ -88,7 +88,7 @@ describe('sentry-informer webhook', () => {
             type: 'section',
             text: {
               type: 'mrkdwn',
-              text: 'some_user has elevated privileges to all for some_incident.',
+              text: ':trash: *some_user* has *elevated* privileges in region *some_region* for Incident *some_incident*',
             },
           },
         ],

--- a/src/webhooks/sentry-informer/sentry-informer.ts
+++ b/src/webhooks/sentry-informer/sentry-informer.ts
@@ -57,7 +57,9 @@ export async function messageSlack(message: SentryInformerResponse) {
       sendBlock.push(
         slackblocks.section(
           slackblocks.markdown(
-            `${message.user} has ${message.action} privileges to ${message.permission} for ${message.incident_id}.`
+            message.action === 'escalated'
+              ? `:alert: *${message.user}* has *${message.action}* privileges in region *${message.region}* for Incident *${message.incident_id}*`
+              : `:trash: *${message.user}* has *${message.action}* privileges in region *${message.region}* for Incident *${message.incident_id}*`
           )
         )
       );
@@ -65,7 +67,9 @@ export async function messageSlack(message: SentryInformerResponse) {
       sendBlock.push(
         slackblocks.section(
           slackblocks.markdown(
-            `${message.user} has ${message.action} privileges to ${message.permission}.`
+            message.action === 'escalated'
+              ? `:alert: *${message.user}* has *${message.action}* privileges in region *${message.region}*`
+              : `:trash: *${message.user}* has *${message.action}* privileges in region *${message.region}*`
           )
         )
       );

--- a/test/payloads/sentry-informer/testPayload.json
+++ b/test/payloads/sentry-informer/testPayload.json
@@ -2,6 +2,7 @@
     "source": "sentry-informer",
     "user": "some_user",
     "incident_id": "some_incident",
+    "region": "some_region",
     "action": "elevated",
     "permission": "all"
 }


### PR DESCRIPTION
We want the region name in which escalation happened to be sent in the slack message