### PR TITLE
chore(s4s): Remove s4s alerting for getsentry/sentry

### DIFF
--- a/src/brain/gocd/gocdDataDog/deployDatadogEvents.ts
+++ b/src/brain/gocd/gocdDataDog/deployDatadogEvents.ts
@@ -305,7 +305,7 @@ export class DeployDatadogEvents {
 
     // Title: GoCD: deploy sha (started/failed/completed)  in <insert>-region
     const title = `GoCD: deploying <${service}> <${stageName}> <${pipelineResult}> in ${region}`;
-    // Automatic deploy triggered by <github push?>  to track details visit: https://deploy.getsentry.net/go/pipelines/value_stream_map/deploy-getsentry-backend-s4s/2237
+    // Automatic deploy triggered by <github push?>  to track details visit: https://deploy.getsentry.net/go/pipelines/value_stream_map/deploy-getsentry-backend-s4s2/2237
     const text = `%%% \n${deploymentReason} from: ${commitShaLink},\n \n ${commitDiffLink} \n GoCD:${stageLink} \n\n   *this message was produced by a eng-pipes gocd brain module* \n %%%`;
     // Tags: source:gocd customer_name:s4s sentry_region:s4s source_tool:gocd sentry_user:git commit email  source_category:infra-tools
     const tags = [

--- a/src/brain/gocd/gocdDataDog/index.ts
+++ b/src/brain/gocd/gocdDataDog/index.ts
@@ -8,7 +8,7 @@ import { GoCDResponse } from '@/types/gocd';
 import { DeployDatadogEvents } from './deployDatadogEvents';
 
 // const ENGINEERING_PIPELINE_FILTER = [
-//   'deploy-getsentry-backend-s4s',
+//   'deploy-getsentry-backend-s4s2',
 //   GOCD_SENTRYIO_BE_PIPELINE_NAME,
 //   GOCD_SENTRYIO_FE_PIPELINE_NAME,
 // ];

--- a/src/brain/gocd/gocdNoDeploysAlert/index.ts
+++ b/src/brain/gocd/gocdNoDeploysAlert/index.ts
@@ -18,7 +18,6 @@ import {
 import { getLastGetSentryGoCDDeploy } from '@/utils/db/getLatestDeploy';
 
 const PIPELINE_FILTER = [
-  'deploy-getsentry-backend-s4s',
   GOCD_SENTRYIO_BE_PIPELINE_NAME,
   GOCD_SENTRYIO_FE_PIPELINE_NAME,
 ];

--- a/src/brain/gocd/gocdSlackFeeds/index.test.ts
+++ b/src/brain/gocd/gocdSlackFeeds/index.test.ts
@@ -289,7 +289,7 @@ describe('gocdSlackFeeds', function () {
     const gocdPayload = merge({}, payload, {
       data: {
         pipeline: {
-          name: 'deploy-getsentry-backend-s4s',
+          name: 'deploy-getsentry-backend-s4s2',
           stage: {
             name: 'soak-time',
             result: 'Failed',
@@ -315,16 +315,16 @@ describe('gocdSlackFeeds', function () {
       blocks: [
         slackblocks.header(
           slackblocks.plaintext(
-            ':double_vertical_bar: deploy-getsentry-backend-s4s has been paused'
+            ':double_vertical_bar: deploy-getsentry-backend-s4s2 has been paused'
           )
         ),
         slackblocks.section(
           slackblocks.markdown(`The deployment pipeline has been paused due to detected issues in soak-time. Here are the steps you should follow to address the situation:\n
-:mag_right: *Step 1: Review the Errors*\n Review the errors in the *<https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-s4s/20/soak-time/1/soak|GoCD Logs>*.\n
+:mag_right: *Step 1: Review the Errors*\n Review the errors in the *<https://deploy.getsentry.net/go/tab/build/detail/deploy-getsentry-backend-s4s2/20/soak-time/1/soak|GoCD Logs>*.\n
 :sentry: *Step 2: Check Sentry Release*\n Check the *<https://sentry-st.sentry.io/releases/backend@2b0034becc4ab26b985f4c1a08ab068f153c274c/?project=1513938|Sentry Release>* for any related issues.\n
 :thinking_face: *Step 3: Is a Rollback Necessary?*\nDetermine if a rollback is necessary by reviewing our *<${IS_ROLLBACK_NECESSARY_LINK}|Guidelines>*.\n
 :arrow_backward: *Step 4: Rollback Procedure*\nIf a rollback is necessary, use the *<${ROLLBACK_PLAYBOOK_LINK}|GoCD Playbook>* or *<${GOCD_USER_GUIDE_LINK}|GoCD User Guide>* to guide you.\n
-:arrow_forward: *Step 5: Unpause the Pipeline*\nWhether or not a rollback was necessary, make sure to *<https://deploy.getsentry.net/go/pipeline/activity/deploy-getsentry-backend-s4s|unpause the pipeline>* once it is safe to do so.`)
+:arrow_forward: *Step 5: Unpause the Pipeline*\nWhether or not a rollback was necessary, make sure to *<https://deploy.getsentry.net/go/pipeline/activity/deploy-getsentry-backend-s4s2|unpause the pipeline>* once it is safe to do so.`)
         ),
         slackblocks.context(
           slackblocks.markdown(
@@ -341,7 +341,7 @@ describe('gocdSlackFeeds', function () {
           color: Color.DANGER,
           blocks: [
             slackblocks.section(
-              slackblocks.markdown('*sentryio/deploy-getsentry-backend-s4s*')
+              slackblocks.markdown('*sentryio/deploy-getsentry-backend-s4s2*')
             ),
             {
               elements: [
@@ -356,7 +356,7 @@ describe('gocdSlackFeeds', function () {
               elements: [
                 slackblocks.markdown('❌ *soak-time*'),
                 slackblocks.markdown(
-                  '<https://deploy.getsentry.net/go/pipelines/deploy-getsentry-backend-s4s/20/soak-time/1|Failed>'
+                  '<https://deploy.getsentry.net/go/pipelines/deploy-getsentry-backend-s4s2/20/soak-time/1|Failed>'
                 ),
               ],
             },
@@ -425,7 +425,7 @@ describe('gocdSlackFeeds', function () {
           color: Color.SUCCESS,
           blocks: [
             slackblocks.section(
-              slackblocks.markdown('*sentryio/deploy-getsentry-backend-s4s*')
+              slackblocks.markdown('*sentryio/deploy-getsentry-backend-s4s2*')
             ),
             {
               elements: [
@@ -440,7 +440,7 @@ describe('gocdSlackFeeds', function () {
               elements: [
                 slackblocks.markdown('✅ *soak-time*'),
                 slackblocks.markdown(
-                  '<https://deploy.getsentry.net/go/pipelines/deploy-getsentry-backend-s4s/20/soak-time/1|Passed>'
+                  '<https://deploy.getsentry.net/go/pipelines/deploy-getsentry-backend-s4s2/20/soak-time/1|Passed>'
                 ),
               ],
             },

--- a/src/brain/gocd/gocdSlackFeeds/index.ts
+++ b/src/brain/gocd/gocdSlackFeeds/index.ts
@@ -41,7 +41,6 @@ enum PauseCause {
 
 // TODO: consolidate constants for regions
 const BACKEND_PIPELINE_FILTER = [
-  'deploy-getsentry-backend-s4s',
   'deploy-getsentry-backend-de',
   'deploy-getsentry-backend-us',
   'deploy-getsentry-backend-s4s2',

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -223,11 +223,6 @@ export const OFFICES_12_HOUR = ['sfo', 'sea'];
 
 export const GOCD_PAUSED_PIPELINE_REMINDERS: GoCDPausedPipelineReminder[] = [
   {
-    pipelineName: 'deploy-getsentry-backend-s4s',
-    slackChannel: DISCUSS_BACKEND_CHANNEL_ID,
-    notifyAfter: moment.duration(1.5, 'hour'),
-  },
-  {
     pipelineName: 'deploy-getsentry-backend-de',
     slackChannel: DISCUSS_BACKEND_CHANNEL_ID,
     notifyAfter: moment.duration(1.5, 'hour'),

--- a/test/payloads/gocd/gocd-stage-checks.json
+++ b/test/payloads/gocd/gocd-stage-checks.json
@@ -1,7 +1,7 @@
 {
   "data": {
       "pipeline": {
-          "name": "deploy-getsentry-backend-s4s",
+          "name": "deploy-getsentry-backend-s4s2",
           "counter": "2373",
           "group": "getsentry-backend",
           "build-cause": [


### PR DESCRIPTION
We are deprecating s4s, which is causing a lot of noisy alerts in slack.

This PR removes mentions of s4s in sentry. In a later PR, we can remove it from sns (snuba, etc.)