### PR TITLE
Remove stale sentry4sentry rows from `unregistered_options`

### DIFF
--- a/migrations/20260417000000_remove-sentry4sentry-unregistered-options.ts
+++ b/migrations/20260417000000_remove-sentry4sentry-unregistered-options.ts
@@ -1,0 +1,7 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex('unregistered_options').where({ region: 'sentry4sentry' }).del();
+}
+
+export async function down(knex: Knex): Promise<void> {}


### PR DESCRIPTION
s4s has been replaced by s4s2. These options are stale and cause the daily summary of deleted options to misfire