### PR TITLE
feat(gocd): add deploy-getsentry-backend-prod-control to backend pipeline filter

### DIFF
--- a/src/brain/gocd/gocdSlackFeeds/index.ts
+++ b/src/brain/gocd/gocdSlackFeeds/index.ts
@@ -44,7 +44,7 @@ const BACKEND_PIPELINE_FILTER = [
   'deploy-getsentry-backend-de',
   'deploy-getsentry-backend-us',
   'deploy-getsentry-backend-s4s2',
-  'deploy-getsentry-backend-control',
+  'deploy-getsentry-backend-prod-control',
   GOCD_SENTRYIO_BE_PIPELINE_NAME,
 ];
 


### PR DESCRIPTION
Dmitrii's getsentry/getsentry#20022 renames the control deploy from deploy-getsentry-backend-control to deploy-getsentry-backend-prod-control. Replacing the old name in BACKEND_PIPELINE_FILTER so #discuss-backend's deploy-failure feed catches deploy failures from the new pipeline. Should land alongside or just after #20022.