### PR TITLE
chore: Remove Ingest team from Source Maps owners

### DIFF
--- a/product-owners.yml
+++ b/product-owners.yml
@@ -30,7 +30,6 @@ product_areas:
   Issues:
   - team-issues
   Issues - Source Maps:
-  - team-ingest
   - team-web-frontend-sdks
   - team-mobile-sdks
   Issues - Suggested Fix:


### PR DESCRIPTION
Source Maps owners are SDKs teams and will involve the Ingest when necessary. 

