### PR TITLE
fix(slack): Revert backend pipeline constant change and fix consecutive pipeline

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -24,6 +24,7 @@ SENTRY_INFORMER_WEBHOOK_SECRET="sentryinformerwebhooksecret"
 # Other
 GOCD_SENTRYIO_FE_PIPELINE_NAME="getsentry-frontend"
 GOCD_SENTRYIO_BE_PIPELINE_NAME="getsentry-backend"
+GOCD_SENTRYIO_BE_CONSECUTIVE_PIPELINE_NAME="getsentry-backend"
 GOCD_ORIGIN="https://deploy.getsentry.net"
 GOCD_TOKEN="fake-token"
 FEED_DEPLOY_CHANNEL_ID="9101112"

--- a/.env.test
+++ b/.env.test
@@ -24,7 +24,6 @@ SENTRY_INFORMER_WEBHOOK_SECRET="sentryinformerwebhooksecret"
 # Other
 GOCD_SENTRYIO_FE_PIPELINE_NAME="getsentry-frontend"
 GOCD_SENTRYIO_BE_PIPELINE_NAME="getsentry-backend"
-GOCD_SENTRYIO_BE_CONSECUTIVE_PIPELINE_NAME="getsentry-backend"
 GOCD_ORIGIN="https://deploy.getsentry.net"
 GOCD_TOKEN="fake-token"
 FEED_DEPLOY_CHANNEL_ID="9101112"

--- a/src/brain/gocd/gocdConsecutiveUnsuccessfulAlert/index.test.ts
+++ b/src/brain/gocd/gocdConsecutiveUnsuccessfulAlert/index.test.ts
@@ -10,8 +10,8 @@ import {
   DISCUSS_BACKEND_CHANNEL_ID,
   DISCUSS_FRONTEND_CHANNEL_ID,
   FEED_DEV_INFRA_CHANNEL_ID,
+  GOCD_SENTRYIO_BE_CONSECUTIVE_PIPELINE_NAME,
   GOCD_SENTRYIO_BE_PIPELINE_GROUP,
-  GOCD_SENTRYIO_BE_PIPELINE_NAME,
   GOCD_SENTRYIO_FE_PIPELINE_GROUP,
   GOCD_SENTRYIO_FE_PIPELINE_NAME,
 } from '@/config';
@@ -75,7 +75,7 @@ describe('gocdConsecutiveUnsuccessfulAlerts', function () {
     const gocdPayload = merge({}, payload, {
       data: {
         pipeline: {
-          name: GOCD_SENTRYIO_BE_PIPELINE_NAME,
+          name: GOCD_SENTRYIO_BE_CONSECUTIVE_PIPELINE_NAME,
           stage: {
             name: 'deploy-canary',
             result: 'Passed',
@@ -94,7 +94,7 @@ describe('gocdConsecutiveUnsuccessfulAlerts', function () {
     const gocdPayload = merge({}, payload, {
       data: {
         pipeline: {
-          name: GOCD_SENTRYIO_BE_PIPELINE_NAME,
+          name: GOCD_SENTRYIO_BE_CONSECUTIVE_PIPELINE_NAME,
           stage: {
             name: 'deploy-canary',
             result: 'Failed',
@@ -113,7 +113,7 @@ describe('gocdConsecutiveUnsuccessfulAlerts', function () {
     await db(DB_TABLE_STAGES).insert({
       pipeline_id: 'pipeline-id-123',
 
-      pipeline_name: GOCD_SENTRYIO_BE_PIPELINE_NAME,
+      pipeline_name: GOCD_SENTRYIO_BE_CONSECUTIVE_PIPELINE_NAME,
       pipeline_counter: 19,
       pipeline_group: GOCD_SENTRYIO_BE_PIPELINE_GROUP,
       pipeline_build_cause: JSON.stringify([
@@ -152,7 +152,7 @@ describe('gocdConsecutiveUnsuccessfulAlerts', function () {
       data: {
         pipeline: {
           group: GOCD_SENTRYIO_BE_PIPELINE_GROUP,
-          name: GOCD_SENTRYIO_BE_PIPELINE_NAME,
+          name: GOCD_SENTRYIO_BE_CONSECUTIVE_PIPELINE_NAME,
           stage: {
             name: 'deploy-canary',
             result: 'Failed',
@@ -171,7 +171,7 @@ describe('gocdConsecutiveUnsuccessfulAlerts', function () {
     await db(DB_TABLE_STAGES).insert({
       pipeline_id: 'pipeline-id-123',
 
-      pipeline_name: GOCD_SENTRYIO_BE_PIPELINE_NAME,
+      pipeline_name: GOCD_SENTRYIO_BE_CONSECUTIVE_PIPELINE_NAME,
       pipeline_counter: 17,
       pipeline_group: GOCD_SENTRYIO_BE_PIPELINE_GROUP,
       pipeline_build_cause: JSON.stringify([
@@ -210,7 +210,7 @@ describe('gocdConsecutiveUnsuccessfulAlerts', function () {
       data: {
         pipeline: {
           group: GOCD_SENTRYIO_BE_PIPELINE_GROUP,
-          name: GOCD_SENTRYIO_BE_PIPELINE_NAME,
+          name: GOCD_SENTRYIO_BE_CONSECUTIVE_PIPELINE_NAME,
           stage: {
             name: 'deploy-canary',
             status: 'Building',
@@ -230,7 +230,7 @@ describe('gocdConsecutiveUnsuccessfulAlerts', function () {
     await db(DB_TABLE_STAGES).insert({
       pipeline_id: 'pipeline-id-123',
 
-      pipeline_name: GOCD_SENTRYIO_BE_PIPELINE_NAME,
+      pipeline_name: GOCD_SENTRYIO_BE_CONSECUTIVE_PIPELINE_NAME,
       pipeline_counter: 20 - CONSECUTIVE_UNSUCCESSFUL_DEPLOYS_LIMIT,
       pipeline_group: GOCD_SENTRYIO_BE_PIPELINE_GROUP,
       pipeline_build_cause: JSON.stringify([
@@ -268,7 +268,7 @@ describe('gocdConsecutiveUnsuccessfulAlerts', function () {
     const gocdPayload = merge({}, payload, {
       data: {
         pipeline: {
-          name: GOCD_SENTRYIO_BE_PIPELINE_NAME,
+          name: GOCD_SENTRYIO_BE_CONSECUTIVE_PIPELINE_NAME,
           group: GOCD_SENTRYIO_BE_PIPELINE_GROUP,
           stage: {
             name: 'deploy-canary',
@@ -308,7 +308,7 @@ describe('gocdConsecutiveUnsuccessfulAlerts', function () {
   it('post to discuss-backend and feed-dev-infra if the number of consecutive unsuccessful backend deploys is exactly the limit', async function () {
     await db(DB_TABLE_STAGES).insert({
       pipeline_id: 'pipeline-id-123',
-      pipeline_name: GOCD_SENTRYIO_BE_PIPELINE_NAME,
+      pipeline_name: GOCD_SENTRYIO_BE_CONSECUTIVE_PIPELINE_NAME,
       pipeline_counter: 20 - CONSECUTIVE_UNSUCCESSFUL_DEPLOYS_LIMIT,
       pipeline_group: GOCD_SENTRYIO_BE_PIPELINE_GROUP,
       pipeline_build_cause: JSON.stringify([
@@ -345,7 +345,7 @@ describe('gocdConsecutiveUnsuccessfulAlerts', function () {
     const gocdPayload = merge({}, payload, {
       data: {
         pipeline: {
-          name: GOCD_SENTRYIO_BE_PIPELINE_NAME,
+          name: GOCD_SENTRYIO_BE_CONSECUTIVE_PIPELINE_NAME,
           group: GOCD_SENTRYIO_BE_PIPELINE_GROUP,
           stage: {
             name: 'deploy-canary',
@@ -368,7 +368,7 @@ describe('gocdConsecutiveUnsuccessfulAlerts', function () {
   it('does not post to discuss-backend again when consecutive unsuccessful backend deploys exceeds the limit', async function () {
     await db(DB_TABLE_STAGES).insert({
       pipeline_id: 'pipeline-id-123',
-      pipeline_name: GOCD_SENTRYIO_BE_PIPELINE_NAME,
+      pipeline_name: GOCD_SENTRYIO_BE_CONSECUTIVE_PIPELINE_NAME,
       pipeline_counter: 20 - CONSECUTIVE_UNSUCCESSFUL_DEPLOYS_LIMIT - 1,
       pipeline_group: GOCD_SENTRYIO_BE_PIPELINE_GROUP,
       pipeline_build_cause: JSON.stringify([
@@ -405,7 +405,7 @@ describe('gocdConsecutiveUnsuccessfulAlerts', function () {
     const gocdPayload = merge({}, payload, {
       data: {
         pipeline: {
-          name: GOCD_SENTRYIO_BE_PIPELINE_NAME,
+          name: GOCD_SENTRYIO_BE_CONSECUTIVE_PIPELINE_NAME,
           group: GOCD_SENTRYIO_BE_PIPELINE_GROUP,
           stage: {
             name: 'deploy-canary',

--- a/src/brain/gocd/gocdConsecutiveUnsuccessfulAlert/index.test.ts
+++ b/src/brain/gocd/gocdConsecutiveUnsuccessfulAlert/index.test.ts
@@ -288,17 +288,17 @@ describe('gocdConsecutiveUnsuccessfulAlerts', function () {
     expect(channels).toContain(FEED_DEV_INFRA_CHANNEL_ID);
     expect(channels).toContain(DISCUSS_BACKEND_CHANNEL_ID);
     expect(bolt.client.chat.postMessage.mock.calls[0][0]).toMatchObject({
-      text: `❗️ *getsentry-backend* has had ${CONSECUTIVE_UNSUCCESSFUL_DEPLOYS_LIMIT} consecutive unsuccessful deploys.`,
+      text: `❗️ *${GOCD_SENTRYIO_BE_CONSECUTIVE_PIPELINE_NAME}* has had ${CONSECUTIVE_UNSUCCESSFUL_DEPLOYS_LIMIT} consecutive unsuccessful deploys.`,
       channel: FEED_DEV_INFRA_CHANNEL_ID,
       blocks: [
         slackblocks.section(
           slackblocks.markdown(
-            `❗️ *getsentry-backend* has had ${CONSECUTIVE_UNSUCCESSFUL_DEPLOYS_LIMIT} consecutive unsuccessful deploys.`
+            `❗️ *${GOCD_SENTRYIO_BE_CONSECUTIVE_PIPELINE_NAME}* has had ${CONSECUTIVE_UNSUCCESSFUL_DEPLOYS_LIMIT} consecutive unsuccessful deploys.`
           )
         ),
         slackblocks.section(
           slackblocks.markdown(
-            `<https://deploy.getsentry.net/go/pipelines/getsentry-backend/20/deploy-canary/1|Latest failure> | <https://deploy.getsentry.net/go/pipelines/value_stream_map/getsentry-backend/17|Last good deploy> | <https://deploy-tools.getsentry.net/services/getsentry-backend|Deploy Tools>`
+            `<https://deploy.getsentry.net/go/pipelines/${GOCD_SENTRYIO_BE_CONSECUTIVE_PIPELINE_NAME}/20/deploy-canary/1|Latest failure> | <https://deploy.getsentry.net/go/pipelines/value_stream_map/${GOCD_SENTRYIO_BE_CONSECUTIVE_PIPELINE_NAME}/17|Last good deploy> | <https://deploy-tools.getsentry.net/services/${GOCD_SENTRYIO_BE_PIPELINE_GROUP}|Deploy Tools>`
           )
         ),
       ],

--- a/src/brain/gocd/gocdConsecutiveUnsuccessfulAlert/index.ts
+++ b/src/brain/gocd/gocdConsecutiveUnsuccessfulAlert/index.ts
@@ -3,7 +3,7 @@ import {
   DISCUSS_BACKEND_CHANNEL_ID,
   DISCUSS_FRONTEND_CHANNEL_ID,
   FEED_DEV_INFRA_CHANNEL_ID,
-  GOCD_SENTRYIO_BE_PIPELINE_NAME,
+  GOCD_SENTRYIO_BE_CONSECUTIVE_PIPELINE_NAME,
   GOCD_SENTRYIO_FE_PIPELINE_NAME,
 } from '@/config';
 import { GoCDResponse } from '@/types/gocd';
@@ -11,7 +11,7 @@ import { GoCDResponse } from '@/types/gocd';
 import { ConsecutiveUnsuccessfulDeploysAlert } from './consecutiveUnsuccessfulDeploysAlert';
 
 const PIPELINE_FILTER = [
-  GOCD_SENTRYIO_BE_PIPELINE_NAME,
+  GOCD_SENTRYIO_BE_CONSECUTIVE_PIPELINE_NAME,
   GOCD_SENTRYIO_FE_PIPELINE_NAME,
 ];
 
@@ -35,7 +35,7 @@ const discussBackendAlert = new ConsecutiveUnsuccessfulDeploysAlert({
   consecutiveUnsuccessfulLimit: 3,
   alertOnlyAtThreshold: true,
   pipelineFilter: (pipeline) =>
-    pipeline.name === GOCD_SENTRYIO_BE_PIPELINE_NAME,
+    pipeline.name === GOCD_SENTRYIO_BE_CONSECUTIVE_PIPELINE_NAME,
 });
 
 export async function handler(body: GoCDResponse) {

--- a/src/brain/gocd/gocdSlackFeeds/index.ts
+++ b/src/brain/gocd/gocdSlackFeeds/index.ts
@@ -21,7 +21,6 @@ import {
   FEED_SNS_SAAS_CHANNEL_ID,
   FEED_SNS_ST_CHANNEL_ID,
   FEED_UPTIME_CHANNEL_ID,
-  GOCD_SENTRYIO_BE_PIPELINE_NAME,
 } from '@/config';
 import { SlackMessage } from '@/config/slackMessage';
 import { GoCDPipeline, GoCDResponse } from '@/types/gocd';
@@ -43,7 +42,8 @@ enum PauseCause {
 const BACKEND_PIPELINE_FILTER = [
   'deploy-getsentry-backend-s4s',
   'deploy-getsentry-backend-de',
-  GOCD_SENTRYIO_BE_PIPELINE_NAME,
+  'deploy-getsentry-backend-us',
+  'deploy-getsentry-backend-s4s2',
   'deploy-getsentry-backend-control',
 ];
 

--- a/src/brain/gocd/gocdSlackFeeds/index.ts
+++ b/src/brain/gocd/gocdSlackFeeds/index.ts
@@ -21,6 +21,7 @@ import {
   FEED_SNS_SAAS_CHANNEL_ID,
   FEED_SNS_ST_CHANNEL_ID,
   FEED_UPTIME_CHANNEL_ID,
+  GOCD_SENTRYIO_BE_PIPELINE_NAME,
 } from '@/config';
 import { SlackMessage } from '@/config/slackMessage';
 import { GoCDPipeline, GoCDResponse } from '@/types/gocd';
@@ -45,6 +46,7 @@ const BACKEND_PIPELINE_FILTER = [
   'deploy-getsentry-backend-us',
   'deploy-getsentry-backend-s4s2',
   'deploy-getsentry-backend-control',
+  GOCD_SENTRYIO_BE_PIPELINE_NAME,
 ];
 
 const GOCD_CUSTOM_JOB_PIPELINE_NAME = 'run-custom-job';

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -32,7 +32,10 @@ export const GOCD_SENTRYIO_FE_PIPELINE_NAME =
 export const GOCD_SENTRYIO_BE_PIPELINE_GROUP =
   process.env.GOCD_SENTRYIO_BE_PIPELINE_GROUP || 'getsentry-backend';
 export const GOCD_SENTRYIO_BE_PIPELINE_NAME =
-  process.env.GOCD_SENTRYIO_BE_PIPELINE_NAME || 'deploy-getsentry-backend-s4s2';
+  process.env.GOCD_SENTRYIO_BE_PIPELINE_NAME || 'deploy-getsentry-backend-us';
+export const GOCD_SENTRYIO_BE_CONSECUTIVE_PIPELINE_NAME =
+  process.env.GOCD_SENTRYIO_BE_CONSECUTIVE_PIPELINE_NAME ||
+  'deploy-getsentry-backend-s4s2';
 export const GOCD_ORIGIN =
   process.env.GOCD_ORIGIN || 'https://deploy.getsentry.net';
 export const FEED_DEPLOY_CHANNEL_ID =


### PR DESCRIPTION
In #948 I changed `GOCD_SENTRYIO_BE_PIPELINE_NAME` so that consecutive deploy failures would only be picked up in s4s2. The problem was `BACKEND_PIPELINE_FILTER` didn't include `us` or `s4s2` by default, and instead just passed in `GOCD_SENTRYIO_BE_PIPELINE_NAME`, so we stopped alerting on `us`.

This addresses both issues simultaneously, reverting the `us` -> `s4s2` change and adding a new constant for the consecutive deploy pipeline