### PR TITLE
Datadog metrics API 

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -7,7 +7,10 @@ import { GoCDPausedPipelineReminder } from '@/types/gocd';
 
 import { makeUserTokenClient } from '../api/github/makeUserTokenClient';
 
-import { loadDatadogApiInstance } from './loadDatadogApiInstance';
+import {
+  loadDatadogApiInstance,
+  loadDatadogApiMetricsInstance,
+} from './loadDatadogApiInstance';
 import { GitHubOrgs, loadGitHubOrgs } from './loadGitHubOrgs';
 
 export const SENTRY_DSN =
@@ -85,7 +88,9 @@ export const PROJECT =
     ? 'super-big-data'
     : process.env.DEV_GCP_PROJECT;
 export const DATADOG_API_INSTANCE = loadDatadogApiInstance(process.env);
-
+export const DATADOG_API_METRICS_INSTANCE = loadDatadogApiMetricsInstance(
+  process.env
+);
 // The name of the GitHub Check that is created in getsentry to aggregate "required" jobs
 export const REQUIRED_CHECK_NAME = 'getsentry required checks';
 export const REQUIRED_CHECK_CHANNEL = '#team-engineering';

--- a/src/config/loadDatadogApiInstance.ts
+++ b/src/config/loadDatadogApiInstance.ts
@@ -1,6 +1,6 @@
 import { client, v1 } from '@datadog/datadog-api-client';
 
-export function loadDatadogApiInstance(env) {
+function loadDatadogConfiguration(env) {
   const configurationOpts = {
     authMethods: {
       apiKeyAuth: env.DD_API_KEY,
@@ -9,6 +9,15 @@ export function loadDatadogApiInstance(env) {
     enableRetry: true,
   };
 
-  const configuration = client.createConfiguration(configurationOpts);
+  return client.createConfiguration(configurationOpts);
+}
+
+export function loadDatadogApiInstance(env): v1.EventsApi {
+  const configuration = loadDatadogConfiguration(env);
   return new v1.EventsApi(configuration);
+}
+
+export function loadDatadogApiMetricsInstance(env): v1.MetricsApi {
+  const configuration = loadDatadogConfiguration(env);
+  return new v1.MetricsApi(configuration);
 }


### PR DESCRIPTION
This adds the ability to send metrics to datadog. These are different from events and will enable better visibiity on options automator. 