### PR TITLE
ref(seer-gpu): Add paused pipeline reminders

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -242,6 +242,16 @@ export const GOCD_PAUSED_PIPELINE_REMINDERS: GoCDPausedPipelineReminder[] = [
     slackChannel: DISCUSS_SEER_INFRA_CHANNEL_ID,
     notifyAfter: moment.duration(1, 'hour'),
   },
+  {
+    pipelineName: 'deploy-seer-gpu-us',
+    slackChannel: DISCUSS_SEER_INFRA_CHANNEL_ID,
+    notifyAfter: moment.duration(1, 'hour'),
+  },
+  {
+    pipelineName: 'deploy-seer-gpu-de',
+    slackChannel: DISCUSS_SEER_INFRA_CHANNEL_ID,
+    notifyAfter: moment.duration(1, 'hour'),
+  },
 ];
 
 /**


### PR DESCRIPTION
seer-gpu also has canaries so would like to know when a pipeline is paused