### PR TITLE
fix(slack): capture errors from triage reminder notifications

### DIFF
--- a/src/jobs/slackNotifications.ts
+++ b/src/jobs/slackNotifications.ts
@@ -385,6 +385,10 @@ export const constructSlackMessage = (
           .insert({ channel_id: channelId, last_notified_at: now })
           .onConflict('channel_id')
           .merge();
+      })
+      .catch((err) => {
+        Sentry.setContext('slack', { channelId });
+        Sentry.captureException(err);
       });
   });
 };


### PR DESCRIPTION
## Summary
- The promise chain in `constructSlackMessage` for posting triage reminders to Slack and updating `channel_last_notified` in the DB had no `.catch()` handler
- If either the Slack post or DB insert failed, the error was silently swallowed — no Sentry alert, no log
- Adds `.catch()` with `Sentry.setContext` and `Sentry.captureException` so failures surface in Sentry with the relevant channel ID

## Test plan
- [x] Lint passes
- [x] Existing tests unaffected (DB-dependent tests already fail due to missing local DB, unrelated)
- [ ] Verify in staging that Sentry captures errors if a triage reminder post fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)