### PR TITLE
feat(slack-bot): notify original commit authors for failed revert commits

### DIFF
--- a/src/brain/gocd/gocdSlackFeeds/index.ts
+++ b/src/brain/gocd/gocdSlackFeeds/index.ts
@@ -196,7 +196,7 @@ const discussSnSFeed = new DeployFeed({
   },
   replyCallback: async (pipeline) => {
     const [base, head] = await getBaseAndHeadCommit(pipeline);
-    const authors = head ? await getAuthors('snuba', base, head) : [];
+    const authors = head ? await getAuthors('snuba', base, head, true) : [];
     // Get unique users from the authors
     const uniqueUsers = await getUniqueUsers(authors);
 
@@ -326,7 +326,7 @@ const discussBackendFeed = new DeployFeed({
 
     if (pauseCause == null) return [];
     const [base, head] = await getBaseAndHeadCommit(pipeline);
-    const authors = head ? await getAuthors('getsentry', base, head) : [];
+    const authors = head ? await getAuthors('getsentry', base, head, true) : [];
     // Get unique users from the authors
     const uniqueUsers = await getUniqueUsers(authors);
 

--- a/src/utils/github/getAuthors.test.ts
+++ b/src/utils/github/getAuthors.test.ts
@@ -1,0 +1,505 @@
+/// <reference types="jest" />
+
+import { GETSENTRY_ORG } from '@/config';
+
+import { getAuthors, getAuthorsWithRevertedCommitAuthors } from './getAuthors';
+
+// Mock the GETSENTRY_ORG.api.repos.compareCommits function
+jest.mock('@/config', () => ({
+  GETSENTRY_ORG: {
+    slug: 'sentry',
+    api: {
+      repos: {
+        compareCommits: jest.fn(),
+      },
+      request: jest.fn(),
+    },
+  },
+}));
+
+describe('getAuthors', () => {
+  const mockCompareCommits = GETSENTRY_ORG.api.repos
+    .compareCommits as unknown as jest.Mock;
+  // @ts-ignore
+  const consoleErrorSpy = jest
+    .spyOn(console, 'error')
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    // Clear mock history before each test
+    mockCompareCommits.mockClear();
+    consoleErrorSpy.mockClear();
+  });
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('should return author login and email from commits', async () => {
+    const mockResponse = {
+      data: {
+        commits: [
+          {
+            commit: { author: { email: 'author1@example.com' } },
+            author: { login: 'author1' },
+          },
+          {
+            commit: { author: { email: 'author2@example.com' } },
+            author: { login: 'author2' },
+          },
+        ],
+      },
+    };
+    mockCompareCommits.mockResolvedValue(mockResponse);
+
+    const authors = await getAuthors('my-repo', 'base-sha', 'head-sha');
+
+    expect(mockCompareCommits).toHaveBeenCalledWith({
+      owner: 'sentry',
+      repo: 'my-repo',
+      base: 'base-sha',
+      head: 'head-sha',
+    });
+    expect(authors).toEqual([
+      { email: 'author1@example.com', login: 'author1' },
+      { email: 'author2@example.com', login: 'author2' },
+    ]);
+  });
+
+  it('should use headCommit as base if baseCommit is null', async () => {
+    const mockResponse = {
+      data: {
+        commits: [
+          {
+            commit: { author: { email: 'author1@example.com' } },
+            author: { login: 'author1' },
+          },
+        ],
+      },
+    };
+    mockCompareCommits.mockResolvedValue(mockResponse);
+
+    await getAuthors('my-repo', null, 'head-sha');
+
+    expect(mockCompareCommits).toHaveBeenCalledWith({
+      owner: 'sentry',
+      repo: 'my-repo',
+      base: 'head-sha', // Expect headCommit to be used as base
+      head: 'head-sha',
+    });
+  });
+
+  it('should return an empty array if there are no commits', async () => {
+    const mockResponse = {
+      data: {
+        commits: [],
+      },
+    };
+    mockCompareCommits.mockResolvedValue(mockResponse);
+
+    const authors = await getAuthors('my-repo', 'base-sha', 'head-sha');
+    expect(authors).toEqual([]);
+  });
+
+  it('should return an empty array if commitsComparison.data.commits is undefined', async () => {
+    const mockResponse = {
+      data: {}, // No commits array
+    };
+    mockCompareCommits.mockResolvedValue(mockResponse);
+
+    const authors = await getAuthors('my-repo', 'base-sha', 'head-sha');
+    expect(authors).toEqual([]);
+  });
+
+  it('should return an empty array and log error if API call fails', async () => {
+    const MOCK_ERROR = new Error('API Error');
+    mockCompareCommits.mockRejectedValue(MOCK_ERROR);
+
+    const authors = await getAuthors('my-repo', 'base-sha', 'head-sha');
+
+    expect(authors).toEqual([]);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(MOCK_ERROR);
+  });
+
+  it('should aggregate all users when multiple commits have different authors', async () => {
+    const mockResponse = {
+      data: {
+        commits: [
+          {
+            commit: { author: { email: 'user1@example.com' } },
+            author: { login: 'user1' },
+          },
+          {
+            commit: { author: { email: 'user2@example.com' } },
+            author: { login: 'user2' },
+          },
+          {
+            commit: { author: { email: 'user3@example.com' } },
+            author: { login: 'user3' },
+          },
+        ],
+      },
+    };
+    mockCompareCommits.mockResolvedValue(mockResponse);
+
+    const authors = await getAuthors('my-repo', 'base-sha', 'head-sha');
+
+    expect(mockCompareCommits).toHaveBeenCalledWith({
+      owner: 'sentry',
+      repo: 'my-repo',
+      base: 'base-sha',
+      head: 'head-sha',
+    });
+    expect(authors).toEqual([
+      { email: 'user1@example.com', login: 'user1' },
+      { email: 'user2@example.com', login: 'user2' },
+      { email: 'user3@example.com', login: 'user3' },
+    ]);
+    expect(authors.length).toBe(3);
+  });
+});
+
+describe('getAuthorsWithRevertedCommitAuthors', () => {
+  const mockCompareCommits = GETSENTRY_ORG.api.repos
+    .compareCommits as unknown as jest.Mock;
+  const mockOctokitRequest = GETSENTRY_ORG.api.request as unknown as jest.Mock;
+  // @ts-ignore
+  const consoleErrorSpy = jest
+    .spyOn(console, 'error')
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    mockCompareCommits.mockClear();
+    mockOctokitRequest.mockClear();
+    consoleErrorSpy.mockClear();
+  });
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('should return authors for standard commits (no reverts)', async () => {
+    const mockApiResponse = {
+      data: {
+        commits: [
+          {
+            sha: 'sha1',
+            commit: { author: { email: 'author1@example.com' } },
+            author: { login: 'author1' },
+          },
+          {
+            sha: 'sha2',
+            commit: { author: { email: 'author2@example.com' } },
+            author: { login: 'author2' },
+          },
+        ],
+      },
+    };
+    mockCompareCommits.mockResolvedValue(mockApiResponse);
+    mockOctokitRequest.mockImplementation(async (url: string, params: any) => {
+      if (url === 'GET /repos/{owner}/{repo}/commits/{ref}') {
+        if (params.ref === 'sha1')
+          return {
+            data: {
+              sha: 'sha1',
+              commit: { message: 'feat: regular commit' },
+              author: { login: 'author1' },
+            },
+          };
+        if (params.ref === 'sha2')
+          return {
+            data: {
+              sha: 'sha2',
+              commit: { message: 'fix: another regular commit' },
+              author: { login: 'author2' },
+            },
+          };
+      }
+      throw new Error(
+        `Unexpected Octokit request: ${url} with params ${JSON.stringify(
+          params
+        )}`
+      );
+    });
+
+    const authors = await getAuthorsWithRevertedCommitAuthors(
+      'my-repo',
+      'base',
+      'head'
+    );
+    expect(authors).toEqual([
+      { email: 'author1@example.com', login: 'author1' },
+      { email: 'author2@example.com', login: 'author2' },
+    ]);
+    expect(mockOctokitRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('should return original author for a revert commit if found', async () => {
+    const REVERTED_COMMIT_SHA = 'revertedsha123';
+    const REVERT_COMMIT_SHA = 'revertcommisha456';
+
+    mockCompareCommits.mockResolvedValue({
+      data: {
+        commits: [
+          {
+            sha: REVERT_COMMIT_SHA,
+            commit: { author: { email: 'reverter@example.com' } },
+            author: { login: 'reverter_user' },
+          },
+        ],
+      },
+    });
+
+    mockOctokitRequest.mockImplementation(async (url: string, params: any) => {
+      if (url === 'GET /repos/{owner}/{repo}/commits/{ref}') {
+        if (params.ref === REVERT_COMMIT_SHA) {
+          return {
+            data: {
+              sha: REVERT_COMMIT_SHA,
+              commit: {
+                message: `Revert "feat: some feature"\n\nThis reverts commit ${REVERTED_COMMIT_SHA}.`,
+              },
+              author: { login: 'reverter_user' },
+            },
+          };
+        }
+        if (params.ref === REVERTED_COMMIT_SHA) {
+          return {
+            data: {
+              sha: REVERTED_COMMIT_SHA,
+              commit: { author: { email: 'original_author@example.com' } },
+              author: { login: 'original_user' },
+            },
+          };
+        }
+      }
+      throw new Error(`Unexpected Octokit request to ${url}`);
+    });
+
+    const authors = await getAuthorsWithRevertedCommitAuthors(
+      'my-repo',
+      'base',
+      'head'
+    );
+    expect(authors).toEqual([
+      { email: 'original_author@example.com', login: 'original_user' },
+    ]);
+    expect(mockOctokitRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('should fallback to reverter if original reverted commit details fail to fetch', async () => {
+    const REVERTED_COMMIT_SHA = 'revertedsha456';
+    const REVERT_COMMIT_SHA = 'revertcommisha789';
+
+    mockCompareCommits.mockResolvedValue({
+      data: {
+        commits: [
+          {
+            sha: REVERT_COMMIT_SHA,
+            commit: { author: { email: 'reverter@sentry.io' } },
+            author: { login: 'reverter_user' },
+          },
+        ],
+      },
+    });
+
+    mockOctokitRequest.mockImplementation(async (url: string, params: any) => {
+      if (url === 'GET /repos/{owner}/{repo}/commits/{ref}') {
+        if (params.ref === REVERT_COMMIT_SHA)
+          return {
+            data: {
+              sha: REVERT_COMMIT_SHA,
+              commit: {
+                message: `This reverts commit ${REVERTED_COMMIT_SHA}.`,
+              },
+              author: { login: 'reverter_user' },
+            },
+          };
+        if (params.ref === REVERTED_COMMIT_SHA) {
+          throw new Error('Failed to fetch original commit');
+        }
+      }
+      throw new Error(`Unexpected Octokit request to ${url}`);
+    });
+
+    const authors = await getAuthorsWithRevertedCommitAuthors(
+      'my-repo',
+      'base',
+      'head'
+    );
+    expect(authors).toEqual([
+      { email: 'reverter@sentry.io', login: 'reverter_user' },
+    ]);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      `  Error fetching details for reverted commit ${REVERTED_COMMIT_SHA}:`,
+      expect.any(Error)
+    );
+  });
+
+  it('should handle a mix of standard and revert commits', async () => {
+    const STANDARD_SHA = 'standardsha';
+    const REVERTED_SHA = 'revertedoriginalsha';
+    const REVERT_SHA = 'revertingsha';
+
+    mockCompareCommits.mockResolvedValue({
+      data: {
+        commits: [
+          {
+            sha: STANDARD_SHA,
+            commit: { author: { email: 'std@example.com' } },
+            author: { login: 'std_user' },
+          },
+          {
+            sha: REVERT_SHA,
+            commit: { author: { email: 'reverter@example.com' } },
+            author: { login: 'reverter_user' },
+          },
+        ],
+      },
+    });
+
+    mockOctokitRequest.mockImplementation(async (url: string, params: any) => {
+      if (url === 'GET /repos/{owner}/{repo}/commits/{ref}') {
+        if (params.ref === STANDARD_SHA)
+          return {
+            data: {
+              sha: STANDARD_SHA,
+              commit: { message: 'feat: standard work' },
+            },
+          };
+        if (params.ref === REVERT_SHA)
+          return {
+            data: {
+              sha: REVERT_SHA,
+              commit: { message: `This reverts commit ${REVERTED_SHA}.` },
+            },
+          };
+        if (params.ref === REVERTED_SHA)
+          return {
+            data: {
+              sha: REVERTED_SHA,
+              commit: { author: { email: 'original@example.com' } },
+              author: { login: 'original_user' },
+            },
+          };
+      }
+      throw new Error(`Unexpected Octokit request to ${url}`);
+    });
+
+    const authors = await getAuthorsWithRevertedCommitAuthors(
+      'my-repo',
+      'base',
+      'head'
+    );
+    expect(authors).toEqual([
+      { email: 'std@example.com', login: 'std_user' },
+      { email: 'original@example.com', login: 'original_user' },
+    ]);
+  });
+
+  it('should return empty array if compareCommits API fails', async () => {
+    mockCompareCommits.mockRejectedValue(new Error('Compare API failed'));
+    const authors = await getAuthorsWithRevertedCommitAuthors(
+      'my-repo',
+      'base',
+      'head'
+    );
+    expect(authors).toEqual([]);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('should return empty array if compareCommits returns no commits', async () => {
+    mockCompareCommits.mockResolvedValue({ data: { commits: [] } });
+    const authors = await getAuthorsWithRevertedCommitAuthors(
+      'my-repo',
+      'base',
+      'head'
+    );
+    expect(authors).toEqual([]);
+  });
+
+  it('should fallback to commitStatus author if processCommit fails for non-revert specific reason', async () => {
+    mockCompareCommits.mockResolvedValue({
+      data: {
+        commits: [
+          {
+            sha: 'errorSha',
+            commit: { author: { email: 'commitstatus@example.com' } },
+            author: { login: 'commitstatus_user' },
+          },
+        ],
+      },
+    });
+    mockOctokitRequest.mockImplementation(async (url: string, params: any) => {
+      if (
+        url === 'GET /repos/{owner}/{repo}/commits/{ref}' &&
+        params.ref === 'errorSha'
+      ) {
+        throw new Error('Failed to fetch commit details for errorSha');
+      }
+      throw new Error(`Unexpected Octokit request to ${url}`);
+    });
+
+    const authors = await getAuthorsWithRevertedCommitAuthors(
+      'my-repo',
+      'base',
+      'head'
+    );
+    expect(authors).toEqual([
+      { email: 'commitstatus@example.com', login: 'commitstatus_user' },
+    ]);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Error processing commit errorSha:',
+      expect.any(Error)
+    );
+  });
+
+  it('should handle missing email or login for original author of a revert commit', async () => {
+    const REVERTED_COMMIT_SHA = 'revertedsha_partial';
+    const REVERT_COMMIT_SHA = 'revertcommisha_partial';
+
+    mockCompareCommits.mockResolvedValue({
+      data: {
+        commits: [
+          {
+            sha: REVERT_COMMIT_SHA,
+            commit: { author: { email: 'reverter@example.com' } },
+            author: { login: 'reverter_user' },
+          },
+        ],
+      },
+    });
+
+    mockOctokitRequest.mockImplementation(async (url: string, params: any) => {
+      if (url === 'GET /repos/{owner}/{repo}/commits/{ref}') {
+        if (params.ref === REVERT_COMMIT_SHA)
+          return {
+            data: {
+              sha: REVERT_COMMIT_SHA,
+              commit: {
+                message: `This reverts commit ${REVERTED_COMMIT_SHA}.`,
+              },
+            },
+          };
+        if (params.ref === REVERTED_COMMIT_SHA)
+          return {
+            data: {
+              sha: REVERTED_COMMIT_SHA,
+              commit: { author: { name: 'Original Name' } }, // email missing
+              author: { login: 'original_user_no_email' },
+            },
+          };
+      }
+      throw new Error(`Unexpected Octokit request to ${url}`);
+    });
+
+    const authors = await getAuthorsWithRevertedCommitAuthors(
+      'my-repo',
+      'base',
+      'head'
+    );
+    expect(authors).toEqual([
+      { email: undefined, login: 'original_user_no_email' },
+    ]);
+  });
+});

--- a/src/utils/github/getAuthors.test.ts
+++ b/src/utils/github/getAuthors.test.ts
@@ -343,9 +343,9 @@ Co-authored-by: originaluser <123456789+originaluser@users.noreply.github.com>`,
   });
 
   it('should handle a mix of standard and revert commits', async () => {
-    const STANDARD_SHA = 'coffeebead';
-    const ORIGINAL_SHA = 'coffee';
-    const REVERT_SHA = 'decaf';
+    const STANDARD_SHA = 'deadc0de';
+    const ORIGINAL_SHA = 'c0ffee';
+    const REVERT_SHA = 'd3caf';
 
     mockCompareCommits.mockResolvedValue({
       data: {
@@ -357,7 +357,10 @@ Co-authored-by: originaluser <123456789+originaluser@users.noreply.github.com>`,
           },
           {
             sha: REVERT_SHA,
-            commit: { author: { email: 'reverter@example.com' } },
+            commit: {
+              author: { email: 'reverter@example.com' },
+              message: `This reverts commit ${ORIGINAL_SHA}`,
+            },
             author: { login: 'reverter_user' },
           },
         ],

--- a/src/utils/github/getAuthors.test.ts
+++ b/src/utils/github/getAuthors.test.ts
@@ -11,6 +11,7 @@ jest.mock('@/config', () => ({
     api: {
       repos: {
         compareCommits: jest.fn(),
+        getCommit: jest.fn(),
       },
       request: jest.fn(),
     },
@@ -212,7 +213,6 @@ describe('getAuthorsWithRevertedCommitAuthors', () => {
       { email: 'author1@example.com', login: 'author1' },
       { email: 'author2@example.com', login: 'author2' },
     ]);
-    expect(mockOctokitRequest).toHaveBeenCalledTimes(2);
   });
 
   it('should return original author for a revert commit if found', async () => {
@@ -272,7 +272,6 @@ Co-authored-by: originaluser <123456789+originaluser@users.noreply.github.com>`,
     expect(authors).toEqual([
       { email: 'original_author@example.com', login: 'original_user' },
     ]);
-    expect(mockOctokitRequest).toHaveBeenCalledTimes(2);
   });
 
   it('should fallback to reverter if original reverted commit details fail to fetch', async () => {
@@ -481,8 +480,6 @@ Co-authored-by: originaluser <123456789+originaluser@users.noreply.github.com>`,
       'base',
       'head'
     );
-    expect(authors).toEqual([
-      { email: undefined, login: 'original_user_no_email' },
-    ]);
+    expect(authors).toEqual([{ email: null, login: 'original_user_no_email' }]);
   });
 });

--- a/src/utils/github/getAuthors.ts
+++ b/src/utils/github/getAuthors.ts
@@ -74,16 +74,11 @@ async function getRevertCommitDetails(
 
 async function processCommit(
   commitSha: string,
+  commitMessage: string,
   repo: string
 ): Promise<RevertAuthorInfo | null> {
   try {
-    const commitDetailsResponse = await GETSENTRY_ORG.api.repos.getCommit({
-      owner: GETSENTRY_ORG.slug,
-      repo,
-      ref: commitSha,
-    });
-    const commitData = commitDetailsResponse.data;
-    const revertedHash = extractRevertedCommitHash(commitData.commit.message);
+    const revertedHash = extractRevertedCommitHash(commitMessage);
     let revertDetails: RevertAuthorInfo | null = null;
 
     if (revertedHash) {
@@ -118,7 +113,11 @@ export async function getAuthorsWithRevertedCommitAuthors(
 
     const authors = await Promise.all(
       commitsComparison.data.commits.map(async (commitMetadata) => {
-        const revertInfo = await processCommit(commitMetadata.sha, repo);
+        const revertInfo = await processCommit(
+          commitMetadata.sha,
+          commitMetadata.commit.message,
+          repo
+        );
 
         if (revertInfo) {
           return {

--- a/src/utils/github/getAuthors.ts
+++ b/src/utils/github/getAuthors.ts
@@ -58,7 +58,6 @@ export async function getAuthors(
     });
   } catch (err) {
     // eslint-disable-next-line no-console
-    // @ts-ignore
     console.error(err);
     return [];
   }

--- a/src/utils/github/getAuthors.ts
+++ b/src/utils/github/getAuthors.ts
@@ -1,9 +1,29 @@
 import { GETSENTRY_ORG } from '@/config';
 
+function extractOriginalAuthor(message: string): {
+  email: undefined;
+  login: string | undefined;
+} {
+  try {
+    const originalAuthorMatch = message.match(/Co-authored-by: (\w+) <[^>]+>/);
+    return {
+      email: undefined,
+      login: originalAuthorMatch ? originalAuthorMatch[1] : undefined,
+    };
+  } catch (error) {
+    console.error('Failed to extract original author:', error);
+    return {
+      email: undefined,
+      login: undefined,
+    };
+  }
+}
+
 export async function getAuthors(
   repo: string,
   baseCommit: string | null,
-  headCommit: string
+  headCommit: string,
+  includeRevertedCommits: boolean = false
 ): Promise<Array<{ email: string | undefined; login: string | undefined }>> {
   try {
     const commitsComparison = await GETSENTRY_ORG.api.repos.compareCommits({
@@ -18,127 +38,24 @@ export async function getAuthors(
     ) {
       return [];
     }
-    return commitsComparison.data.commits.map((commitStatus) => {
-      return {
-        email: commitStatus.commit.author?.email,
-        login: commitStatus.author?.login,
-      };
-    });
-  } catch (err) {
-    // eslint-disable-next-line no-console
-    // @ts-ignore
-    console.error(err);
-    return [];
-  }
-}
+    return commitsComparison.data.commits.flatMap((commitStatus) => {
+      const authors = [
+        {
+          email: commitStatus.commit.author?.email,
+          login: commitStatus.author?.login,
+        },
+      ];
+      if (includeRevertedCommits) {
+        const originalAuthor = extractOriginalAuthor(
+          commitStatus.commit.message
+        );
 
-interface RevertAuthorInfo {
-  login: string | null;
-  email: string | null;
-}
-
-function extractRevertedCommitHash(commitMessage: string): string | null {
-  const match = commitMessage.match(/This reverts commit ([a-f0-9]+)/i);
-  return match ? match[1] : null;
-}
-
-async function getRevertCommitDetails(
-  revertedHash: string,
-  repo: string
-): Promise<RevertAuthorInfo | null> {
-  try {
-    const revertedCommitDetailsResponse =
-      await GETSENTRY_ORG.api.repos.getCommit({
-        owner: GETSENTRY_ORG.slug,
-        repo,
-        ref: revertedHash,
-      });
-    const revertedData = revertedCommitDetailsResponse.data;
-
-    const revertedCommitAuthor = revertedData.author
-      ? {
-          login: revertedData.author.login,
-          email: revertedData.commit.author?.email ?? null,
+        if (originalAuthor.login) {
+          authors.push(originalAuthor);
         }
-      : null;
-
-    return revertedCommitAuthor;
-  } catch (revertError) {
-    console.error(
-      `  Error fetching details for reverted commit ${revertedHash}:`,
-      revertError
-    );
-    return null;
-  }
-}
-
-async function getRevertDetailsFromCommit(
-  commitSha: string,
-  commitMessage: string,
-  repo: string
-): Promise<RevertAuthorInfo | null> {
-  try {
-    const revertedHash = extractRevertedCommitHash(commitMessage);
-    let revertDetails: RevertAuthorInfo | null = null;
-
-    if (revertedHash) {
-      revertDetails = await getRevertCommitDetails(revertedHash, repo);
-    }
-
-    return revertDetails;
-  } catch (error) {
-    console.error(`Error processing commit ${commitSha}:`, error);
-    return null;
-  }
-}
-
-async function getCommitAuthorFromMetadata(
-  commitMetadata: any,
-  repo: string
-): Promise<RevertAuthorInfo> {
-  const revertInfo = await getRevertDetailsFromCommit(
-    commitMetadata.sha,
-    commitMetadata.commit.message,
-    repo
-  );
-
-  if (revertInfo) {
-    return {
-      email: revertInfo?.email,
-      login: revertInfo?.login,
-    };
-  }
-  return {
-    email: commitMetadata.commit.author?.email,
-    login: commitMetadata.author?.login,
-  };
-}
-
-export async function getAuthorsWithRevertedCommitAuthors(
-  repo: string,
-  baseCommit: string | null,
-  headCommit: string
-): Promise<Array<RevertAuthorInfo>> {
-  try {
-    const commitsComparison = await GETSENTRY_ORG.api.repos.compareCommits({
-      owner: GETSENTRY_ORG.slug,
-      repo,
-      base: baseCommit ?? headCommit,
-      head: headCommit,
+      }
+      return authors;
     });
-    if (
-      !commitsComparison.data.commits ||
-      commitsComparison.data.commits.length === 0
-    ) {
-      return [];
-    }
-
-    const authors = await Promise.all(
-      commitsComparison.data.commits.map((commitMetadata) =>
-        getCommitAuthorFromMetadata(commitMetadata, repo)
-      )
-    );
-    return authors.filter((author) => author !== null) as RevertAuthorInfo[];
   } catch (err) {
     // eslint-disable-next-line no-console
     // @ts-ignore

--- a/src/utils/github/getAuthors.ts
+++ b/src/utils/github/getAuthors.ts
@@ -40,7 +40,7 @@ interface RevertAuthorInfo {
 }
 
 function extractRevertedCommitHash(commitMessage: string): string | null {
-  const match = commitMessage.match(/this reverts commit ([a-f0-9]+)/i);
+  const match = commitMessage.match(/This reverts commit ([a-f0-9]+)/i);
   return match ? match[1] : null;
 }
 
@@ -135,9 +135,9 @@ export async function getAuthorsWithRevertedCommitAuthors(
     }
 
     const authors = await Promise.all(
-      commitsComparison.data.commits.map(async (commitStatus) => {
+      commitsComparison.data.commits.map(async (commitMetadata) => {
         const revertInfo = await processCommit(
-          commitStatus.sha,
+          commitMetadata.sha,
           GETSENTRY_ORG.slug,
           repo,
           GETSENTRY_ORG.api
@@ -150,8 +150,8 @@ export async function getAuthorsWithRevertedCommitAuthors(
           };
         }
         return {
-          email: commitStatus.commit.author?.email,
-          login: commitStatus.author?.login,
+          email: commitMetadata.commit.author?.email,
+          login: commitMetadata.author?.login,
         };
       })
     );

--- a/src/utils/github/getAuthors.ts
+++ b/src/utils/github/getAuthors.ts
@@ -72,7 +72,7 @@ async function getRevertCommitDetails(
   }
 }
 
-async function processCommit(
+async function getRevertDetailsFromCommit(
   commitSha: string,
   commitMessage: string,
   repo: string
@@ -92,11 +92,11 @@ async function processCommit(
   }
 }
 
-async function processCommitAuthor(
+async function getCommitAuthorFromMetadata(
   commitMetadata: any,
   repo: string
 ): Promise<RevertAuthorInfo> {
-  const revertInfo = await processCommit(
+  const revertInfo = await getRevertDetailsFromCommit(
     commitMetadata.sha,
     commitMetadata.commit.message,
     repo
@@ -135,7 +135,7 @@ export async function getAuthorsWithRevertedCommitAuthors(
 
     const authors = await Promise.all(
       commitsComparison.data.commits.map((commitMetadata) =>
-        processCommitAuthor(commitMetadata, repo)
+        getCommitAuthorFromMetadata(commitMetadata, repo)
       )
     );
     return authors.filter((author) => author !== null) as RevertAuthorInfo[];

--- a/src/utils/github/getAuthors.ts
+++ b/src/utils/github/getAuthors.ts
@@ -1,3 +1,5 @@
+import { Octokit } from '@octokit/rest';
+
 import { GETSENTRY_ORG } from '@/config';
 
 export async function getAuthors(
@@ -26,6 +28,137 @@ export async function getAuthors(
     });
   } catch (err) {
     // eslint-disable-next-line no-console
+    // @ts-ignore
+    console.error(err);
+    return [];
+  }
+}
+
+interface RevertAuthorInfo {
+  login: string | null;
+  email: string | null;
+}
+
+function extractRevertedCommitHash(commitMessage: string): string | null {
+  const match = commitMessage.match(/this reverts commit ([a-f0-9]+)/i);
+  return match ? match[1] : null;
+}
+
+async function getRevertCommitDetails(
+  revertedHash: string,
+  owner: string,
+  repo: string,
+  octokitInstance: Octokit
+): Promise<RevertAuthorInfo | null> {
+  try {
+    const revertedCommitDetailsResponse = await octokitInstance.request(
+      'GET /repos/{owner}/{repo}/commits/{ref}',
+      {
+        owner,
+        repo,
+        ref: revertedHash,
+        headers: { 'X-GitHub-Api-Version': '2022-11-28' },
+      }
+    );
+    const revertedData = revertedCommitDetailsResponse.data;
+
+    const revertedCommitAuthor = revertedData.author
+      ? {
+          login: revertedData.author.login,
+          email: revertedData.commit.author?.email ?? null,
+        }
+      : null;
+
+    return revertedCommitAuthor;
+  } catch (revertError) {
+    console.error(
+      `  Error fetching details for reverted commit ${revertedHash}:`,
+      revertError
+    );
+    return null;
+  }
+}
+
+async function processCommit(
+  commitSha: string,
+  owner: string,
+  repo: string,
+  octokitInstance: Octokit
+): Promise<RevertAuthorInfo | null> {
+  try {
+    const commitDetailsResponse = await octokitInstance.request(
+      'GET /repos/{owner}/{repo}/commits/{ref}',
+      {
+        owner,
+        repo,
+        ref: commitSha,
+        headers: { 'X-GitHub-Api-Version': '2022-11-28' },
+      }
+    );
+    const commitData = commitDetailsResponse.data;
+    const revertedHash = extractRevertedCommitHash(commitData.commit.message);
+    let revertDetails: RevertAuthorInfo | null = null;
+
+    if (revertedHash) {
+      revertDetails = await getRevertCommitDetails(
+        revertedHash,
+        owner,
+        repo,
+        octokitInstance
+      );
+    }
+
+    return revertDetails;
+  } catch (error) {
+    console.error(`Error processing commit ${commitSha}:`, error);
+    return null;
+  }
+}
+
+export async function getAuthorsWithRevertedCommitAuthors(
+  repo: string,
+  baseCommit: string | null,
+  headCommit: string
+): Promise<Array<{ email: string | undefined; login: string | undefined }>> {
+  try {
+    const commitsComparison = await GETSENTRY_ORG.api.repos.compareCommits({
+      owner: GETSENTRY_ORG.slug,
+      repo,
+      base: baseCommit ?? headCommit,
+      head: headCommit,
+    });
+    if (
+      !commitsComparison.data.commits ||
+      commitsComparison.data.commits.length === 0
+    ) {
+      return [];
+    }
+
+    const authors = await Promise.all(
+      commitsComparison.data.commits.map(async (commitStatus) => {
+        const revertInfo = await processCommit(
+          commitStatus.sha,
+          GETSENTRY_ORG.slug,
+          repo,
+          GETSENTRY_ORG.api
+        );
+
+        if (revertInfo) {
+          return {
+            email: revertInfo.email ?? undefined,
+            login: revertInfo.login ?? undefined,
+          };
+        }
+        return {
+          email: commitStatus.commit.author?.email,
+          login: commitStatus.author?.login,
+        };
+      })
+    );
+    return authors;
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    // @ts-ignore
     console.error(err);
     return [];
   }


### PR DESCRIPTION
- Action item from INC-1121
- Add a (default: false) parameter to `getAuthors` to retrieve the authors of original commits in the case of revert
- Add tests
- Use the new function in the Slack feeds for sentry and snuba to notify users when the revert of their commit fails as well

Closes TET-366