### PR TITLE
chore(Linear): Remove routing of issues from our sentry-docs repo

### DIFF
--- a/github-orgs.yml
+++ b/github-orgs.yml
@@ -26,7 +26,6 @@ getsentry:
   repos:
     withRouting:
       - 'sentry'
-      - 'sentry-docs'
 
     withoutRouting:
       - 'arroyo'

--- a/src/config/loadGitHubOrgs.test.ts
+++ b/src/config/loadGitHubOrgs.test.ts
@@ -28,7 +28,7 @@ describe('loadGitHubOrgs', function () {
     });
 
     // Spot-check repos for good measure.
-    expect(org.repos.withRouting).toEqual(['sentry', 'sentry-docs']);
+    expect(org.repos.withRouting).toEqual(['sentry']);
   });
 
   it('chokes on non-numeric appId', async function () {


### PR DESCRIPTION
This change should have the effect, that `sentry-docs` issues no longer receive the `Waiting for: Support` label