### PR TITLE
feat: add paused pipeline reminders for seer

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -232,6 +232,16 @@ export const GOCD_PAUSED_PIPELINE_REMINDERS: GoCDPausedPipelineReminder[] = [
     slackChannel: DISCUSS_BACKEND_CHANNEL_ID,
     notifyAfter: moment.duration(1.5, 'hour'),
   },
+  {
+    pipelineName: 'deploy-seer-us',
+    slackChannel: DISCUSS_SEER_INFRA_CHANNEL_ID,
+    notifyAfter: moment.duration(1, 'hour'),
+  },
+  {
+    pipelineName: 'deploy-seer-de',
+    slackChannel: DISCUSS_SEER_INFRA_CHANNEL_ID,
+    notifyAfter: moment.duration(1, 'hour'),
+  },
 ];
 
 /**


### PR DESCRIPTION
refs CW-926

we want this in discuss seer infra since we added canary deploys for seer
which means we will now automatically pause the pipeline, and it's easy to
miss messages when the pipeline has failed
