### PR TITLE
fix(gocd): cc authors on all stage failures, not just canary/soak-time

### DIFF
--- a/src/brain/gocd/gocdSlackFeeds/index.test.ts
+++ b/src/brain/gocd/gocdSlackFeeds/index.test.ts
@@ -1662,6 +1662,42 @@ describe('gocdSlackFeeds', function () {
     });
   });
 
+  it('cc authors on non-pause stage failure (e.g. migration)', async function () {
+    const gocdPayload = merge({}, payload, {
+      data: {
+        pipeline: {
+          name: GOCD_SENTRYIO_BE_PIPELINE_NAME,
+          stage: {
+            name: 'migrate',
+            result: 'Failed',
+            jobs: [{ name: 'migrate-job', result: 'Failed' }],
+          },
+        },
+      },
+    });
+
+    await handler(gocdPayload);
+
+    // 3 feed messages + 1 reply with cc
+    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(4);
+
+    const postCalls = bolt.client.chat.postMessage.mock.calls;
+    const reply = postCalls.find(
+      (call) => call[0].text === '' && call[0].blocks
+    );
+    expect(reply).toBeDefined();
+    expect(reply![0]).toMatchObject({
+      channel: DISCUSS_BACKEND_CHANNEL_ID,
+      blocks: expect.arrayContaining([
+        expect.objectContaining({
+          text: expect.objectContaining({
+            text: expect.stringContaining('has failed'),
+          }),
+        }),
+      ]),
+    });
+  });
+
   it('post message to feed-deploy only misc pipeline', async function () {
     const gocdPayload = merge({}, payload, {
       data: {

--- a/src/brain/gocd/gocdSlackFeeds/index.test.ts
+++ b/src/brain/gocd/gocdSlackFeeds/index.test.ts
@@ -670,7 +670,7 @@ describe('gocdSlackFeeds', function () {
     expect(slackMessages).toHaveLength(3);
   });
 
-  it('do not reply to canary if deploy-backend job did not fail', async function () {
+  it('reply with generic failure for canary if deploy-backend job did not fail', async function () {
     org.api.repos.compareCommits.mockImplementation((args) => {
       if (args.owner !== GETSENTRY_ORG.slug) {
         throw new Error(`Unexpected compareCommits() owner: ${args.owner}`);
@@ -717,7 +717,26 @@ describe('gocdSlackFeeds', function () {
     // First Event
     await handler(gocdPayload);
 
-    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(3);
+    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(4);
+
+    const failureReply = {
+      channel: DISCUSS_BACKEND_CHANNEL_ID,
+      text: '',
+      blocks: [
+        slackblocks.header(
+          slackblocks.plaintext(':x: getsentry-backend has failed')
+        ),
+        slackblocks.section(
+          slackblocks.markdown(`The deployment pipeline has failed due to detected issues in deploy-canary.\n
+*Review the errors* in the *<https://deploy.getsentry.net/go/tab/build/detail/getsentry-backend/20/deploy-canary/1/another-job|GoCD Logs>*.`)
+        ),
+        slackblocks.context(
+          slackblocks.markdown(
+            `cc'ing the following people who have commits in this deploy:\n<@U018H4DA8N5>`
+          )
+        ),
+      ],
+    };
 
     const wantPostMsg = {
       text: 'GoCD deployment started',
@@ -749,17 +768,17 @@ describe('gocdSlackFeeds', function () {
         },
       ],
     };
-    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(3);
 
     const postCalls = bolt.client.chat.postMessage.mock.calls;
     postCalls.sort(sortMessages);
     expect(postCalls[0][0]).toMatchObject(
       merge({}, wantPostMsg, { channel: DISCUSS_BACKEND_CHANNEL_ID })
     );
-    expect(postCalls[1][0]).toMatchObject(
+    expect(postCalls[1][0]).toMatchObject(failureReply);
+    expect(postCalls[2][0]).toMatchObject(
       merge({}, wantPostMsg, { channel: FEED_DEPLOY_CHANNEL_ID })
     );
-    expect(postCalls[2][0]).toMatchObject(
+    expect(postCalls[3][0]).toMatchObject(
       merge({}, wantPostMsg, { channel: FEED_DEV_INFRA_CHANNEL_ID })
     );
 
@@ -832,7 +851,7 @@ describe('gocdSlackFeeds', function () {
         },
       ],
     };
-    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(3);
+    expect(bolt.client.chat.postMessage).toHaveBeenCalledTimes(4);
     // The reply message is not updated
     expect(bolt.client.chat.update).toHaveBeenCalledTimes(3);
     const updateCalls = bolt.client.chat.update.mock.calls;

--- a/src/brain/gocd/gocdSlackFeeds/index.ts
+++ b/src/brain/gocd/gocdSlackFeeds/index.ts
@@ -122,7 +122,7 @@ export const CANARY_GUIDANCE_LINK =
  * @param pipeline The pipeline to get the pause cause for
  * @returns The pause cause or null if there is none
  */
-function getPauseCause(pipeline: GoCDPipeline) {
+function getPauseCause(pipeline: GoCDPipeline): string | null {
   if (
     pipeline.stage.name.includes('canary') &&
     pipeline.stage.result.toLowerCase() === 'failed' &&
@@ -137,6 +137,14 @@ function getPauseCause(pipeline: GoCDPipeline) {
     pipeline.stage.result.toLowerCase() === 'failed'
   ) {
     return PauseCause.SOAK;
+  }
+  // Canary stages that didn't match the specific job check above shouldn't alert
+  if (pipeline.stage.name.includes('canary')) {
+    return null;
+  }
+  // Any other failed stage (e.g. migration) should alert and cc authors
+  if (pipeline.stage.result.toLowerCase() === 'failed') {
+    return pipeline.stage.name;
   }
   return null;
 }

--- a/src/brain/gocd/gocdSlackFeeds/index.ts
+++ b/src/brain/gocd/gocdSlackFeeds/index.ts
@@ -420,7 +420,9 @@ ${
           markdown(
             `cc'ing the following ${
               uniqueUsers.length > 10 ? `10 of ${uniqueUsers.length} ` : ''
-            }people who have commits in this deploy${pauseCause != null ? ', please triage using the above steps' : ''}:\n${ccString}`
+            }people who have commits in this deploy${
+              pauseCause != null ? ', please triage using the above steps' : ''
+            }:\n${ccString}`
           )
         )
       );

--- a/src/brain/gocd/gocdSlackFeeds/index.ts
+++ b/src/brain/gocd/gocdSlackFeeds/index.ts
@@ -122,7 +122,7 @@ export const CANARY_GUIDANCE_LINK =
  * @param pipeline The pipeline to get the pause cause for
  * @returns The pause cause or null if there is none
  */
-function getPauseCause(pipeline: GoCDPipeline): string | null {
+function getPauseCause(pipeline: GoCDPipeline) {
   if (
     pipeline.stage.name.includes('canary') &&
     pipeline.stage.result.toLowerCase() === 'failed' &&
@@ -137,14 +137,6 @@ function getPauseCause(pipeline: GoCDPipeline): string | null {
     pipeline.stage.result.toLowerCase() === 'failed'
   ) {
     return PauseCause.SOAK;
-  }
-  // Canary stages that didn't match the specific job check above shouldn't alert
-  if (pipeline.stage.name.includes('canary')) {
-    return null;
-  }
-  // Any other failed stage (e.g. migration) should alert and cc authors
-  if (pipeline.stage.result.toLowerCase() === 'failed') {
-    return pipeline.stage.name;
   }
   return null;
 }
@@ -363,9 +355,6 @@ const discussBackendFeed = new DeployFeed({
     return pipeline.stage.result.toLowerCase() === 'failed';
   },
   replyCallback: async (pipeline) => {
-    const pauseCause = getPauseCause(pipeline);
-
-    if (pauseCause == null) return [];
     const [base, head] = await getBaseAndHeadCommit(pipeline);
     const authors = head ? await getAuthors('getsentry', base, head, true) : [];
     // Get unique users from the authors
@@ -395,12 +384,15 @@ const discussBackendFeed = new DeployFeed({
       ? `https://sentry-st.sentry.io/releases/backend@${head}/?project=1513938`
       : `https://sentry.sentry.io/releases/backend@${head}/?project=1`;
 
-    const blocks = [
-      header(
-        plaintext(`:double_vertical_bar: ${pipeline.name} has been paused`)
-      ),
-      section(
-        markdown(`The deployment pipeline has been paused due to detected issues in ${pauseCause}. Here are the steps you should follow to address the situation:\n
+    const pauseCause = getPauseCause(pipeline);
+    let blocks;
+    if (pauseCause != null) {
+      blocks = [
+        header(
+          plaintext(`:double_vertical_bar: ${pipeline.name} has been paused`)
+        ),
+        section(
+          markdown(`The deployment pipeline has been paused due to detected issues in ${pauseCause}. Here are the steps you should follow to address the situation:\n
 :mag_right: *Step 1: Review the Errors*\n Review the errors in the *<${gocdLogsLink}|GoCD Logs>*.\n
 :sentry: *Step 2: Check Sentry Release*\n Check the *<${sentryReleaseLink}|Sentry Release>* for any related issues.\n
 :thinking_face: *Step 3: Is a Rollback Necessary?*\nDetermine if a rollback is necessary by reviewing our *<${IS_ROLLBACK_NECESSARY_LINK}|Guidelines>*.\n
@@ -411,15 +403,24 @@ ${
 :arrow_forward: *Step 6: Unpause the Pipeline*\nWhether or not a rollback was necessary, make sure to *<${gocdUnpausePipelineLink}|unpause the pipeline>* once it is safe to do so.`
     : `:arrow_forward: *Step 5: Unpause the Pipeline*\nWhether or not a rollback was necessary, make sure to *<${gocdUnpausePipelineLink}|unpause the pipeline>* once it is safe to do so.`
 }`)
-      ),
-    ];
+        ),
+      ];
+    } else {
+      blocks = [
+        header(plaintext(`:x: ${pipeline.name} has failed`)),
+        section(
+          markdown(`The deployment pipeline has failed due to detected issues in ${pipeline.stage.name}.\n
+*Review the errors* in the *<${gocdLogsLink}|GoCD Logs>*.`)
+        ),
+      ];
+    }
     if (ccUsers.length > 0) {
       blocks.push(
         context(
           markdown(
             `cc'ing the following ${
               uniqueUsers.length > 10 ? `10 of ${uniqueUsers.length} ` : ''
-            }people who have commits in this deploy, please triage using the above steps:\n${ccString}`
+            }people who have commits in this deploy${pauseCause != null ? ', please triage using the above steps' : ''}:\n${ccString}`
           )
         )
       );


### PR DESCRIPTION
We ping commit authors when a deploy fails in canary/soak time stages, but we should make them aware for migrations (and deploy-primary). It seems that people in #discuss-backend are currently pinging people manually for those stages.

Migration failures post to #discuss-backend but never pinged commit authors. Let's make the reply fire for all failed stages. Pause causes (canary / soak-time) get the existing detailed triage message (of GoCD logs link + Sentry errors), other failures get a simpler message with the GoCD logs link and author cc.

I wonder if eventually we can ping junior in it haha.