### PR TITLE
Add options automator latency as a tag and into the msg

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,7 @@ export interface SentryOptionsResponse {
     got_type: string;
     expected_type: string;
   }[];
+  latency_seconds?: number;
 }
 
 export interface KafkaControlPlaneResponse {

--- a/src/webhooks/sentry-options/sentry-options.test.ts
+++ b/src/webhooks/sentry-options/sentry-options.test.ts
@@ -639,7 +639,7 @@ describe('sentry-options webhook', function () {
     expect(driftedMessage).toEqual({
       body: {
         dateHappened: 1699563828,
-        text: '{"change":"drifted_options","option":{"option_name":"drifted_option_1","option_value":"value_1"}}',
+        text: '{"change":"drifted_options","option":{"option_name":"drifted_option_1","option_value":"value_1"},"latency_seconds":2.5}',
         title: 'Sentry Options Update',
         alertType: 'error',
         tags: [
@@ -659,7 +659,7 @@ describe('sentry-options webhook', function () {
     expect(updatedMessage).toEqual({
       body: {
         dateHappened: 1699563828,
-        text: '{"change":"updated_options","option":{"option_name":"updated_option_1","db_value":"db_value_1","value":"new_value_1"}}',
+        text: '{"change":"updated_options","option":{"option_name":"updated_option_1","db_value":"db_value_1","value":"new_value_1"},"latency_seconds":2.5}',
         title: 'Sentry Options Update',
         alertType: 'success',
         tags: [

--- a/src/webhooks/sentry-options/sentry-options.test.ts
+++ b/src/webhooks/sentry-options/sentry-options.test.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/node';
 import testAdminPayload from '@test/payloads/sentry-options/test-admin-payload.json';
 import testBadPayload from '@test/payloads/sentry-options/test-bad-payload.json';
 import testEmptyPayload from '@test/payloads/sentry-options/test-empty-payload.json';
+import testLatencyPayload from '@test/payloads/sentry-options/test-latency-payload.json';
 import testMegaPayload from '@test/payloads/sentry-options/test-mega-payload.json';
 import testPartialPayload from '@test/payloads/sentry-options/test-partial-payload.json';
 import testPayload from '@test/payloads/sentry-options/test-payload.json';
@@ -627,5 +628,66 @@ describe('sentry-options webhook', function () {
         ],
       },
     });
+  });
+
+  it('should include latency_seconds tag when present', async function () {
+    await sendSentryOptionsUpdatesToDatadog(testLatencyPayload, 1699563828);
+    expect(datadogApiInstanceSpy).toHaveBeenCalledTimes(2);
+
+    // Check the drifted_options message
+    const driftedMessage = datadogApiInstanceSpy.mock.calls[0][0];
+    expect(driftedMessage).toEqual({
+      body: {
+        dateHappened: 1699563828,
+        text: '{"change":"drifted_options","option":{"option_name":"drifted_option_1","option_value":"value_1"}}',
+        title: 'Sentry Options Update',
+        alertType: 'error',
+        tags: [
+          'sentry_region:st-test_region',
+          'source_tool:options-automator',
+          'source:options-automator',
+          'source_category:infra-tools',
+          'option_name:drifted_option_1',
+          'sentry_user:options-automator',
+          'latency_seconds:2.5',
+        ],
+      },
+    });
+
+    // Check the updated_options message
+    const updatedMessage = datadogApiInstanceSpy.mock.calls[1][0];
+    expect(updatedMessage).toEqual({
+      body: {
+        dateHappened: 1699563828,
+        text: '{"change":"updated_options","option":{"option_name":"updated_option_1","db_value":"db_value_1","value":"new_value_1"}}',
+        title: 'Sentry Options Update',
+        alertType: 'success',
+        tags: [
+          'sentry_region:st-test_region',
+          'source_tool:options-automator',
+          'source:options-automator',
+          'source_category:infra-tools',
+          'option_name:updated_option_1',
+          'sentry_user:options-automator',
+          'latency_seconds:2.5',
+        ],
+      },
+    });
+  });
+
+  it('should not include latency_seconds tag when not present', async function () {
+    await sendSentryOptionsUpdatesToDatadog(testPartialPayload, 1699563828);
+    expect(datadogApiInstanceSpy).toHaveBeenCalledTimes(2);
+
+    // Check that no tags contain latency_seconds
+    const firstMessage = datadogApiInstanceSpy.mock.calls[0][0];
+    const secondMessage = datadogApiInstanceSpy.mock.calls[1][0];
+
+    expect(firstMessage.body.tags).not.toContain(
+      expect.stringMatching(/^latency_seconds:/)
+    );
+    expect(secondMessage.body.tags).not.toContain(
+      expect.stringMatching(/^latency_seconds:/)
+    );
   });
 });

--- a/src/webhooks/sentry-options/sentry-options.test.ts
+++ b/src/webhooks/sentry-options/sentry-options.test.ts
@@ -654,7 +654,6 @@ describe('sentry-options webhook', function () {
       },
     });
 
-    // Check the updated_options message
     const updatedMessage = datadogApiInstanceSpy.mock.calls[1][0];
     expect(updatedMessage).toEqual({
       body: {
@@ -679,7 +678,6 @@ describe('sentry-options webhook', function () {
     await sendSentryOptionsUpdatesToDatadog(testPartialPayload, 1699563828);
     expect(datadogApiInstanceSpy).toHaveBeenCalledTimes(2);
 
-    // Check that no tags contain latency_seconds
     const firstMessage = datadogApiInstanceSpy.mock.calls[0][0];
     const secondMessage = datadogApiInstanceSpy.mock.calls[1][0];
 

--- a/src/webhooks/sentry-options/sentry-options.ts
+++ b/src/webhooks/sentry-options/sentry-options.ts
@@ -75,7 +75,12 @@ export async function sendSentryOptionsUpdatesToDatadog(
   const region = formatRegionTag(message.region);
 
   for (const optionType in message) {
-    if (optionType === 'region' || optionType === 'source') continue;
+    if (
+      optionType === 'region' ||
+      optionType === 'source' ||
+      optionType === 'latency_seconds'
+    )
+      continue;
     for (const option of message[optionType]) {
       const text = {
         change: optionType,

--- a/src/webhooks/sentry-options/sentry-options.ts
+++ b/src/webhooks/sentry-options/sentry-options.ts
@@ -80,9 +80,26 @@ export async function sendSentryOptionsUpdatesToDatadog(
       const text = {
         change: optionType,
         option: option,
+        ...(message.latency_seconds !== undefined && {
+          latency_seconds: message.latency_seconds,
+        }),
       };
 
       const alertType = formatAlertType(optionType);
+
+      const tags = [
+        region,
+        `source_tool:${message.source}`,
+        `source:${message.source}`,
+        `source_category:infra-tools`,
+        `option_name:${option.option_name}`,
+        `sentry_user:${message.source}`,
+      ];
+
+      // Add latency_seconds as a tag if it exists
+      if (message.latency_seconds !== undefined) {
+        tags.push(`latency_seconds:${message.latency_seconds}`);
+      }
 
       const params: v1.EventCreateRequest = {
         title: 'Sentry Options Update',
@@ -90,14 +107,7 @@ export async function sendSentryOptionsUpdatesToDatadog(
         text: JSON.stringify(text),
         alertType: alertType,
         dateHappened: timestamp,
-        tags: [
-          region,
-          `source_tool:${message.source}`,
-          `source:${message.source}`,
-          `source_category:infra-tools`,
-          `option_name:${option.option_name}`,
-          `sentry_user:${message.source}`,
-        ],
+        tags: tags,
       };
       await DATADOG_API_INSTANCE.createEvent({ body: params });
     }

--- a/test/payloads/sentry-options/test-latency-payload.json
+++ b/test/payloads/sentry-options/test-latency-payload.json
@@ -11,5 +11,10 @@
             "db_value": "db_value_1",
             "value": "new_value_1"
         }
-    ]
+    ],
+    "set_options": [],
+    "unset_options": [],
+    "not_writable_options": [],
+    "unregistered_options": [],
+    "invalid_type_options": []
 }

--- a/test/payloads/sentry-options/test-latency-payload.json
+++ b/test/payloads/sentry-options/test-latency-payload.json
@@ -1,0 +1,15 @@
+{
+    "region": "test_region",
+    "source": "options-automator",
+    "latency_seconds": 2.5,
+    "drifted_options": [
+        {"option_name": "drifted_option_1", "option_value": "value_1"}
+    ],
+    "updated_options": [
+        {
+            "option_name": "updated_option_1",
+            "db_value": "db_value_1",
+            "value": "new_value_1"
+        }
+    ]
+}


### PR DESCRIPTION
This adds a latency metric that the options automator can write to datadog to help better report options automator SLOs. 