### PR TITLE
chore(options): Improve @jr message to make creating unused option removal more consistent

### DIFF
--- a/src/jobs/unregisteredOptionsSummary.ts
+++ b/src/jobs/unregisteredOptionsSummary.ts
@@ -36,7 +36,8 @@ export async function sendUnregisteredOptionsSummary(): Promise<void> {
         slackblocks.markdown(
           `*${optionRegions.size} unregistered option(s)* found across regions.\n` +
             `These options exist in \`sentry-options-automator\` but are not registered in \`sentry\`. ` +
-            `<@U0AGGRG1V0X> please create a PR in <https://github.com/getsentry/sentry-options-automator|sentry-options-automator> to remove the unregistered options listed below from the YAML files in \`options/default/\` and \`options/regions/\`.`
+            `<@U0AGGRG1V0X> please create a PR in <https://github.com/getsentry/sentry-options-automator|sentry-options-automator> to remove the unregistered options listed below from the YAML files in \`options/default/\` and \`options/regions/\`. ` +
+            `No sentry account is needed — all you need to do is create a PR in sentry-options-automator. If you can't open the PR directly, push the branch and share the compare link.`
         )
       ),
       slackblocks.divider(),


### PR DESCRIPTION
Today @jr decided that it couldn't proceed without a Sentry account connection, which is unnecessary. Adding in more guidance.