### PR TITLE
chore(gocd): Add pipeline name to the DD event

### DIFF
--- a/src/brain/gocd/gocdDataDog/deployDatadogEvents.test.ts
+++ b/src/brain/gocd/gocdDataDog/deployDatadogEvents.test.ts
@@ -243,7 +243,9 @@ describe('GocdDatadogEvents', () => {
       const message = datadogApiInstanceSpy.mock.calls[0][0];
       expect(message).toEqual({
         body: {
-          title: 'GoCD: deploying <sentryio> <getsentry_frontend> <deploying> <In progress> in all',
+          title:
+            'GoCD: deploying <sentryio> <getsentry_frontend> <deploying> ' +
+            <In progress> in all',
           text:
             '%%% \n' +
             'GoCD deployment started from: [getsentry@2b0034becc4a](https://github.com/getsentry/getsentry/commits/2b0034becc4ab26b985f4c1a08ab068f153c274c),\n' +
@@ -276,7 +278,9 @@ describe('GocdDatadogEvents', () => {
       const message = datadogApiInstanceSpy.mock.calls[0][0];
       expect(message).toEqual({
         body: {
-          title: 'GoCD: deploying <snuba> <deploy-snuba-us> <st_migrate> <Passed> in us',
+          title:
+            'GoCD: deploying <snuba> <deploy-snuba-us> <st_migrate> ' +
+            <Passed> in us',
           text:
             '%%% \n' +
             'GoCD auto-deployment started from: [snuba@4d71a785da42](https://github.com/getsentry/snuba/commits/4d71a785da42db5606c2c82bb5a91adfb5006fc7),\n' +

--- a/src/brain/gocd/gocdDataDog/deployDatadogEvents.test.ts
+++ b/src/brain/gocd/gocdDataDog/deployDatadogEvents.test.ts
@@ -91,7 +91,7 @@ describe('GocdDatadogEvents', () => {
       expect(message).toEqual({
         body: {
           title:
-            'GoCD: deploying <getsentry-control-frontend> <deploy> <In progress> in all',
+            'GoCD: deploying <getsentry-control-frontend> <deploy-getsentry-control-frontend-test> <deploy> <In progress> in all',
           text:
             '%%% \n' +
             'GoCD auto-deployment started from: [getsentry@d2501d598f97](https://github.com/getsentry/getsentry/commits/d2501d598f97829b43627ba5d5721013f1d217dc),\n' +
@@ -132,7 +132,7 @@ describe('GocdDatadogEvents', () => {
       expect(message).toEqual({
         body: {
           title:
-            'GoCD: deploying <getsentry-control-frontend> <deploy> <Cancelled> in all',
+            'GoCD: deploying <getsentry-control-frontend> <deploy-getsentry-control-frontend-test> <deploy> <Cancelled> in all',
           text:
             '%%% \n' +
             'GoCD deployment started by <@U018H4DA8N5> from: [getsentry@d2501d598f97](https://github.com/getsentry/getsentry/commits/d2501d598f97829b43627ba5d5721013f1d217dc),\n' +
@@ -243,7 +243,7 @@ describe('GocdDatadogEvents', () => {
       const message = datadogApiInstanceSpy.mock.calls[0][0];
       expect(message).toEqual({
         body: {
-          title: 'GoCD: deploying <sentryio> <deploying> <In progress> in all',
+          title: 'GoCD: deploying <sentryio> <getsentry_frontend> <deploying> <In progress> in all',
           text:
             '%%% \n' +
             'GoCD deployment started from: [getsentry@2b0034becc4a](https://github.com/getsentry/getsentry/commits/2b0034becc4ab26b985f4c1a08ab068f153c274c),\n' +
@@ -276,7 +276,7 @@ describe('GocdDatadogEvents', () => {
       const message = datadogApiInstanceSpy.mock.calls[0][0];
       expect(message).toEqual({
         body: {
-          title: 'GoCD: deploying <snuba> <st_migrate> <Passed> in us',
+          title: 'GoCD: deploying <snuba> <deploy-snuba-us> <st_migrate> <Passed> in us',
           text:
             '%%% \n' +
             'GoCD auto-deployment started from: [snuba@4d71a785da42](https://github.com/getsentry/snuba/commits/4d71a785da42db5606c2c82bb5a91adfb5006fc7),\n' +

--- a/src/brain/gocd/gocdDataDog/deployDatadogEvents.ts
+++ b/src/brain/gocd/gocdDataDog/deployDatadogEvents.ts
@@ -281,6 +281,9 @@ export class DeployDatadogEvents {
     // getsentry-frontend
     const service = pipeline.group;
 
+    // deploy-getsentry-backend-us
+    const pipelineName = pipeline.name;
+
     // getsentry@h92mfyw
     // let repoSha = this.getRepoSha(pipeline);
 
@@ -304,7 +307,7 @@ export class DeployDatadogEvents {
     const sentry_user_tags = authors.map((user) => `sentry_user:${user.login}`);
 
     // Title: GoCD: deploy sha (started/failed/completed)  in <insert>-region
-    const title = `GoCD: deploying <${service}> <${stageName}> <${pipelineResult}> in ${region}`;
+    const title = `GoCD: deploying <${service}> <${pipelineName}> <${stageName}> <${pipelineResult}> in ${region}`;
     // Automatic deploy triggered by <github push?>  to track details visit: https://deploy.getsentry.net/go/pipelines/value_stream_map/deploy-getsentry-backend-s4s/2237
     const text = `%%% \n${deploymentReason} from: ${commitShaLink},\n \n ${commitDiffLink} \n GoCD:${stageLink} \n\n   *this message was produced by a eng-pipes gocd brain module* \n %%%`;
     // Tags: source:gocd customer_name:s4s sentry_region:s4s source_tool:gocd sentry_user:git commit email  source_category:infra-tools


### PR DESCRIPTION
When we report GoCD events to DataDog we don't include the pipeline name, this can make it a little confusing where we have non-chained pipelines like `post-deploy-migrations` and `run-custom-job`.  When looking for events for these kinds of pipelines it can be not obvious that they're not standard pipedream pipelines.