### PR TITLE
fix(options webhook): Create options update metric tags correctly based on option type

### DIFF
--- a/src/webhooks/sentry-options/sentry-options.ts
+++ b/src/webhooks/sentry-options/sentry-options.ts
@@ -104,7 +104,9 @@ export async function sendSentryOptionsUpdatesToDatadog(
         `source_tool:${message.source}`,
         `source:${message.source}`,
         `source_category:infra-tools`,
-        `option_name:${option.option_name}`,
+        `option_name:${
+          typeof option === 'string' ? option : option.option_name
+        }`,
         `sentry_user:${message.source}`,
       ];
 


### PR DESCRIPTION
`option` can be a string (for unset options and unregistered options). Fixing the metric tag creation.