### PR TITLE
ref(ingest): Make feed-ingest-triage the issue channel

### DIFF
--- a/product-owners.yml
+++ b/product-owners.yml
@@ -186,7 +186,7 @@ teams:
   team-ingest:
     offices:
     - vie
-    slack_channel: C019637C760
+    slack_channel: C027DDC5WTG # feed-ingest-triage
   team-insights:
     offices:
     - yyz


### PR DESCRIPTION
This changes the channel for triage notifications for the ingest team from `#discuss-ingest` to `#feed-ingest-triage`.